### PR TITLE
Add conditional field visibility (visible_when) (#7)

### DIFF
--- a/docs/DEVLOG.md
+++ b/docs/DEVLOG.md
@@ -14,6 +14,28 @@
 
 ## Log
 
+### 2026-03-03 — Conditional Field Visibility with `visible_when` (#7)
+**Issues:** #7 (Add conditional/dynamic field visibility)
+
+- Updated `schemas/_schema.spec.json` to allow optional `visible_when` object on field definitions with required `field` (matching field ID pattern) and `equals` (string) properties, plus `additionalProperties: false`
+- Added `setupConditionalVisibility()` in `index.html` — builds a dependency map from source field IDs to dependent fields, attaches `change`/`input` event listeners based on source field type (select/radio use `change`, text/textarea use `input`+`change`), and evaluates initial state
+- Added `getFieldValue()` helper that handles radio, checkbox, and standard input/select value retrieval
+- Added `isFieldConditionallyHidden()` check used by `validateForm()` and `wizardValidateStep()` to skip validation of hidden conditional fields
+- `collectFormData()` unchanged — always collects all fields (hidden ones return empty strings), ensuring templates always receive every key
+- `resetForm()` calls `setupConditionalVisibility()` after reset to re-evaluate all conditions
+- Added CSS class `conditional-hidden` with `display: none`
+- Added 5 new tests to `tests/test_schemas.py`: visible_when validates, missing field rejected, missing equals rejected, extra property rejected, existing schemas regression
+- All 44 tests pass
+
+**Decisions:**
+- `visible_when` uses simple `equals` string matching — sufficient for the current use case and keeps the schema spec clean. More complex operators (not_equals, contains, etc.) can be added later by extending the `visible_when` object
+- Conditional fields are hidden via a CSS class on `.field-group` rather than removing from DOM — preserves form state so Back button in wizard mode doesn't lose data
+- `collectFormData()` always includes hidden conditional fields (as empty strings) rather than omitting them — ensures templates always receive a consistent set of keys regardless of visibility state
+- Event listeners support order-independent references: a field can depend on a source that appears later in the schema since listeners are attached after all fields are rendered
+- Multiple fields can depend on the same source field via the dependency map pattern
+
+---
+
 ### 2026-03-03 — Multi-Step Wizard Form Support (#6)
 **Issues:** #6 (Add multi-step wizard form support)
 

--- a/index.html
+++ b/index.html
@@ -359,6 +359,7 @@
   .wizard-nav .btn-wizard-next:hover { background: var(--accent-hover); }
   .wizard-nav .btn-wizard-next:active { transform: scale(0.97); }
   .form-section.wizard-hidden { display: none; }
+  .field-group.conditional-hidden { display: none; }
 
   /* Buttons */
   .submit-area { margin-top: 40px; display: flex; align-items: center; gap: 16px; }
@@ -1643,8 +1644,96 @@ function buildForm(schema) {
     document.querySelector('.submit-area').style.display = '';
   }
 
+  // Set up conditional visibility (visible_when)
+  setupConditionalVisibility(schema);
+
   const totalFields = schema.sections.reduce((a, s) => a + s.fields.length, 0);
   log(`Form built: ${schema.sections.length} sections, ${totalFields} fields${isWizard ? ' (wizard mode)' : ''}`, 'success');
+}
+
+// ============================================================
+//  CONDITIONAL VISIBILITY (visible_when)
+// ============================================================
+
+function setupConditionalVisibility(schema) {
+  // Build map: sourceFieldId -> [{targetFieldId, equals}]
+  const dependencies = {};
+  for (const section of schema.sections) {
+    for (const field of section.fields) {
+      if (!field.visible_when) continue;
+      const src = field.visible_when.field;
+      if (!dependencies[src]) dependencies[src] = [];
+      dependencies[src].push({ targetId: field.id, equals: field.visible_when.equals });
+
+      // Set initial hidden state
+      const group = document.getElementById(field.id)?.closest('.field-group');
+      if (group) group.classList.add('conditional-hidden');
+    }
+  }
+
+  // For each source field, attach listeners and evaluate initial state
+  for (const srcId of Object.keys(dependencies)) {
+    const evaluate = () => {
+      const srcValue = getFieldValue(srcId);
+      for (const dep of dependencies[srcId]) {
+        const targetEl = document.getElementById(dep.targetId);
+        const group = targetEl?.closest('.field-group');
+        if (!group) continue;
+        if (srcValue === dep.equals) {
+          group.classList.remove('conditional-hidden');
+        } else {
+          group.classList.add('conditional-hidden');
+        }
+      }
+    };
+
+    // Attach to the right elements based on field type
+    const srcField = findFieldDef(schema, srcId);
+    if (srcField && (srcField.type === 'radio' || srcField.type === 'checkbox')) {
+      document.querySelectorAll(`input[name="${srcId}"]`).forEach(el => {
+        el.addEventListener('change', evaluate);
+      });
+    } else if (srcField && srcField.type === 'select') {
+      const el = document.getElementById(srcId);
+      if (el) el.addEventListener('change', evaluate);
+    } else {
+      const el = document.getElementById(srcId);
+      if (el) {
+        el.addEventListener('input', evaluate);
+        el.addEventListener('change', evaluate);
+      }
+    }
+
+    // Evaluate initial state
+    evaluate();
+  }
+}
+
+function getFieldValue(fieldId) {
+  // Radio: get selected value
+  const radio = document.querySelector(`input[name="${fieldId}"][type="radio"]:checked`);
+  if (radio) return radio.value;
+  // Checkbox: get comma-separated checked values
+  const checkboxes = document.querySelectorAll(`input[name="${fieldId}"][type="checkbox"]:checked`);
+  if (checkboxes.length > 0) return Array.from(checkboxes).map(c => c.value).join(', ');
+  // Default: input/select/textarea
+  const el = document.getElementById(fieldId);
+  return el ? el.value : '';
+}
+
+function findFieldDef(schema, fieldId) {
+  for (const section of schema.sections) {
+    for (const field of section.fields) {
+      if (field.id === fieldId) return field;
+    }
+  }
+  return null;
+}
+
+function isFieldConditionallyHidden(fieldId) {
+  const el = document.getElementById(fieldId);
+  const group = el?.closest('.field-group');
+  return group ? group.classList.contains('conditional-hidden') : false;
 }
 
 // ============================================================
