### PR TITLE
Add schema validation with _schema.spec.json (#4)

### DIFF
--- a/docs/DEVLOG.md
+++ b/docs/DEVLOG.md
@@ -14,6 +14,26 @@
 
 ## Log
 
+### 2026-03-03 — Added Schema Validation with `_schema.spec.json` (#4)
+**Issues:** #4 (Add schema validation)
+
+- Created `schemas/_schema.spec.json` using JSON Schema draft 2020-12 to validate all form schemas
+- Spec validates top-level structure (`title`, `sections`), section structure (`title`, `fields`), and field structure (`id` pattern, `label`, `type` enum)
+- All 17 field types enumerated in the `type` enum with type-specific conditional validation via `if/then/allOf`
+- Conditional rules enforce: `options` required for select/radio/checkbox, `default_value` for hidden, `fields` for repeater
+- Type-specific properties restricted to their correct types (e.g., `min/max/step` only on `number`, `maxLength` only on `text/longtext`, `accept/max_size_mb` only on `file`)
+- Repeater sub-fields validated separately with restricted type enum (`text`, `email`, `tel`, `number`, `currency`, `select`)
+- Created `tests/test_schemas.py` with 15 tests: spec validity, field type coverage, positive validation of both existing schemas, and 9 negative tests for invalid schemas
+- Both `onboarding.json` and `expense-report.json` validate successfully against the spec
+
+**Decisions:**
+- Used `if/then` within `allOf` for conditional validation rather than `oneOf` with separate schemas per type — keeps the spec more readable and maintainable
+- Used `additionalProperties: false` at all levels to catch typos and unknown properties early
+- Template path pattern enforced as `^templates/.+\.py$` to match the project convention
+- Repeater sub-fields defined as a separate `$defs/repeaterField` schema with its own restricted type enum, matching the subset supported by the app
+
+---
+
 ### 2026-03-03 — Created Shared Template Base `_base.py` (#3)
 **Issues:** #3 (Create shared template base)
 

--- a/schemas/_schema.spec.json
+++ b/schemas/_schema.spec.json
@@ -1,0 +1,271 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/ccirone2/form-forge/schemas/_schema.spec.json",
+  "title": "FormForge Schema",
+  "description": "Validates FormForge form definition schemas.",
+  "type": "object",
+  "required": ["title", "sections"],
+  "properties": {
+    "title": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Form heading displayed in the picker and form header."
+    },
+    "description": {
+      "type": "string",
+      "description": "Subheading shown in the picker and form header."
+    },
+    "icon": {
+      "type": "string",
+      "description": "Single emoji character shown in the form picker."
+    },
+    "template": {
+      "type": "string",
+      "pattern": "^templates/.+\\.py$",
+      "description": "Path to the Python template file, relative to repo root."
+    },
+    "sections": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/section" }
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "fieldType": {
+      "type": "string",
+      "enum": [
+        "text", "email", "tel", "date",
+        "textarea", "longtext",
+        "select", "radio", "checkbox",
+        "list", "number", "currency",
+        "heading", "hidden",
+        "address", "file", "signature",
+        "repeater"
+      ]
+    },
+    "repeaterFieldType": {
+      "type": "string",
+      "enum": ["text", "email", "tel", "number", "currency", "select"]
+    },
+    "section": {
+      "type": "object",
+      "required": ["title", "fields"],
+      "properties": {
+        "title": {
+          "type": "string",
+          "minLength": 1
+        },
+        "fields": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/field" }
+        }
+      },
+      "additionalProperties": false
+    },
+    "field": {
+      "type": "object",
+      "required": ["id", "label", "type"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_]*$"
+        },
+        "label": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": { "$ref": "#/$defs/fieldType" },
+        "required": { "type": "boolean" },
+        "placeholder": { "type": "string" },
+        "hint": { "type": "string" },
+        "options": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string" }
+        },
+        "maxLength": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "min": { "type": "integer" },
+        "max": { "type": "integer" },
+        "step": { "type": "number" },
+        "currency_symbol": { "type": "string" },
+        "default_value": { "type": "string" },
+        "accept": { "type": "string" },
+        "max_size_mb": { "type": "integer", "minimum": 1 },
+        "min_rows": { "type": "integer", "minimum": 1 },
+        "max_rows": { "type": "integer", "minimum": 1 },
+        "fields": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/repeaterField" }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "type": { "enum": ["select", "radio", "checkbox"] } },
+            "required": ["type"]
+          },
+          "then": {
+            "required": ["options"]
+          }
+        },
+        {
+          "if": {
+            "properties": { "type": { "const": "hidden" } },
+            "required": ["type"]
+          },
+          "then": {
+            "required": ["default_value"]
+          }
+        },
+        {
+          "if": {
+            "properties": { "type": { "const": "repeater" } },
+            "required": ["type"]
+          },
+          "then": {
+            "required": ["fields"]
+          }
+        },
+        {
+          "if": {
+            "properties": { "type": { "enum": ["text", "email", "tel", "date", "textarea", "longtext", "list", "number", "currency", "address", "file", "signature", "repeater", "heading", "hidden"] } },
+            "required": ["type"]
+          },
+          "then": {
+            "not": { "required": ["options"] }
+          }
+        },
+        {
+          "if": {
+            "properties": { "type": { "enum": ["text", "email", "tel", "date", "textarea", "longtext", "select", "radio", "checkbox", "list", "currency", "heading", "hidden", "address", "file", "signature", "repeater"] } },
+            "required": ["type"]
+          },
+          "then": {
+            "properties": {
+              "min": false,
+              "max": false,
+              "step": false
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": { "type": { "enum": ["text", "email", "tel", "date", "textarea", "longtext", "select", "radio", "checkbox", "list", "number", "heading", "hidden", "address", "file", "signature", "repeater"] } },
+            "required": ["type"]
+          },
+          "then": {
+            "properties": {
+              "currency_symbol": false
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": { "type": { "enum": ["email", "tel", "date", "textarea", "select", "radio", "checkbox", "list", "number", "currency", "heading", "hidden", "address", "file", "signature", "repeater"] } },
+            "required": ["type"]
+          },
+          "then": {
+            "properties": {
+              "maxLength": false
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": { "type": { "enum": ["text", "email", "tel", "date", "textarea", "longtext", "select", "radio", "checkbox", "list", "number", "currency", "heading", "hidden", "address", "signature", "repeater"] } },
+            "required": ["type"]
+          },
+          "then": {
+            "properties": {
+              "accept": false,
+              "max_size_mb": false
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": { "type": { "enum": ["text", "email", "tel", "date", "textarea", "longtext", "select", "radio", "checkbox", "list", "number", "currency", "heading", "hidden", "address", "file", "signature"] } },
+            "required": ["type"]
+          },
+          "then": {
+            "properties": {
+              "min_rows": false,
+              "max_rows": false,
+              "fields": false
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": { "type": { "enum": ["text", "email", "tel", "date", "textarea", "longtext", "select", "radio", "checkbox", "list", "number", "currency", "heading", "address", "file", "signature", "repeater"] } },
+            "required": ["type"]
+          },
+          "then": {
+            "properties": {
+              "default_value": false
+            }
+          }
+        }
+      ],
+      "additionalProperties": false
+    },
+    "repeaterField": {
+      "type": "object",
+      "required": ["id", "label", "type"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_]*$"
+        },
+        "label": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": { "$ref": "#/$defs/repeaterFieldType" },
+        "required": { "type": "boolean" },
+        "placeholder": { "type": "string" },
+        "hint": { "type": "string" },
+        "options": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string" }
+        },
+        "maxLength": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "min": { "type": "integer" },
+        "max": { "type": "integer" },
+        "step": { "type": "number" },
+        "currency_symbol": { "type": "string" }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "type": { "const": "select" } },
+            "required": ["type"]
+          },
+          "then": {
+            "required": ["options"]
+          }
+        },
+        {
+          "if": {
+            "properties": { "type": { "enum": ["text", "email", "tel", "number", "currency"] } },
+            "required": ["type"]
+          },
+          "then": {
+            "not": { "required": ["options"] }
+          }
+        }
+      ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,0 +1,237 @@
+"""Tests for schema validation against _schema.spec.json."""
+
+import json
+from pathlib import Path
+
+import jsonschema
+
+SCHEMAS_DIR = Path(__file__).resolve().parent.parent / "schemas"
+SPEC_PATH = SCHEMAS_DIR / "_schema.spec.json"
+
+
+def _load_spec():
+    return json.loads(SPEC_PATH.read_text(encoding="utf-8"))
+
+
+def _schema_files():
+    """Return all .json files in schemas/ except the spec itself."""
+    return sorted(
+        p for p in SCHEMAS_DIR.glob("*.json") if p.name != "_schema.spec.json"
+    )
+
+
+def test_spec_is_valid_json_schema():
+    """The spec file itself must be a valid JSON Schema (draft 2020-12)."""
+    spec = _load_spec()
+    assert spec["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+    # Validate the meta-schema (checks the spec is well-formed)
+    jsonschema.Draft202012Validator.check_schema(spec)
+
+
+def test_spec_requires_title_and_sections():
+    spec = _load_spec()
+    assert "title" in spec["required"]
+    assert "sections" in spec["required"]
+
+
+def test_spec_enumerates_all_field_types():
+    spec = _load_spec()
+    expected_types = {
+        "text",
+        "email",
+        "tel",
+        "date",
+        "textarea",
+        "longtext",
+        "select",
+        "radio",
+        "checkbox",
+        "list",
+        "number",
+        "currency",
+        "heading",
+        "hidden",
+        "address",
+        "file",
+        "signature",
+        "repeater",
+    }
+    actual_types = set(spec["$defs"]["fieldType"]["enum"])
+    assert actual_types == expected_types
+
+
+def test_validate_onboarding_schema():
+    spec = _load_spec()
+    schema = json.loads((SCHEMAS_DIR / "onboarding.json").read_text(encoding="utf-8"))
+    jsonschema.validate(instance=schema, schema=spec)
+
+
+def test_validate_expense_report_schema():
+    spec = _load_spec()
+    schema = json.loads(
+        (SCHEMAS_DIR / "expense-report.json").read_text(encoding="utf-8")
+    )
+    jsonschema.validate(instance=schema, schema=spec)
+
+
+def test_validate_all_schemas():
+    """Every schema file in schemas/ must validate against the spec."""
+    spec = _load_spec()
+    schema_files = _schema_files()
+    assert len(schema_files) > 0, "No schema files found"
+    for path in schema_files:
+        schema = json.loads(path.read_text(encoding="utf-8"))
+        jsonschema.validate(instance=schema, schema=spec)
+
+
+# --- Negative tests: schemas that SHOULD fail ---
+
+
+def test_rejects_missing_title():
+    spec = _load_spec()
+    bad = {
+        "sections": [
+            {"title": "S", "fields": [{"id": "x", "label": "X", "type": "text"}]}
+        ]
+    }
+    try:
+        jsonschema.validate(instance=bad, schema=spec)
+        assert False, "Should have raised ValidationError"
+    except jsonschema.ValidationError:
+        pass
+
+
+def test_rejects_empty_sections():
+    spec = _load_spec()
+    bad = {"title": "T", "sections": []}
+    try:
+        jsonschema.validate(instance=bad, schema=spec)
+        assert False, "Should have raised ValidationError"
+    except jsonschema.ValidationError:
+        pass
+
+
+def test_rejects_invalid_field_id():
+    spec = _load_spec()
+    bad = {
+        "title": "T",
+        "sections": [
+            {
+                "title": "S",
+                "fields": [{"id": "BadId", "label": "X", "type": "text"}],
+            }
+        ],
+    }
+    try:
+        jsonschema.validate(instance=bad, schema=spec)
+        assert False, "Should have raised ValidationError"
+    except jsonschema.ValidationError:
+        pass
+
+
+def test_rejects_unknown_field_type():
+    spec = _load_spec()
+    bad = {
+        "title": "T",
+        "sections": [
+            {
+                "title": "S",
+                "fields": [{"id": "x", "label": "X", "type": "foobar"}],
+            }
+        ],
+    }
+    try:
+        jsonschema.validate(instance=bad, schema=spec)
+        assert False, "Should have raised ValidationError"
+    except jsonschema.ValidationError:
+        pass
+
+
+def test_rejects_select_without_options():
+    spec = _load_spec()
+    bad = {
+        "title": "T",
+        "sections": [
+            {
+                "title": "S",
+                "fields": [{"id": "x", "label": "X", "type": "select"}],
+            }
+        ],
+    }
+    try:
+        jsonschema.validate(instance=bad, schema=spec)
+        assert False, "Should have raised ValidationError"
+    except jsonschema.ValidationError:
+        pass
+
+
+def test_rejects_hidden_without_default_value():
+    spec = _load_spec()
+    bad = {
+        "title": "T",
+        "sections": [
+            {
+                "title": "S",
+                "fields": [{"id": "x", "label": "X", "type": "hidden"}],
+            }
+        ],
+    }
+    try:
+        jsonschema.validate(instance=bad, schema=spec)
+        assert False, "Should have raised ValidationError"
+    except jsonschema.ValidationError:
+        pass
+
+
+def test_rejects_repeater_without_fields():
+    spec = _load_spec()
+    bad = {
+        "title": "T",
+        "sections": [
+            {
+                "title": "S",
+                "fields": [{"id": "x", "label": "X", "type": "repeater"}],
+            }
+        ],
+    }
+    try:
+        jsonschema.validate(instance=bad, schema=spec)
+        assert False, "Should have raised ValidationError"
+    except jsonschema.ValidationError:
+        pass
+
+
+def test_rejects_options_on_text_field():
+    spec = _load_spec()
+    bad = {
+        "title": "T",
+        "sections": [
+            {
+                "title": "S",
+                "fields": [{"id": "x", "label": "X", "type": "text", "options": ["a"]}],
+            }
+        ],
+    }
+    try:
+        jsonschema.validate(instance=bad, schema=spec)
+        assert False, "Should have raised ValidationError"
+    except jsonschema.ValidationError:
+        pass
+
+
+def test_rejects_min_on_text_field():
+    spec = _load_spec()
+    bad = {
+        "title": "T",
+        "sections": [
+            {
+                "title": "S",
+                "fields": [{"id": "x", "label": "X", "type": "text", "min": 0}],
+            }
+        ],
+    }
+    try:
+        jsonschema.validate(instance=bad, schema=spec)
+        assert False, "Should have raised ValidationError"
+    except jsonschema.ValidationError:
+        pass


### PR DESCRIPTION
## Summary
- Create `schemas/_schema.spec.json` (JSON Schema draft 2020-12) that validates all form schemas
- Enforces required top-level, section, and field properties with `additionalProperties: false`
- All 17 field types enumerated with type-specific conditional validation (`if/then/allOf`)
- Repeater sub-fields validated with restricted type enum (text, email, tel, number, currency, select)
- Add `tests/test_schemas.py` with 15 tests (spec validity, positive + negative validation)

## Test plan
- [x] Spec is valid JSON Schema (meta-schema check)
- [x] `onboarding.json` validates against spec
- [x] `expense-report.json` validates against spec
- [x] Invalid schemas rejected (missing title, bad field ID, unknown type, select without options, hidden without default_value, repeater without fields, options on text, min on text)
- [x] All 33 tests pass (`pytest tests/ -v`)
- [x] Lint passes (`ruff check`)

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)