### PR TITLE
Add multi-step wizard form support (#6)

### DIFF
--- a/docs/DEVLOG.md
+++ b/docs/DEVLOG.md
@@ -14,6 +14,28 @@
 
 ## Log
 
+### 2026-03-03 — Multi-Step Wizard Form Support (#6)
+**Issues:** #6 (Add multi-step wizard form support)
+
+- Updated `schemas/_schema.spec.json` to allow optional `"wizard": true` boolean at the top level and optional `"step"` (positive integer, minimum 1) on section objects
+- Added wizard CSS styles to `index.html`: step indicator with circles, connectors, and labels; navigation buttons; section visibility toggling
+- Modified `buildForm()` in `index.html` to detect `wizard: true` and render a step indicator, show only one section at a time, and add Next/Back navigation buttons per section
+- Added `wizardValidateStep()` for per-step validation — clicking Next validates only the current section's required fields before advancing
+- Added `wizardNext()` and `wizardGoTo()` for step navigation with indicator state updates (active/completed styling)
+- Back button hidden on first step; submit area hidden until last step; data preserved across step navigation
+- Non-wizard schemas render exactly as before — no visual or behavioral changes
+- Added 6 new tests to `tests/test_schemas.py`: wizard schema validation, wizard without step, non-wizard regression, rejects non-boolean wizard, rejects non-integer step, rejects step zero
+- All 39 tests pass
+
+**Decisions:**
+- Wizard navigation buttons are placed inside each section div rather than in a fixed footer — keeps the flow natural and avoids layout conflicts with the existing submit area
+- Submit area (`Export to DOCX` + `Reset`) is hidden during wizard navigation and only shown on the final step, where it replaces the Next button
+- Per-step validation reuses the same pattern as `validateForm()` but scoped to one section — `collectFormData()` and full `validateForm()` still operate across all sections for final export
+- Step indicator uses numbered circles with connectors — completed steps get accent-glow background, active step gets solid accent fill
+- If sections omit `step`, the indicator defaults to section index + 1
+
+---
+
 ### 2026-03-03 — Template Testing with pytest (#5)
 **Issues:** #5 (Set up template testing with pytest)
 

--- a/index.html
+++ b/index.html
@@ -309,6 +309,57 @@
   }
   .btn-remove-row:hover { color: var(--error); border-color: var(--error); }
 