@@ -1658,6 +1747,7 @@ function wizardValidateStep(stepIndex) {
   for (const field of section.fields) {
     if (field.type === 'heading') continue;
     if (!field.required) continue;
+    if (isFieldConditionallyHidden(field.id)) continue;
     if (field.type === 'address') {
       const el = document.getElementById(`${field.id}_street`);
       if (!el || !el.value.trim()) missing.push(field.label);
@@ -2249,6 +2339,7 @@ function validateForm() {
     for (const field of section.fields) {
       if (field.type === 'heading') continue; // non-input, skip
       if (!field.required) continue;
+      if (isFieldConditionallyHidden(field.id)) continue;
       if (field.type === 'address') {
         const addr = JSON.parse(data[field.id] || '{}');
         if (!addr.street || !addr.street.trim()) missing.push(field.label);
@@ -2292,6 +2383,8 @@ function resetForm() {
       }
     }
   }
+  // Re-evaluate conditional visibility after reset
+  if (currentSchema) setupConditionalVisibility(currentSchema);
   log('Form reset', 'info');
 }
 

--- a/schemas/_schema.spec.json
+++ b/schemas/_schema.spec.json
@@ -107,6 +107,22 @@
         "max_size_mb": { "type": "integer", "minimum": 1 },
         "min_rows": { "type": "integer", "minimum": 1 },
         "max_rows": { "type": "integer", "minimum": 1 },
+        "visible_when": {
+          "type": "object",
+          "required": ["field", "equals"],
+          "properties": {
+            "field": {
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9_]*$",
+              "description": "The id of the field whose value controls visibility."
+            },
+            "equals": {
+              "type": "string",
+              "description": "The value that triggers this field to become visible."
+            }
+          },
+          "additionalProperties": false
+        },
         "fields": {
           "type": "array",
           "minItems": 1,

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -353,3 +353,124 @@ def test_rejects_step_zero():
         assert False, "Should have raised ValidationError"
     except jsonschema.ValidationError:
         pass
+
+
+# --- visible_when tests ---
+
+
+def test_visible_when_validates():
+    """A field with visible_when should validate."""
+    spec = _load_spec()
+    schema = {
+        "title": "T",
+        "sections": [
+            {
+                "title": "S",
+                "fields": [
+                    {
+                        "id": "color",
+                        "label": "Color",
+                        "type": "select",
+                        "options": ["Red", "Blue", "Other"],
+                    },
+                    {
+                        "id": "other_color",
+                        "label": "Describe color",
+                        "type": "text",
+                        "visible_when": {"field": "color", "equals": "Other"},
+                    },
+                ],
+            }
+        ],
+    }
+    jsonschema.validate(instance=schema, schema=spec)
+
+
+def test_rejects_visible_when_missing_field():
+    """visible_when must have a 'field' property."""
+    spec = _load_spec()
+    bad = {
+        "title": "T",
+        "sections": [
+            {
+                "title": "S",
+                "fields": [
+                    {
+                        "id": "x",
+                        "label": "X",
+                        "type": "text",
+                        "visible_when": {"equals": "yes"},
+                    }
+                ],
+            }
+        ],
+    }
+    try:
+        jsonschema.validate(instance=bad, schema=spec)
+        assert False, "Should have raised ValidationError"
+    except jsonschema.ValidationError:
+        pass
+
+
+def test_rejects_visible_when_missing_equals():
+    """visible_when must have an 'equals' property."""
+    spec = _load_spec()
+    bad = {
+        "title": "T",
+        "sections": [
+            {
+                "title": "S",
+                "fields": [
+                    {
+                        "id": "x",
+                        "label": "X",
+                        "type": "text",
+                        "visible_when": {"field": "y"},
+                    }
+                ],
+            }
+        ],
+    }
+    try:
+        jsonschema.validate(instance=bad, schema=spec)
+        assert False, "Should have raised ValidationError"
+    except jsonschema.ValidationError:
+        pass
+
+
+def test_rejects_visible_when_extra_property():
+    """visible_when must not have extra properties."""
+    spec = _load_spec()
+    bad = {
+        "title": "T",
+        "sections": [
+            {
+                "title": "S",
+                "fields": [
+                    {
+                        "id": "x",
+                        "label": "X",
+                        "type": "text",
+                        "visible_when": {
+                            "field": "y",
+                            "equals": "yes",
+                            "operator": "eq",
+                        },
+                    }
+                ],
+            }
+        ],
+    }
+    try:
+        jsonschema.validate(instance=bad, schema=spec)
+        assert False, "Should have raised ValidationError"
+    except jsonschema.ValidationError:
+        pass
+
+
+def test_existing_schemas_still_validate_after_visible_when():
+    """Regression: all existing schemas must still validate."""
+    spec = _load_spec()
+    for path in _schema_files():
+        schema = json.loads(path.read_text(encoding="utf-8"))
+        jsonschema.validate(instance=schema, schema=spec)


### PR DESCRIPTION
## Summary
- Added `visible_when` property to field schema: `{ "field": "source_id", "equals": "value" }`
- `_schema.spec.json` validates `visible_when` with required `field`/`equals`, `additionalProperties: false`
- `setupConditionalVisibility()` builds dependency map, attaches event listeners (change for select/radio, input+change for text), evaluates initial state
- Fields hidden via `.conditional-hidden` CSS class on `.field-group`
- `validateForm()` and `wizardValidateStep()` skip hidden conditional fields
- `collectFormData()` always includes all fields (hidden ones as empty strings)
- `resetForm()` re-evaluates all conditions after reset
- Supports multiple dependents per source, order-independent references

## Test plan
- [x] 5 new schema tests: visible_when validates, missing field/equals rejected, extra property rejected, existing schemas regression
- [x] All 44 tests pass (`PYTHONPATH=. python -m pytest tests/ -v`)
- [ ] Manual: create schema with `visible_when` on a select field, verify field shows/hides on selection change
- [ ] Manual: verify hidden conditional fields are not flagged as missing during validation
- [ ] Manual: verify non-wizard and wizard schemas still work unchanged

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)