### PR TITLE
Fix: filter out _schema.spec.json from schema picker

### DIFF
--- a/docs/DEVLOG.md
+++ b/docs/DEVLOG.md
@@ -14,6 +14,15 @@
 
 ## Log
 
+### 2026-03-03 — Filter _schema.spec.json from Schema Picker
+**Issues:** #26
+
+- `_schema.spec.json` was appearing in the web UI schema picker and failing to load when selected
+- Added `!f.name.startsWith('_')` filter in `index.html` to exclude all `_`-prefixed JSON files from the listing
+- Convention: `_`-prefixed files in `schemas/` are internal infrastructure, not form definitions
+
+---
+
 ### 2026-03-03 — Updated FIELD_TYPES.md to Reflect Current Project State
 **Issues:** documentation maintenance
 

--- a/index.html
+++ b/index.html
@@ -1293,7 +1293,7 @@ async function connectRepo() {
 
     if (!Array.isArray(schemaFiles)) throw new Error('schemas/ directory not found or not a directory');
 
-    const jsonFiles = schemaFiles.filter(f => f.name.endsWith('.json'));
+    const jsonFiles = schemaFiles.filter(f => f.name.endsWith('.json') && !f.name.startsWith('_'));
     if (jsonFiles.length === 0) throw new Error('No .json files found in schemas/');
 
     // Fetch each schema for metadata


### PR DESCRIPTION
## Summary
- Excludes `_`-prefixed JSON files from the schema picker in the web UI
- `_schema.spec.json` was appearing as a selectable form and failing to load — it's a meta-schema, not a form definition
- One-line filter change in `index.html` line 1296

Closes #26

## Test plan
- [ ] Connect the web UI to this repo and verify `_schema.spec.json` no longer appears in the schema picker
- [ ] Verify all valid form schemas still load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)