### PR TITLE
Add CI with GitHub Actions (#9)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,37 @@
+name: Validate Schemas & Templates
+
+on:
+  push:
+    branches: [develop, main]
+  pull_request:
+    branches: [develop, main]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install python-docx jsonschema pytest
+
+      - name: Validate schemas against spec
+        run: |
+          python -c "
+          import json, jsonschema
+          from pathlib import Path
+          spec = json.loads(Path('schemas/_schema.spec.json').read_text())
+          for f in sorted(Path('schemas').glob('*.json')):
+              if f.name.startswith('_'): continue
+              schema = json.loads(f.read_text())
+              jsonschema.validate(schema, spec)
+              print(f'  ✓ {f.name}')
+          print('All schemas valid.')
+          "
+
+      - name: Run tests
+        run: PYTHONPATH=. pytest tests/ -v

--- a/docs/DEVLOG.md
+++ b/docs/DEVLOG.md
@@ -14,6 +14,22 @@
 
 ## Log
 
+### 2026-03-03 — CI with GitHub Actions (#9)
+**Issues:** #9 (Set up CI with GitHub Actions)
+
+- Created `.github/workflows/validate.yml` with two jobs: schema validation and pytest
+- Triggers on `push` and `pull_request` to `develop` and `main` branches
+- Uses `ubuntu-latest`, Python 3.12, installs `python-docx`, `jsonschema`, `pytest`
+- Schema validation step validates all `schemas/*.json` (excluding `_schema.spec.json`) against the spec
+- Test step runs `PYTHONPATH=. pytest tests/ -v` (44 tests)
+
+**Decisions:**
+- Scoped triggers to `develop` and `main` branches only — avoids unnecessary CI runs on ephemeral branches
+- Used inline Python for schema validation rather than a separate script — keeps the repo simple and avoids adding a new file for a few lines of code
+- Followed the workflow structure from `docs/FORMFORGE_EXPANSION_GUIDE.md` Section 8
+
+---
+
 ### 2026-03-03 — Conditional Field Visibility with `visible_when` (#7)
 **Issues:** #7 (Add conditional/dynamic field visibility)
 


### PR DESCRIPTION
## Summary
- Created `.github/workflows/validate.yml` — CI pipeline for schema validation and tests
- Triggers on push and PR to `develop` and `main`
- Python 3.12 on ubuntu-latest, installs python-docx + jsonschema + pytest
- Step 1: validates all `schemas/*.json` against `_schema.spec.json`
- Step 2: runs `PYTHONPATH=. pytest tests/ -v` (44 tests)

## Test plan
- [x] All 44 tests pass locally
- [ ] CI workflow triggers on this PR and passes (self-validating)

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)