+  /* Wizard */
+  .wizard-indicator {
+    display: flex; align-items: center; justify-content: center; gap: 0;
+    margin-bottom: 32px; padding: 0 16px;
+  }
+  .wizard-step {
+    display: flex; align-items: center; gap: 0; cursor: default;
+  }
+  .wizard-step-circle {
+    width: 32px; height: 32px; border-radius: 50%; display: flex; align-items: center;
+    justify-content: center; font-size: 13px; font-weight: 600; flex-shrink: 0;
+    border: 2px solid var(--border); color: var(--text-muted); background: var(--surface);
+    transition: all 0.3s;
+  }
+  .wizard-step.active .wizard-step-circle {
+    border-color: var(--accent); background: var(--accent); color: #fff;
+  }
+  .wizard-step.completed .wizard-step-circle {
+    border-color: var(--accent); background: var(--accent-glow); color: var(--accent);
+  }
+  .wizard-step-label {
+    font-size: 12px; color: var(--text-muted); margin-left: 8px;
+    white-space: nowrap; transition: color 0.3s;
+  }
+  .wizard-step.active .wizard-step-label { color: var(--text); font-weight: 500; }
+  .wizard-step.completed .wizard-step-label { color: var(--accent-hover); }
+  .wizard-step-connector {
+    width: 40px; height: 2px; background: var(--border); margin: 0 8px; flex-shrink: 0;
+    transition: background 0.3s;
+  }
+  .wizard-step-connector.completed { background: var(--accent); }
+  .wizard-nav {
+    display: flex; align-items: center; justify-content: space-between;
+    margin-top: 24px; gap: 16px;
+  }
+  .wizard-nav .btn-wizard {
+    display: inline-flex; align-items: center; gap: 8px;
+    padding: 10px 24px; border-radius: 8px; font-family: 'DM Sans', sans-serif;
+    font-size: 14px; font-weight: 600; cursor: pointer; transition: all 0.2s;
+  }
+  .wizard-nav .btn-wizard-back {
+    background: transparent; color: var(--text-muted); border: 1px solid var(--border);
+  }
+  .wizard-nav .btn-wizard-back:hover { border-color: var(--text-muted); color: var(--text); }
+  .wizard-nav .btn-wizard-next {
+    background: var(--accent); color: #fff; border: none;
+  }
+  .wizard-nav .btn-wizard-next:hover { background: var(--accent-hover); }
+  .wizard-nav .btn-wizard-next:active { transform: scale(0.97); }
+  .form-section.wizard-hidden { display: none; }
+
   /* Buttons */
   .submit-area { margin-top: 40px; display: flex; align-items: center; gap: 16px; }
   .btn-primary {
@@ -768,6 +819,7 @@ let pyodide = null;
 let pyodideReady = false;
 let baseModuleLoaded = false;  // Whether _base.py has been loaded into Pyodide
 let currentSchema = null;
+let wizardCurrentStep = 0;  // Current wizard step index (0-based)
 let currentTemplateCode = null;
 let repoSchemas = [];      // [{name, path, description, icon, templatePath}]
 let selectedSchemaIdx = -1;
@@ -1474,9 +1526,42 @@ function buildForm(schema) {
 
   if (!schema.sections) { log('Schema has no sections array', 'error'); return; }
 
-  for (const section of schema.sections) {
+  const isWizard = schema.wizard === true;
+
+  // Build wizard step indicator
+  if (isWizard) {
+    const indicator = document.createElement('div');
+    indicator.className = 'wizard-indicator';
+    indicator.id = 'wizardIndicator';
+    schema.sections.forEach((section, i) => {
+      if (i > 0) {
+        const connector = document.createElement('div');
+        connector.className = 'wizard-step-connector';
+        connector.dataset.connectorIndex = i - 1;
+        indicator.appendChild(connector);
+      }
+      const step = document.createElement('div');
+      step.className = 'wizard-step' + (i === 0 ? ' active' : '');
+      step.dataset.stepIndex = i;
+      const circle = document.createElement('div');
+      circle.className = 'wizard-step-circle';
+      circle.textContent = section.step || (i + 1);
+      const label = document.createElement('span');
+      label.className = 'wizard-step-label';
+      label.textContent = section.title;
+      step.appendChild(circle);
+      step.appendChild(label);
+      indicator.appendChild(step);
+    });
+    form.appendChild(indicator);
+  }
+
+  for (const [sectionIdx, section] of schema.sections.entries()) {
     const sectionDiv = document.createElement('div');
     sectionDiv.className = 'form-section';
+    sectionDiv.dataset.sectionIndex = sectionIdx;
+    if (isWizard && sectionIdx > 0) sectionDiv.classList.add('wizard-hidden');
+
     const sectionTitle = document.createElement('h3');
     sectionTitle.className = 'section-title';
     sectionTitle.textContent = section.title;
@@ -1501,7 +1586,6 @@ function buildForm(schema) {
 
     for (const field of section.fields) {
       if (field.type === 'hidden') {
-        // Hidden fields don't participate in layout at all
         sectionDiv.appendChild(createField(field));
         continue;
       }
@@ -1515,11 +1599,126 @@ function buildForm(schema) {
       }
     }
     flushRow();
+
+    // Add wizard navigation buttons inside each section
+    if (isWizard) {
+      const nav = document.createElement('div');
+      nav.className = 'wizard-nav';
+      nav.dataset.navIndex = sectionIdx;
+
+      const isFirst = sectionIdx === 0;
+      const isLast = sectionIdx === schema.sections.length - 1;
+
+      if (!isFirst) {
+        const backBtn = document.createElement('button');
+        backBtn.type = 'button';
+        backBtn.className = 'btn-wizard btn-wizard-back';
+        backBtn.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M19 12H5M12 19l-7-7 7-7"/></svg> Back';
+        backBtn.onclick = () => wizardGoTo(sectionIdx - 1);
+        nav.appendChild(backBtn);
+      } else {
+        nav.appendChild(document.createElement('div')); // spacer
+      }
+
+      if (!isLast) {
+        const nextBtn = document.createElement('button');
+        nextBtn.type = 'button';
+        nextBtn.className = 'btn-wizard btn-wizard-next';
+        nextBtn.innerHTML = 'Next <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14M12 5l7 7-7 7"/></svg>';
+        nextBtn.onclick = () => wizardNext(sectionIdx);
+        nav.appendChild(nextBtn);
+      }
+
+      sectionDiv.appendChild(nav);
+    }
+
     form.appendChild(sectionDiv);
   }
 
+  // Wizard: hide the default submit area, show it only on the last step
+  if (isWizard) {
+    wizardCurrentStep = 0;
+    document.querySelector('.submit-area').style.display = 'none';
+  } else {
+    document.querySelector('.submit-area').style.display = '';
+  }
+
   const totalFields = schema.sections.reduce((a, s) => a + s.fields.length, 0);
-  log(`Form built: ${schema.sections.length} sections, ${totalFields} fields`, 'success');
+  log(`Form built: ${schema.sections.length} sections, ${totalFields} fields${isWizard ? ' (wizard mode)' : ''}`, 'success');
+}
+
+// ============================================================
+//  WIZARD NAVIGATION
+// ============================================================
+
+function wizardValidateStep(stepIndex) {
+  if (!currentSchema || !currentSchema.sections[stepIndex]) return [];
+  const section = currentSchema.sections[stepIndex];
+  const missing = [];
+  for (const field of section.fields) {
+    if (field.type === 'heading') continue;
+    if (!field.required) continue;
+    if (field.type === 'address') {
+      const el = document.getElementById(`${field.id}_street`);
+      if (!el || !el.value.trim()) missing.push(field.label);
+    } else if (field.type === 'checkbox') {
+      const checked = document.querySelectorAll(`input[name="${field.id}"]:checked`);
+      if (checked.length === 0) missing.push(field.label);
+    } else if (field.type === 'radio') {
+      const selected = document.querySelector(`input[name="${field.id}"]:checked`);
+      if (!selected) missing.push(field.label);
+    } else {
+      const el = document.getElementById(field.id);
+      if (!el || !el.value || !el.value.trim()) missing.push(field.label);
+    }
+  }
+  return missing;
+}
+
+function wizardNext(fromStep) {
+  const missing = wizardValidateStep(fromStep);
+  if (missing.length > 0) {
+    showToast(`Missing: ${missing.slice(0, 3).join(', ')}${missing.length > 3 ? '...' : ''}`, 'error');
+    log('Step validation failed: ' + missing.join(', '), 'error');
+    return;
+  }
+  wizardGoTo(fromStep + 1);
+}
+
+function wizardGoTo(stepIndex) {
+  if (!currentSchema) return;
+  const totalSteps = currentSchema.sections.length;
+  if (stepIndex < 0 || stepIndex >= totalSteps) return;
+
+  wizardCurrentStep = stepIndex;
+  const form = document.getElementById('dynamicForm');
+
+  // Toggle section visibility
+  form.querySelectorAll('.form-section').forEach(el => {
+    const idx = parseInt(el.dataset.sectionIndex);
+    if (idx === stepIndex) {
+      el.classList.remove('wizard-hidden');
+    } else {
+      el.classList.add('wizard-hidden');
+    }
+  });
+
+  // Update step indicator
+  form.querySelectorAll('.wizard-step').forEach(el => {
+    const idx = parseInt(el.dataset.stepIndex);
+    el.classList.remove('active', 'completed');
+    if (idx === stepIndex) el.classList.add('active');
+    else if (idx < stepIndex) el.classList.add('completed');
+  });
+  form.querySelectorAll('.wizard-step-connector').forEach(el => {
+    const idx = parseInt(el.dataset.connectorIndex);
+    if (idx < stepIndex) el.classList.add('completed');
+    else el.classList.remove('completed');
+  });
+
+  // Show/hide submit area on last step
+  const isLast = stepIndex === totalSteps - 1;
+  document.querySelector('.submit-area').style.display = isLast ? '' : 'none';
 }
 
 function createField(field) {

--- a/schemas/_schema.spec.json
+++ b/schemas/_schema.spec.json
@@ -24,6 +24,10 @@
       "pattern": "^templates/.+\\.py$",
       "description": "Path to the Python template file, relative to repo root."
     },
+    "wizard": {
+      "type": "boolean",
+      "description": "When true, sections render as wizard steps with next/back navigation."
+    },
     "sections": {
       "type": "array",
       "minItems": 1,
@@ -55,6 +59,11 @@
         "title": {
           "type": "string",
           "minLength": 1
+        },
+        "step": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Step number for wizard mode. Defaults to section index + 1 if omitted."
         },
         "fields": {
           "type": "array",

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -235,3 +235,121 @@ def test_rejects_min_on_text_field():
         assert False, "Should have raised ValidationError"
     except jsonschema.ValidationError:
         pass
+
+
+# --- Wizard schema tests ---
+
+
+def test_wizard_schema_validates():
+    """A schema with wizard: true and step on sections should validate."""
+    spec = _load_spec()
+    wizard_schema = {
+        "title": "Wizard Form",
+        "wizard": True,
+        "sections": [
+            {
+                "title": "Step 1",
+                "step": 1,
+                "fields": [{"id": "name", "label": "Name", "type": "text"}],
+            },
+            {
+                "title": "Step 2",
+                "step": 2,
+                "fields": [{"id": "email", "label": "Email", "type": "email"}],
+            },
+        ],
+    }
+    jsonschema.validate(instance=wizard_schema, schema=spec)
+
+
+def test_wizard_schema_without_step_validates():
+    """A wizard schema where sections omit step should still validate."""
+    spec = _load_spec()
+    wizard_schema = {
+        "title": "Wizard Form",
+        "wizard": True,
+        "sections": [
+            {
+                "title": "Part A",
+                "fields": [{"id": "x", "label": "X", "type": "text"}],
+            },
+            {
+                "title": "Part B",
+                "fields": [{"id": "y", "label": "Y", "type": "text"}],
+            },
+        ],
+    }
+    jsonschema.validate(instance=wizard_schema, schema=spec)
+
+
+def test_non_wizard_schemas_still_validate():
+    """Existing schemas without wizard flag must continue to validate."""
+    spec = _load_spec()
+    schema_files = _schema_files()
+    assert len(schema_files) > 0
+    for path in schema_files:
+        schema = json.loads(path.read_text(encoding="utf-8"))
+        assert "wizard" not in schema or isinstance(schema.get("wizard"), bool)
+        jsonschema.validate(instance=schema, schema=spec)
+
+
+def test_rejects_wizard_non_boolean():
+    """wizard must be a boolean, not a string or int."""
+    spec = _load_spec()
+    bad = {
+        "title": "T",
+        "wizard": "yes",
+        "sections": [
+            {
+                "title": "S",
+                "fields": [{"id": "x", "label": "X", "type": "text"}],
+            }
+        ],
+    }
+    try:
+        jsonschema.validate(instance=bad, schema=spec)
+        assert False, "Should have raised ValidationError"
+    except jsonschema.ValidationError:
+        pass
+
+
+def test_rejects_step_non_integer():
+    """step must be a positive integer, not a string."""
+    spec = _load_spec()
+    bad = {
+        "title": "T",
+        "wizard": True,
+        "sections": [
+            {
+                "title": "S",
+                "step": "one",
+                "fields": [{"id": "x", "label": "X", "type": "text"}],
+            }
+        ],
+    }
+    try:
+        jsonschema.validate(instance=bad, schema=spec)
+        assert False, "Should have raised ValidationError"
+    except jsonschema.ValidationError:
+        pass
+
+
+def test_rejects_step_zero():
+    """step must be >= 1."""
+    spec = _load_spec()
+    bad = {
+        "title": "T",
+        "wizard": True,
+        "sections": [
+            {
+                "title": "S",
+                "step": 0,
+                "fields": [{"id": "x", "label": "X", "type": "text"}],
+            }
+        ],
+    }
+    try:
+        jsonschema.validate(instance=bad, schema=spec)
+        assert False, "Should have raised ValidationError"
+    except jsonschema.ValidationError:
+        pass


### PR DESCRIPTION
## Summary
- Added `wizard: true` schema flag and optional `step` integer on sections to `_schema.spec.json`
- `buildForm()` detects wizard mode and renders a step indicator with numbered circles and connectors
- Only one section visible at a time; Next/Back buttons navigate between steps
- Per-step validation on Next — prevents advancing with missing required fields
- Submit area (Export to DOCX) only appears on the final step
- Non-wizard schemas render exactly as before — zero regressions

## Test plan
- [x] 6 new schema tests: wizard validates, wizard without step, non-wizard regression, rejects non-boolean wizard, rejects non-integer step, rejects step zero
- [x] All 39 tests pass (`PYTHONPATH=. python -m pytest tests/ -v`)
- [ ] Manual: open a wizard schema in browser, verify step indicator, Next/Back navigation, per-step validation, and DOCX export on final step
- [ ] Manual: open existing non-wizard schemas, verify no visual or behavioral changes

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)