### PR TITLE
Add 8 new field types (#2)

### DIFF
--- a/docs/DEVLOG.md
+++ b/docs/DEVLOG.md
@@ -14,6 +14,28 @@
 
 ## Log
 
+### 2026-03-03 — Implemented All 8 New Field Types (#2)
+**Issues:** #2, #11 (number), #12 (currency), #13 (heading), #14 (hidden), #15 (address), #16 (file), #17 (signature), #18 (repeater), #19 (demo schema)
+
+- Added 8 new field types to `createField()`, `collectFormData()`, `validateForm()`, and `resetForm()` in `index.html`
+- Added CSS styles for all new field types (currency wrapper, heading divider, address group, file upload with preview, signature canvas pad, repeater rows)
+- Updated `buildForm()` layout: `number` and `currency` pair in 2-column rows; `hidden` skipped from visible layout
+- Created `schemas/expense-report.json` — demo form exercising all 8 new types plus existing types
+- Created `templates/expense-report.py` — handles JSON parsing for address/repeater, base64 decoding for file/signature, currency formatting
+- Created `tests/fixtures/expense-report_sample.json` — sample data for template testing
+- Updated `docs/FIELD_TYPES.md` with all 8 new types: JSON schema examples, schema properties, and template handling code
+
+**Decisions:**
+- Heading fields return early from `createField()` to skip the default hint rendering (they handle their own hint)
+- Hidden fields use `default_value` schema property; the field group is `display: none`
+- Address data is serialized as a JSON object string; validation checks street is non-empty when required
+- Signature uses `canvas.toDataURL('image/png')` saved to a hidden input on each `mouseup`/`touchend`
+- Repeater stores sub-field config via `wrapper.dataset.subFields` for `collectFormData()` to reference
+- Repeater sub-fields support text, email, tel, number, currency, and select types
+- File upload validates size client-side via `max_size_mb` and shows image preview for image types
+
+---
+
 ### 2026-03-03 — Implementation Plan for #2 (New Field Types)
 **Issues:** #2, #11–#19
 

--- a/docs/FIELD_TYPES.md
+++ b/docs/FIELD_TYPES.md
@@ -16,13 +16,22 @@ Every field in a schema has a `type` that controls how it renders in the form an
 | `radio` | Radio button group | `"Full-Time"` | yes |
 | `checkbox` | Checkbox group (multi-select) | `"A, B, C"` | yes |
 | `list` | Dynamic add/remove rows with bulk paste | `"X\nY\nZ"` | no |
+| `number` | Number input with min/max/step | `"42.5"` | no |
+| `currency` | Number input with currency prefix | `"1250.00"` | no |
+| `heading` | Non-input section divider | *(skipped)* | no |
+| `hidden` | Not rendered (passes static value) | `"1.0"` | no |
+| `address` | Multi-field group (street/city/state/zip) | JSON string | no |
+| `file` | File upload with preview | base64 data URI | no |
+| `signature` | Canvas drawing pad | base64 PNG data URI | no |
+| `repeater` | Dynamic group of rows | JSON array string | needs `fields` |
 
 ## Layout Rules
 
 Fields are automatically arranged in the form:
 
-- `text`, `email`, `tel`, `date`, `select` — paired into **two-column rows** when consecutive
-- `textarea`, `longtext`, `list`, `radio`, `checkbox` — always **full-width**, breaks any pairing
+- `text`, `email`, `tel`, `date`, `select`, `number`, `currency` — paired into **two-column rows** when consecutive
+- `textarea`, `longtext`, `list`, `radio`, `checkbox`, `heading`, `address`, `file`, `signature`, `repeater` — always **full-width**, breaks any pairing
+- `hidden` — not rendered in the visible layout at all
 
 You control layout through field ordering. Two consecutive `text` fields pair up. A `text` followed by a `longtext` will not.
 
@@ -195,6 +204,167 @@ if skills:
             doc.add_paragraph(item.strip(), style='List Bullet')
 ```
 
+## number
+
+Numeric input with optional `min`, `max`, and `step` constraints. Renders as `<input type="number">`.
+
+```json
+{ "id": "quantity", "label": "Quantity", "type": "number", "min": 0, "max": 100, "step": 1 }
+```
+
+**Schema properties:** `min`, `max`, `step` (all optional).
+
+**Template:** Value is a string — parse with `int()` or `float()` as needed.
+
+```python
+qty = int(data.get('quantity', '0'))
+```
+
+## currency
+
+Number input with a currency symbol prefix. Defaults to `$` with `step="0.01"`.
+
+```json
+{ "id": "total_amount", "label": "Total Amount", "type": "currency", "required": true, "placeholder": "0.00" }
+```
+
+**Schema properties:** `currency_symbol` (optional, defaults to `"$"`).
+
+**Template:** Value is a string like `"1250.00"`. Format in the template:
+
+```python
+amount = data.get('total_amount', '0')
+formatted = f"${float(amount):,.2f}"  # "$1,250.00"
+```
+
+## heading
+
+Non-input element that renders as a visual section divider within a form section. Not collected in form data, not passed to templates. Useful for grouping related fields without creating a new schema section.
+
+```json
+{ "id": "emergency_heading", "label": "Emergency Contact Information", "type": "heading", "hint": "Provide at least one emergency contact" }
+```
+
+**Template:** Not passed — heading fields are skipped during data collection.
+
+## hidden
+
+Invisible field that passes a static value to the template. Use for metadata like form version numbers, form IDs, or computed values.
+
+```json
+{ "id": "form_version", "label": "Form Version", "type": "hidden", "default_value": "2.1" }
+```
+
+**Schema properties:** `default_value` (the static value to pass).
+
+**Template:** `data.get('form_version', '')` → `"2.1"`
+
+## address
+
+Compound field that renders as a group of 4 sub-inputs: street, city, state, and ZIP code.
+
+```json
+{ "id": "mailing_address", "label": "Mailing Address", "type": "address", "hint": "Where should we send it?" }
+```
+
+**Template:** Value is a JSON string. Parse it to access sub-fields:
+
+```python
+import json
+addr = json.loads(data.get('mailing_address', '{}'))
+street = addr.get('street', '')
+city = addr.get('city', '')
+state = addr.get('state', '')
+zip_code = addr.get('zip', '')
+formatted = f"{street}\n{city}, {state} {zip_code}"
+```
+
+**Validation:** When `required`, checks that the street field is non-empty.
+
+## file
+
+File upload input with image preview. The file is read as a base64 data URI and passed to the template.
+
+```json
+{
+  "id": "receipt_photo",
+  "label": "Receipt Photo",
+  "type": "file",
+  "accept": "image/*",
+  "max_size_mb": 5,
+  "hint": "Upload a photo of your receipt"
+}
+```
+
+**Schema properties:**
+- `accept` — file type filter (defaults to `"image/*"`)
+- `max_size_mb` — maximum file size in MB (defaults to `5`)
+
+**Template:** Value is a base64 data URI string (e.g., `"data:image/png;base64,iVBOR..."`) or empty string.
+
+```python
+import base64, io
+receipt = data.get('receipt_photo', '')
+if receipt and ',' in receipt:
+    img_data = receipt.split(',')[1]
+    img_bytes = base64.b64decode(img_data)
+    doc.add_picture(io.BytesIO(img_bytes), width=Inches(3))
+```
+
+## signature
+
+Canvas-based drawing pad for capturing signatures. Supports both mouse and touch input. Exports as a base64 PNG data URI. Includes a "Clear" button to reset.
+
+```json
+{ "id": "employee_signature", "label": "Employee Signature", "type": "signature", "required": true }
+```
+
+**Template:** Value is a base64 PNG data URI string or empty string. Embed in DOCX:
+
+```python
+import base64, io
+from docx.shared import Inches
+sig = data.get('employee_signature', '')
+if sig and ',' in sig:
+    sig_bytes = base64.b64decode(sig.split(',')[1])
+    doc.add_picture(io.BytesIO(sig_bytes), width=Inches(2.5))
+```
+
+## repeater
+
+Dynamic field group — users can add N copies of a set of sub-fields. Ideal for line items, references, dependents, etc.
+
+```json
+{
+  "id": "line_items",
+  "label": "Expense Line Items",
+  "type": "repeater",
+  "min_rows": 1,
+  "max_rows": 20,
+  "fields": [
+    { "id": "description", "label": "Description", "type": "text", "placeholder": "Flight to NYC" },
+    { "id": "amount", "label": "Amount", "type": "currency" },
+    { "id": "category", "label": "Category", "type": "select", "options": ["", "Travel", "Meals", "Supplies"] }
+  ]
+}
+```
+
+**Schema properties:**
+- `fields` — array of sub-field definitions (supports `text`, `email`, `tel`, `number`, `currency`, `select`)
+- `min_rows` — minimum rows shown initially (defaults to `1`)
+- `max_rows` — maximum rows allowed (defaults to `10`)
+
+**Template:** Value is a JSON array string. Parse and iterate:
+
+```python
+import json
+items = json.loads(data.get('line_items', '[]'))
+for item in items:
+    desc = item.get('description', '')
+    amount = item.get('amount', '0')
+    category = item.get('category', '')
+```
+
 ---
 
 ## Choosing the Right Type
@@ -210,3 +380,11 @@ if skills:
 | One choice from a fixed list | `select` (5+ options) or `radio` (2-4 options) |
 | Multiple choices from a fixed list | `checkbox` |
 | A user-defined list of items | `list` |
+| A numeric value with constraints | `number` |
+| A dollar/currency amount | `currency` |
+| A visual divider between fields | `heading` |
+| Metadata not shown to the user | `hidden` |
+| A mailing/physical address | `address` |
+| An uploaded image or document | `file` |
+| A hand-drawn signature | `signature` |
+| Repeated rows of fields (line items) | `repeater` |

--- a/index.html
+++ b/index.html
@@ -172,7 +172,7 @@
 
   /* Inputs */
   input[type="text"], input[type="date"], input[type="email"], input[type="tel"],
-  textarea, select {
+  input[type="number"], textarea, select {
     width: 100%; padding: 10px 14px; background: var(--surface-2);
     border: 1px solid var(--border); border-radius: 8px; color: var(--text);
     font-family: 'DM Sans', sans-serif; font-size: 14px;
@@ -235,6 +235,79 @@
   }
   .list-or-divider::before, .list-or-divider::after { content: ''; flex: 1; height: 1px; background: var(--border); }
   .list-bulk-textarea { min-height: 80px; font-size: 13px; line-height: 1.6; }
+
+  /* Currency */
+  .currency-wrapper {
+    display: flex; align-items: center; gap: 0;
+  }
+  .currency-prefix {
+    padding: 10px 12px; background: var(--surface-2); border: 1px solid var(--border);
+    border-right: none; border-radius: 8px 0 0 8px; font-weight: 600;
+    color: var(--text-muted); font-size: 14px; line-height: 1;
+  }
+  .currency-wrapper input[type="number"] {
+    border-radius: 0 8px 8px 0; flex: 1;
+  }
+
+  /* Heading (non-input divider) */
+  .field-heading {
+    font-size: 15px; font-weight: 600; color: var(--text);
+    border-bottom: 2px solid var(--border); padding-bottom: 8px; margin-top: 8px;
+  }
+  .field-heading-hint {
+    font-size: 12px; color: var(--text-muted); margin-top: 4px;
+  }
+
+  /* Address */
+  .address-group { display: flex; flex-direction: column; gap: 8px; }
+  .address-row { display: grid; grid-template-columns: 2fr 1fr 1fr; gap: 8px; }
+  .address-sub-label { font-size: 11px; color: var(--text-muted); margin-top: 2px; }
+  @media (max-width: 600px) { .address-row { grid-template-columns: 1fr; } }
+
+  /* File upload */
+  .file-upload-wrapper { display: flex; flex-direction: column; gap: 8px; }
+  .file-preview {
+    max-width: 200px; max-height: 200px; border-radius: 8px;
+    border: 1px solid var(--border); display: none; object-fit: contain;
+  }
+  .file-info { font-size: 12px; color: var(--text-muted); }
+
+  /* Signature pad */
+  .signature-pad-wrapper { display: flex; flex-direction: column; gap: 8px; }
+  .signature-canvas {
+    border: 2px dashed var(--border); border-radius: 8px; cursor: crosshair;
+    background: #fff; touch-action: none; width: 100%; height: 150px;
+  }
+  .signature-actions { display: flex; gap: 8px; }
+  .btn-clear-sig {
+    background: var(--surface-2); border: 1px solid var(--border); color: var(--text-muted);
+    padding: 6px 12px; border-radius: 6px; font-family: 'DM Sans', sans-serif;
+    font-size: 12px; cursor: pointer; transition: all 0.15s;
+  }
+  .btn-clear-sig:hover { border-color: var(--error); color: var(--error); }
+
+  /* Repeater */
+  .repeater-wrapper { display: flex; flex-direction: column; gap: 10px; }
+  .repeater-row {
+    padding: 12px; border: 1px solid var(--border); border-radius: 8px;
+    background: var(--surface-2); display: flex; flex-direction: column; gap: 8px;
+  }
+  .repeater-row-header {
+    display: flex; justify-content: space-between; align-items: center;
+    font-size: 12px; font-weight: 500; color: var(--text-muted);
+  }
+  .repeater-row-fields {
+    display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 8px;
+  }
+  .repeater-row-fields .field-group { margin-bottom: 0; }
+  .repeater-row-fields .field-label { font-size: 11px; }
+  .repeater-actions { display: flex; gap: 8px; align-items: center; }
+  .btn-remove-row {
+    background: none; border: 1px solid transparent; color: var(--text-muted);
+    cursor: pointer; padding: 2px 6px; border-radius: 4px; font-size: 14px;
+    transition: all 0.15s;
+  }
+  .btn-remove-row:hover { color: var(--error); border-color: var(--error); }
 
   /* Buttons */
   .submit-area { margin-top: 40px; display: flex; align-items: center; gap: 16px; }
@@ -1355,7 +1428,7 @@ function buildForm(schema) {
     sectionTitle.textContent = section.title;
     sectionDiv.appendChild(sectionTitle);
 
-    const shortTypes = ['text', 'email', 'tel', 'date', 'select'];
+    const shortTypes = ['text', 'email', 'tel', 'date', 'select', 'number', 'currency'];
     let rowBuffer = [];
 
     function flushRow() {
@@ -1373,6 +1446,11 @@ function buildForm(schema) {
     }
 
     for (const field of section.fields) {
+      if (field.type === 'hidden') {
+        // Hidden fields don't participate in layout at all
+        sectionDiv.appendChild(createField(field));
+        continue;
+      }
       const fieldEl = createField(field);
       if (shortTypes.includes(field.type)) {
         rowBuffer.push(fieldEl);
@@ -1394,8 +1472,10 @@ function createField(field) {
   const group = document.createElement('div');
   group.className = 'field-group';
 
-  // Label
-  if (field.type !== 'checkbox' && field.type !== 'radio') {
+  // Label (skip for heading and hidden — they handle their own rendering)
+  if (field.type === 'heading' || field.type === 'hidden') {
+    // no label
+  } else if (field.type !== 'checkbox' && field.type !== 'radio') {
     const label = document.createElement('label');
     label.className = 'field-label';
     label.setAttribute('for', field.id);
@@ -1529,6 +1609,263 @@ function createField(field) {
       setTimeout(() => addListItem(field.id, field.placeholder || '', itemsContainer, countEl), 0);
       break;
     }
+    case 'number': {
+      const input = document.createElement('input');
+      input.type = 'number'; input.id = field.id; input.name = field.id;
+      input.placeholder = field.placeholder || '';
+      input.required = field.required || false;
+      if (field.min !== undefined) input.min = field.min;
+      if (field.max !== undefined) input.max = field.max;
+      if (field.step !== undefined) input.step = field.step;
+      group.appendChild(input);
+      break;
+    }
+    case 'currency': {
+      const wrapper = document.createElement('div');
+      wrapper.className = 'currency-wrapper';
+      const prefix = document.createElement('span');
+      prefix.className = 'currency-prefix';
+      prefix.textContent = field.currency_symbol || '$';
+      const input = document.createElement('input');
+      input.type = 'number'; input.id = field.id; input.name = field.id;
+      input.step = '0.01'; input.min = '0';
+      input.placeholder = field.placeholder || '0.00';
+      input.required = field.required || false;
+      wrapper.appendChild(prefix);
+      wrapper.appendChild(input);
+      group.appendChild(wrapper);
+      break;
+    }
+    case 'heading': {
+      const h = document.createElement('div');
+      h.className = 'field-heading';
+      h.textContent = field.label;
+      group.appendChild(h);
+      if (field.hint) {
+        const hintEl = document.createElement('div');
+        hintEl.className = 'field-heading-hint';
+        hintEl.textContent = field.hint;
+        group.appendChild(hintEl);
+      }
+      return group; // skip the default hint logic below
+    }
+    case 'hidden': {
+      const input = document.createElement('input');
+      input.type = 'hidden'; input.id = field.id; input.name = field.id;
+      input.value = field.default_value || '';
+      group.style.display = 'none';
+      group.appendChild(input);
+      break;
+    }
+    case 'address': {
+      const wrapper = document.createElement('div');
+      wrapper.className = 'address-group';
+      const streetInput = document.createElement('input');
+      streetInput.type = 'text'; streetInput.id = `${field.id}_street`; streetInput.name = `${field.id}_street`;
+      streetInput.placeholder = 'Street address';
+      wrapper.appendChild(streetInput);
+      const row = document.createElement('div');
+      row.className = 'address-row';
+      const cityInput = document.createElement('input');
+      cityInput.type = 'text'; cityInput.id = `${field.id}_city`; cityInput.name = `${field.id}_city`;
+      cityInput.placeholder = 'City';
+      const stateInput = document.createElement('input');
+      stateInput.type = 'text'; stateInput.id = `${field.id}_state`; stateInput.name = `${field.id}_state`;
+      stateInput.placeholder = 'State';
+      const zipInput = document.createElement('input');
+      zipInput.type = 'text'; zipInput.id = `${field.id}_zip`; zipInput.name = `${field.id}_zip`;
+      zipInput.placeholder = 'ZIP code';
+      row.appendChild(cityInput); row.appendChild(stateInput); row.appendChild(zipInput);
+      wrapper.appendChild(row);
+      group.appendChild(wrapper);
+      break;
+    }
+    case 'file': {
+      const wrapper = document.createElement('div');
+      wrapper.className = 'file-upload-wrapper';
+      const fileInput = document.createElement('input');
+      fileInput.type = 'file'; fileInput.id = `${field.id}_input`;
+      fileInput.accept = field.accept || 'image/*';
+      const hiddenInput = document.createElement('input');
+      hiddenInput.type = 'hidden'; hiddenInput.id = field.id;
+      const preview = document.createElement('img');
+      preview.className = 'file-preview'; preview.id = `${field.id}_preview`;
+      const info = document.createElement('div');
+      info.className = 'file-info'; info.id = `${field.id}_info`;
+      const maxMb = field.max_size_mb || 5;
+      fileInput.addEventListener('change', () => {
+        const file = fileInput.files[0];
+        if (!file) { hiddenInput.value = ''; preview.style.display = 'none'; info.textContent = ''; return; }
+        if (file.size > maxMb * 1024 * 1024) {
+          showToast(`File too large (max ${maxMb}MB)`, 'error');
+          fileInput.value = ''; hiddenInput.value = ''; return;
+        }
+        const reader = new FileReader();
+        reader.onload = (e) => {
+          hiddenInput.value = e.target.result;
+          if (file.type.startsWith('image/')) { preview.src = e.target.result; preview.style.display = 'block'; }
+          else { preview.style.display = 'none'; }
+          info.textContent = `${file.name} (${(file.size / 1024).toFixed(1)} KB)`;
+        };
+        reader.readAsDataURL(file);
+      });
+      wrapper.appendChild(fileInput);
+      wrapper.appendChild(preview);
+      wrapper.appendChild(info);
+      wrapper.appendChild(hiddenInput);
+      group.appendChild(wrapper);
+      break;
+    }
+    case 'signature': {
+      const wrapper = document.createElement('div');
+      wrapper.className = 'signature-pad-wrapper';
+      const canvas = document.createElement('canvas');
+      canvas.className = 'signature-canvas'; canvas.id = `${field.id}_canvas`;
+      canvas.width = 400; canvas.height = 150;
+      const hiddenInput = document.createElement('input');
+      hiddenInput.type = 'hidden'; hiddenInput.id = field.id;
+      let drawing = false;
+      function getPos(e) {
+        const rect = canvas.getBoundingClientRect();
+        const scaleX = canvas.width / rect.width;
+        const scaleY = canvas.height / rect.height;
+        if (e.touches) {
+          return { x: (e.touches[0].clientX - rect.left) * scaleX, y: (e.touches[0].clientY - rect.top) * scaleY };
+        }
+        return { x: (e.clientX - rect.left) * scaleX, y: (e.clientY - rect.top) * scaleY };
+      }
+      const ctx = canvas.getContext('2d');
+      ctx.lineWidth = 2; ctx.lineCap = 'round'; ctx.lineJoin = 'round'; ctx.strokeStyle = '#000';
+      function startDraw(e) { e.preventDefault(); drawing = true; const p = getPos(e); ctx.beginPath(); ctx.moveTo(p.x, p.y); }
+      function moveDraw(e) { if (!drawing) return; e.preventDefault(); const p = getPos(e); ctx.lineTo(p.x, p.y); ctx.stroke(); }
+      function endDraw() { if (!drawing) return; drawing = false; hiddenInput.value = canvas.toDataURL('image/png'); }
+      canvas.addEventListener('mousedown', startDraw);
+      canvas.addEventListener('mousemove', moveDraw);
+      canvas.addEventListener('mouseup', endDraw);
+      canvas.addEventListener('mouseleave', endDraw);
+      canvas.addEventListener('touchstart', startDraw);
+      canvas.addEventListener('touchmove', moveDraw);
+      canvas.addEventListener('touchend', endDraw);
+      const actions = document.createElement('div');
+      actions.className = 'signature-actions';
+      const clearBtn = document.createElement('button');
+      clearBtn.type = 'button'; clearBtn.className = 'btn-clear-sig'; clearBtn.textContent = 'Clear';
+      clearBtn.addEventListener('click', () => {
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        hiddenInput.value = '';
+      });
+      actions.appendChild(clearBtn);
+      wrapper.appendChild(canvas);
+      wrapper.appendChild(actions);
+      wrapper.appendChild(hiddenInput);
+      group.appendChild(wrapper);
+      break;
+    }
+    case 'repeater': {
+      const wrapper = document.createElement('div');
+      wrapper.className = 'repeater-wrapper'; wrapper.id = `${field.id}_repeater`;
+      const rowsContainer = document.createElement('div');
+      rowsContainer.id = `${field.id}_rows`;
+      const minRows = field.min_rows || 1;
+      const maxRows = field.max_rows || 10;
+      const subFields = field.fields || [];
+      let rowCount = 0;
+
+      function addRepeaterRow() {
+        if (rowCount >= maxRows) return;
+        const rowIdx = rowCount++;
+        const row = document.createElement('div');
+        row.className = 'repeater-row'; row.dataset.rowIdx = rowIdx;
+        const header = document.createElement('div');
+        header.className = 'repeater-row-header';
+        const rowLabel = document.createElement('span');
+        rowLabel.textContent = `#${rowIdx + 1}`;
+        const removeBtn = document.createElement('button');
+        removeBtn.type = 'button'; removeBtn.className = 'btn-remove-row'; removeBtn.innerHTML = '&times;';
+        removeBtn.addEventListener('click', () => {
+          if (rowsContainer.children.length <= minRows) return;
+          row.remove();
+          updateRepeaterNumbers();
+          updateAddBtn();
+        });
+        header.appendChild(rowLabel); header.appendChild(removeBtn);
+        const fieldsDiv = document.createElement('div');
+        fieldsDiv.className = 'repeater-row-fields';
+        for (const sf of subFields) {
+          const subId = `${field.id}_r${rowIdx}_${sf.id}`;
+          const fg = document.createElement('div');
+          fg.className = 'field-group';
+          const lbl = document.createElement('label');
+          lbl.className = 'field-label'; lbl.setAttribute('for', subId);
+          lbl.textContent = sf.label;
+          fg.appendChild(lbl);
+          if (sf.type === 'select') {
+            const sel = document.createElement('select');
+            sel.id = subId; sel.name = subId;
+            for (const opt of (sf.options || [])) {
+              const o = document.createElement('option');
+              o.value = opt; o.textContent = opt || '— Select —';
+              sel.appendChild(o);
+            }
+            fg.appendChild(sel);
+          } else if (sf.type === 'currency') {
+            const cw = document.createElement('div'); cw.className = 'currency-wrapper';
+            const pfx = document.createElement('span'); pfx.className = 'currency-prefix';
+            pfx.textContent = sf.currency_symbol || '$';
+            const inp = document.createElement('input');
+            inp.type = 'number'; inp.id = subId; inp.name = subId;
+            inp.step = '0.01'; inp.min = '0'; inp.placeholder = sf.placeholder || '0.00';
+            cw.appendChild(pfx); cw.appendChild(inp);
+            fg.appendChild(cw);
+          } else if (sf.type === 'number') {
+            const inp = document.createElement('input');
+            inp.type = 'number'; inp.id = subId; inp.name = subId;
+            inp.placeholder = sf.placeholder || '';
+            if (sf.min !== undefined) inp.min = sf.min;
+            if (sf.max !== undefined) inp.max = sf.max;
+            if (sf.step !== undefined) inp.step = sf.step;
+            fg.appendChild(inp);
+          } else {
+            const inp = document.createElement('input');
+            inp.type = sf.type === 'email' ? 'email' : sf.type === 'tel' ? 'tel' : 'text';
+            inp.id = subId; inp.name = subId; inp.placeholder = sf.placeholder || '';
+            fg.appendChild(inp);
+          }
+          fieldsDiv.appendChild(fg);
+        }
+        row.appendChild(header);
+        row.appendChild(fieldsDiv);
+        rowsContainer.appendChild(row);
+        updateAddBtn();
+      }
+
+      function updateRepeaterNumbers() {
+        Array.from(rowsContainer.children).forEach((row, i) => {
+          const label = row.querySelector('.repeater-row-header span');
+          if (label) label.textContent = `#${i + 1}`;
+        });
+      }
+
+      const actionsDiv = document.createElement('div');
+      actionsDiv.className = 'repeater-actions';
+      const addBtn = document.createElement('button');
+      addBtn.type = 'button'; addBtn.className = 'btn-add-item';
+      addBtn.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 5v14M5 12h14"/></svg> Add row';
+      addBtn.addEventListener('click', addRepeaterRow);
+      function updateAddBtn() { addBtn.disabled = rowsContainer.children.length >= maxRows; }
+
+      wrapper.appendChild(rowsContainer);
+      actionsDiv.appendChild(addBtn);
+      wrapper.appendChild(actionsDiv);
+      group.appendChild(wrapper);
+
+      // Store subFields config on wrapper for collectFormData
+      wrapper.dataset.subFields = JSON.stringify(subFields);
+      wrapper.dataset.fieldId = field.id;
+
+      setTimeout(() => { for (let i = 0; i < minRows; i++) addRepeaterRow(); }, 0);
+      break;
+    }
   }
 
   if (field.hint) {
@@ -1606,6 +1943,7 @@ function collectFormData() {
   if (!currentSchema || !currentSchema.sections) return data;
   for (const section of currentSchema.sections) {
     for (const field of section.fields) {
+      if (field.type === 'heading') continue; // non-input, skip
       if (field.type === 'checkbox') {
         const checked = document.querySelectorAll(`input[name="${field.id}"]:checked`);
         data[field.id] = Array.from(checked).map(c => c.value).join(', ');
@@ -1614,7 +1952,31 @@ function collectFormData() {
         data[field.id] = selected ? selected.value : '';
       } else if (field.type === 'list') {
         data[field.id] = getListValues(field.id).join('\n');
+      } else if (field.type === 'address') {
+        data[field.id] = JSON.stringify({
+          street: (document.getElementById(`${field.id}_street`) || {}).value || '',
+          city: (document.getElementById(`${field.id}_city`) || {}).value || '',
+          state: (document.getElementById(`${field.id}_state`) || {}).value || '',
+          zip: (document.getElementById(`${field.id}_zip`) || {}).value || ''
+        });
+      } else if (field.type === 'repeater') {
+        const wrapper = document.getElementById(`${field.id}_repeater`);
+        const subFields = field.fields || [];
+        const rows = [];
+        if (wrapper) {
+          const rowEls = wrapper.querySelectorAll('.repeater-row');
+          rowEls.forEach((rowEl, i) => {
+            const rowData = {};
+            for (const sf of subFields) {
+              const input = rowEl.querySelector(`[id$="_${sf.id}"]`);
+              rowData[sf.id] = input ? input.value : '';
+            }
+            rows.push(rowData);
+          });
+        }
+        data[field.id] = JSON.stringify(rows);
       } else {
+        // text, email, tel, date, textarea, longtext, select, number, currency, hidden, file, signature
         const el = document.getElementById(field.id);
         data[field.id] = el ? el.value : '';
       }
@@ -1632,9 +1994,15 @@ function validateForm() {
   if (!currentSchema) return missing;
   for (const section of currentSchema.sections) {
     for (const field of section.fields) {
+      if (field.type === 'heading') continue; // non-input, skip
       if (!field.required) continue;
-      const val = data[field.id];
-      if (!val || val.trim() === '') missing.push(field.label);
+      if (field.type === 'address') {
+        const addr = JSON.parse(data[field.id] || '{}');
+        if (!addr.street || !addr.street.trim()) missing.push(field.label);
+      } else {
+        const val = data[field.id];
+        if (!val || val.trim() === '') missing.push(field.label);
+      }
     }
   }
   return missing;
@@ -1652,6 +2020,21 @@ function resetForm() {
           const container = document.getElementById(`${field.id}_items`);
           const countEl = document.getElementById(`${field.id}_count`);
           if (container) { container.innerHTML = ''; addListItem(field.id, field.placeholder || '', container, countEl); }
+        } else if (field.type === 'signature') {
+          const canvas = document.getElementById(`${field.id}_canvas`);
+          if (canvas) { const ctx = canvas.getContext('2d'); ctx.clearRect(0, 0, canvas.width, canvas.height); }
+          const hidden = document.getElementById(field.id);
+          if (hidden) hidden.value = '';
+        } else if (field.type === 'file') {
+          const preview = document.getElementById(`${field.id}_preview`);
+          if (preview) preview.style.display = 'none';
+          const info = document.getElementById(`${field.id}_info`);
+          if (info) info.textContent = '';
+          const hidden = document.getElementById(field.id);
+          if (hidden) hidden.value = '';
+        } else if (field.type === 'hidden') {
+          const el = document.getElementById(field.id);
+          if (el) el.value = field.default_value || '';
         }
       }
     }

--- a/schemas/expense-report.json
+++ b/schemas/expense-report.json
@@ -1,0 +1,134 @@
+{
+  "title": "Expense Report",
+  "description": "Submit an expense report for reimbursement. Attach receipts and provide line items for each expense.",
+  "icon": "💰",
+  "template": "templates/expense-report.py",
+  "sections": [
+    {
+      "title": "Report Details",
+      "fields": [
+        {
+          "id": "form_version",
+          "label": "Form Version",
+          "type": "hidden",
+          "default_value": "1.0"
+        },
+        {
+          "id": "employee_name",
+          "label": "Employee Name",
+          "type": "text",
+          "required": true,
+          "placeholder": "Jane Doe"
+        },
+        {
+          "id": "department",
+          "label": "Department",
+          "type": "select",
+          "required": true,
+          "options": [
+            "",
+            "Engineering",
+            "Design",
+            "Marketing",
+            "Sales",
+            "Operations",
+            "Finance",
+            "HR",
+            "Legal"
+          ]
+        },
+        {
+          "id": "report_date",
+          "label": "Report Date",
+          "type": "date",
+          "required": true
+        },
+        {
+          "id": "total_amount",
+          "label": "Total Amount",
+          "type": "currency",
+          "required": true,
+          "placeholder": "0.00"
+        }
+      ]
+    },
+    {
+      "title": "Expenses",
+      "fields": [
+        {
+          "id": "expenses_heading",
+          "label": "Expense Line Items",
+          "type": "heading",
+          "hint": "Add each expense as a separate row below"
+        },
+        {
+          "id": "line_items",
+          "label": "Line Items",
+          "type": "repeater",
+          "min_rows": 1,
+          "max_rows": 20,
+          "fields": [
+            { "id": "description", "label": "Description", "type": "text", "placeholder": "Flight to NYC" },
+            { "id": "amount", "label": "Amount", "type": "currency" },
+            { "id": "category", "label": "Category", "type": "select", "options": ["", "Travel", "Meals", "Lodging", "Supplies", "Other"] }
+          ]
+        },
+        {
+          "id": "item_count",
+          "label": "Number of Receipts",
+          "type": "number",
+          "min": 0,
+          "max": 50,
+          "step": 1,
+          "placeholder": "0"
+        }
+      ]
+    },
+    {
+      "title": "Supporting Documents",
+      "fields": [
+        {
+          "id": "receipt_photo",
+          "label": "Receipt / Invoice Photo",
+          "type": "file",
+          "accept": "image/*",
+          "max_size_mb": 5,
+          "hint": "Upload a photo of your receipt or invoice"
+        },
+        {
+          "id": "notes",
+          "label": "Additional Notes",
+          "type": "textarea",
+          "placeholder": "Any additional context for this expense report..."
+        }
+      ]
+    },
+    {
+      "title": "Mailing Address",
+      "fields": [
+        {
+          "id": "mailing_address",
+          "label": "Reimbursement Mailing Address",
+          "type": "address",
+          "hint": "Where should the reimbursement check be mailed?"
+        }
+      ]
+    },
+    {
+      "title": "Approval",
+      "fields": [
+        {
+          "id": "employee_signature",
+          "label": "Employee Signature",
+          "type": "signature",
+          "required": true
+        },
+        {
+          "id": "manager_signature",
+          "label": "Manager Signature",
+          "type": "signature"
+        }
+      ]
+    }
+  ]
+}

--- a/templates/expense-report.py
+++ b/templates/expense-report.py
@@ -1,0 +1,253 @@
+"""
+FormForge DOCX Template: Expense Report
+========================================
+Demonstrates all new field types (number, currency, heading, hidden,
+address, file, signature, repeater) alongside existing types.
+
+Field type notes:
+  - text/email/tel/date/select/radio/textarea → str
+  - number/currency → str (e.g. "42.5", "1250.00")
+  - hidden → str (static default_value from schema)
+  - heading → not passed (skipped in collectFormData)
+  - checkbox → comma-separated str
+  - longtext → str with possible newlines
+  - list → newline-separated str
+  - address → JSON string: {"street","city","state","zip"}
+  - file/signature → base64 data URI str or ""
+  - repeater → JSON array string: [{"field":"value"}, ...]
+"""
+
+import io
+import json
+import base64
+from datetime import datetime
+from docx import Document
+from docx.shared import Inches, Pt, RGBColor
+from docx.enum.text import WD_ALIGN_PARAGRAPH
+from docx.enum.table import WD_TABLE_ALIGNMENT
+
+
+# -- Color palette --
+COLOR_NAVY = RGBColor(0x1A, 0x1A, 0x3E)
+COLOR_BLUE = RGBColor(0x33, 0x33, 0x66)
+COLOR_SOFT = RGBColor(0x66, 0x66, 0x99)
+COLOR_MUTED = RGBColor(0x99, 0x99, 0x99)
+
+
+def generate_docx(data):
+    """
+    Generate an Expense Report Document from form data.
+
+    Args:
+        data: dict mapping field IDs to their string values.
+
+    Returns:
+        bytes: The generated .docx file as raw bytes.
+    """
+    doc = Document()
+
+    # ── Global styles ───────────────────────────────────────
+    style = doc.styles["Normal"]
+    style.font.name = "Calibri"
+    style.font.size = Pt(11)
+
+    # ── Title ───────────────────────────────────────────────
+    title = doc.add_heading("Expense Report", level=0)
+    title.alignment = WD_ALIGN_PARAGRAPH.CENTER
+    for run in title.runs:
+        run.font.color.rgb = COLOR_BLUE
+
+    doc.add_paragraph("")
+
+    # ── Summary line ────────────────────────────────────────
+    name = data.get("employee_name", "")
+    dept = data.get("department", "")
+    report_date = data.get("report_date", "")
+    form_ver = data.get("form_version", "")
+
+    p = doc.add_paragraph()
+    p.alignment = WD_ALIGN_PARAGRAPH.CENTER
+    run = p.add_run(f"{name} — {dept} — {report_date}")
+    run.font.size = Pt(12)
+    run.font.color.rgb = COLOR_SOFT
+
+    doc.add_paragraph("")
+
+    # ── Report Details ──────────────────────────────────────
+    total = data.get("total_amount", "0")
+    try:
+        total_fmt = f"${float(total):,.2f}"
+    except (ValueError, TypeError):
+        total_fmt = f"${total}"
+
+    _add_table_section(doc, "Report Details", [
+        ("Employee", name),
+        ("Department", dept),
+        ("Report Date", report_date),
+        ("Total Amount", total_fmt),
+        ("Form Version", form_ver),
+    ])
+
+    # ── Line Items (repeater) ───────────────────────────────
+    doc.add_heading("Expense Line Items", level=1)
+
+    raw_items = data.get("line_items", "[]")
+    try:
+        items = json.loads(raw_items)
+    except (json.JSONDecodeError, TypeError):
+        items = []
+
+    if items:
+        table = doc.add_table(rows=1, cols=3)
+        table.alignment = WD_TABLE_ALIGNMENT.CENTER
+        table.style = "Light Grid Accent 1"
+        for i, header in enumerate(["Description", "Amount", "Category"]):
+            cell_p = table.rows[0].cells[i].paragraphs[0]
+            r = cell_p.add_run(header)
+            r.bold = True
+            r.font.size = Pt(10)
+        for item in items:
+            row = table.add_row()
+            row.cells[0].text = item.get("description", "")
+            amt = item.get("amount", "0")
+            try:
+                row.cells[1].text = f"${float(amt):,.2f}"
+            except (ValueError, TypeError):
+                row.cells[1].text = str(amt)
+            row.cells[2].text = item.get("category", "")
+    else:
+        p = doc.add_paragraph()
+        r = p.add_run("No line items provided.")
+        r.italic = True
+        r.font.color.rgb = COLOR_MUTED
+
+    doc.add_paragraph("")
+
+    # ── Number of Receipts (number field) ───────────────────
+    receipt_count = data.get("item_count", "0")
+    p = doc.add_paragraph()
+    r = p.add_run(f"Number of receipts attached: {receipt_count}")
+    r.font.size = Pt(10)
+
+    doc.add_paragraph("")
+
+    # ── Receipt Photo (file field) ──────────────────────────
+    doc.add_heading("Receipt / Invoice", level=1)
+    receipt_b64 = data.get("receipt_photo", "")
+    if receipt_b64 and "," in receipt_b64:
+        try:
+            img_data = receipt_b64.split(",")[1]
+            img_bytes = base64.b64decode(img_data)
+            doc.add_picture(io.BytesIO(img_bytes), width=Inches(3))
+        except Exception:
+            p = doc.add_paragraph()
+            r = p.add_run("[Receipt image could not be embedded]")
+            r.italic = True
+            r.font.color.rgb = COLOR_MUTED
+    else:
+        p = doc.add_paragraph()
+        r = p.add_run("No receipt uploaded.")
+        r.italic = True
+        r.font.color.rgb = COLOR_MUTED
+
+    doc.add_paragraph("")
+
+    # ── Notes ───────────────────────────────────────────────
+    notes = data.get("notes", "")
+    if notes and notes.strip():
+        doc.add_heading("Additional Notes", level=1)
+        p = doc.add_paragraph()
+        r = p.add_run(notes)
+        r.font.size = Pt(10)
+        doc.add_paragraph("")
+
+    # ── Mailing Address (address field) ─────────────────────
+    doc.add_heading("Reimbursement Mailing Address", level=1)
+    raw_addr = data.get("mailing_address", "{}")
+    try:
+        addr = json.loads(raw_addr)
+    except (json.JSONDecodeError, TypeError):
+        addr = {}
+
+    if addr.get("street"):
+        p = doc.add_paragraph()
+        lines = [
+            addr.get("street", ""),
+            f"{addr.get('city', '')}, {addr.get('state', '')} {addr.get('zip', '')}".strip(),
+        ]
+        for line in lines:
+            if line.strip() and line.strip() != ",":
+                r = p.add_run(line.strip() + "\n")
+                r.font.size = Pt(10)
+    else:
+        p = doc.add_paragraph()
+        r = p.add_run("No address provided.")
+        r.italic = True
+        r.font.color.rgb = COLOR_MUTED
+
+    doc.add_paragraph("")
+
+    # ── Signatures (signature fields) ───────────────────────
+    doc.add_heading("Approval Signatures", level=1)
+
+    for label, field_id in [("Employee Signature", "employee_signature"),
+                            ("Manager Signature", "manager_signature")]:
+        sig_b64 = data.get(field_id, "")
+        p = doc.add_paragraph()
+        if sig_b64 and "," in sig_b64:
+            try:
+                sig_data = sig_b64.split(",")[1]
+                sig_bytes = base64.b64decode(sig_data)
+                doc.add_picture(io.BytesIO(sig_bytes), width=Inches(2.5))
+            except Exception:
+                r = p.add_run("_" * 40)
+        else:
+            r = p.add_run("_" * 40)
+        lp = doc.add_paragraph()
+        lr = lp.add_run(label)
+        lr.font.size = Pt(9)
+        lr.font.color.rgb = COLOR_MUTED
+
+    doc.add_paragraph("")
+
+    # ── Footer ──────────────────────────────────────────────
+    fp = doc.add_paragraph()
+    fp.alignment = WD_ALIGN_PARAGRAPH.CENTER
+    fr = fp.add_run(
+        "This document was auto-generated by FormForge. "
+        "Please review all information for accuracy."
+    )
+    fr.font.size = Pt(8)
+    fr.font.color.rgb = COLOR_MUTED
+    fr.italic = True
+
+    # ── Serialize ───────────────────────────────────────────
+    buffer = io.BytesIO()
+    doc.save(buffer)
+    buffer.seek(0)
+    return buffer.getvalue()
+
+
+# ═══════════════════════════════════════════════════════════
+#  HELPER FUNCTIONS
+# ═══════════════════════════════════════════════════════════
+
+def _add_table_section(doc, title_text, fields):
+    """Add a heading + two-column key/value table."""
+    doc.add_heading(title_text, level=1)
+
+    table = doc.add_table(rows=0, cols=2)
+    table.alignment = WD_TABLE_ALIGNMENT.CENTER
+    table.style = "Light Grid Accent 1"
+
+    for label, value in fields:
+        row = table.add_row()
+        lp = row.cells[0].paragraphs[0]
+        lr = lp.add_run(label)
+        lr.bold = True
+        lr.font.size = Pt(10)
+        vp = row.cells[1].paragraphs[0]
+        vr = vp.add_run(str(value) if value else "\u2014")
+        vr.font.size = Pt(10)
+
+    doc.add_paragraph("")

--- a/tests/fixtures/expense-report_sample.json
+++ b/tests/fixtures/expense-report_sample.json
@@ -1,0 +1,14 @@
+{
+  "form_version": "1.0",
+  "employee_name": "Jane Doe",
+  "department": "Engineering",
+  "report_date": "2026-03-01",
+  "total_amount": "1375.50",
+  "line_items": "[{\"description\":\"Flight to NYC\",\"amount\":\"450.00\",\"category\":\"Travel\"},{\"description\":\"Client dinner\",\"amount\":\"125.50\",\"category\":\"Meals\"},{\"description\":\"Hotel 2 nights\",\"amount\":\"800.00\",\"category\":\"Lodging\"}]",
+  "item_count": "3",
+  "receipt_photo": "",
+  "notes": "Business trip for client onsite meeting, March 1-3.",
+  "mailing_address": "{\"street\":\"123 Main Street\",\"city\":\"Springfield\",\"state\":\"IL\",\"zip\":\"62701\"}",
+  "employee_signature": "",
+  "manager_signature": ""
+}


### PR DESCRIPTION
## Summary
- Implements all 8 new field types from issue #2: `number`, `currency`, `heading`, `hidden`, `address`, `file`, `signature`, `repeater`
- Each type implemented across all touchpoints: `createField()`, `collectFormData()`, `validateForm()`, `resetForm()`, CSS, and layout
- New `expense-report` demo schema + template exercising all new types end-to-end
- Updated `docs/FIELD_TYPES.md` with JSON schema examples and template handling for all 18 field types

## New Field Types

| Type | Category | Description |
|------|----------|-------------|
| `number` | Tier 1 | HTML number input with min/max/step |
| `currency` | Tier 1 | Number input with $ prefix, step=0.01 |
| `heading` | Tier 1 | Non-input section divider (skipped in data collection) |
| `hidden` | Tier 1 | Invisible field passing static default_value |
| `address` | Tier 2 | Compound field: street/city/state/zip → JSON object |
| `file` | Tier 2 | File upload → base64 data URI with image preview |
| `signature` | Tier 2 | Canvas drawing pad → base64 PNG (mouse + touch) |
| `repeater` | Tier 2 | Dynamic row group → JSON array of objects |

## Test plan
- [x] Expense report template generates valid DOCX from sample fixture (37KB)
- [x] Schema validated: all 8 new types present in expense-report.json
- [ ] Manual: open index.html, load expense-report schema, fill all fields, export DOCX
- [ ] Manual: verify signature pad works on mobile (touch events)
- [ ] Manual: verify file upload rejects files > max_size_mb
- [ ] Manual: verify repeater add/remove rows with min/max constraints

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)