### PR TITLE
Add demo schema with all 17 field types, wizard, and visible_when

### DIFF
--- a/docs/DEVLOG.md
+++ b/docs/DEVLOG.md
@@ -14,6 +14,22 @@
 
 ## Log
 
+### 2026-03-03 — Add Demo Schema Exercising All Field Types, Wizard, and Conditionals
+**Issues:** #19
+
+- Created `schemas/field-type-demo.json` — "Event Registration" wizard form with 4 steps, all 17 field types, and 3 `visible_when` conditionals
+- Created `templates/field-type-demo.py` — template handling all field types including JSON-parsed address, repeater, file, and signature
+- Created `tests/fixtures/field-type-demo_sample.json` — comprehensive sample data
+- Added 2 template tests (`test_field_type_demo_generates_valid_docx`, `test_field_type_demo_with_empty_data`)
+- All 46 tests pass; schema validates against `_schema.spec.json`
+
+**Conditional visibility demonstrated:**
+- `venue_address` (address) → shown when `attendance_mode` = "In-person"
+- `dietary_restrictions` (checkbox) → shown when `attendance_mode` = "In-person"
+- `virtual_platform` (text) → shown when `attendance_mode` = "Virtual"
+
+---
+
 ### 2026-03-03 — Filter _schema.spec.json from Schema Picker
 **Issues:** #26
 

--- a/schemas/field-type-demo.json
+++ b/schemas/field-type-demo.json
@@ -1,0 +1,175 @@
+{
+  "title": "Event Registration",
+  "description": "Register for an upcoming event. This demo exercises all 17 field types, wizard mode, and conditional visibility.",
+  "icon": "🎪",
+  "template": "templates/field-type-demo.py",
+  "wizard": true,
+  "sections": [
+    {
+      "title": "Applicant Info",
+      "step": 1,
+      "fields": [
+        {
+          "id": "form_version",
+          "label": "Form Version",
+          "type": "hidden",
+          "default_value": "2.0"
+        },
+        {
+          "id": "full_name",
+          "label": "Full Name",
+          "type": "text",
+          "required": true,
+          "placeholder": "Jane Doe"
+        },
+        {
+          "id": "email",
+          "label": "Email Address",
+          "type": "email",
+          "required": true,
+          "placeholder": "jane@example.com"
+        },
+        {
+          "id": "phone",
+          "label": "Phone Number",
+          "type": "tel",
+          "placeholder": "(555) 123-4567"
+        },
+        {
+          "id": "event_date",
+          "label": "Preferred Event Date",
+          "type": "date",
+          "required": true
+        }
+      ]
+    },
+    {
+      "title": "Event Details",
+      "step": 2,
+      "fields": [
+        {
+          "id": "event_details_heading",
+          "label": "Tell Us About Your Event",
+          "type": "heading",
+          "hint": "Provide details so we can plan accordingly"
+        },
+        {
+          "id": "event_type",
+          "label": "Event Type",
+          "type": "select",
+          "required": true,
+          "options": ["", "Conference", "Workshop", "Meetup", "Webinar"]
+        },
+        {
+          "id": "event_description",
+          "label": "Brief Description",
+          "type": "textarea",
+          "placeholder": "Summarize the event in a few sentences..."
+        },
+        {
+          "id": "detailed_proposal",
+          "label": "Detailed Proposal",
+          "type": "longtext",
+          "maxLength": 3000,
+          "hint": "Full event proposal with goals, agenda, and expected outcomes"
+        },
+        {
+          "id": "attendance_mode",
+          "label": "Attendance Mode",
+          "type": "radio",
+          "required": true,
+          "options": ["In-person", "Virtual", "Hybrid"]
+        },
+        {
+          "id": "venue_address",
+          "label": "Venue Address",
+          "type": "address",
+          "hint": "Required for in-person events",
+          "visible_when": { "field": "attendance_mode", "equals": "In-person" }
+        },
+        {
+          "id": "dietary_restrictions",
+          "label": "Dietary Restrictions",
+          "type": "checkbox",
+          "options": ["Vegetarian", "Vegan", "Gluten-free", "Halal", "Kosher", "None"],
+          "hint": "Select all that apply for catering",
+          "visible_when": { "field": "attendance_mode", "equals": "In-person" }
+        },
+        {
+          "id": "virtual_platform",
+          "label": "Preferred Virtual Platform",
+          "type": "text",
+          "placeholder": "e.g., Zoom, Teams, Google Meet",
+          "visible_when": { "field": "attendance_mode", "equals": "Virtual" }
+        }
+      ]
+    },
+    {
+      "title": "Budget & Items",
+      "step": 3,
+      "fields": [
+        {
+          "id": "budget_amount",
+          "label": "Estimated Budget",
+          "type": "currency",
+          "required": true,
+          "placeholder": "0.00"
+        },
+        {
+          "id": "attendee_count",
+          "label": "Expected Attendees",
+          "type": "number",
+          "min": 1,
+          "max": 500,
+          "step": 1,
+          "placeholder": "50"
+        },
+        {
+          "id": "expense_items",
+          "label": "Budget Line Items",
+          "type": "repeater",
+          "min_rows": 1,
+          "max_rows": 10,
+          "fields": [
+            { "id": "item_name", "label": "Item", "type": "text", "placeholder": "Venue rental" },
+            { "id": "quantity", "label": "Qty", "type": "number", "min": 1, "max": 999, "step": 1 },
+            { "id": "unit_cost", "label": "Unit Cost", "type": "currency" },
+            { "id": "category", "label": "Category", "type": "select", "options": ["", "Venue", "Catering", "Equipment", "Marketing", "Other"] }
+          ]
+        },
+        {
+          "id": "special_requests",
+          "label": "Special Requests",
+          "type": "list",
+          "hint": "One request per line"
+        }
+      ]
+    },
+    {
+      "title": "Attachments & Approval",
+      "step": 4,
+      "fields": [
+        {
+          "id": "supporting_doc",
+          "label": "Supporting Document",
+          "type": "file",
+          "accept": ".pdf,image/*",
+          "max_size_mb": 10,
+          "hint": "Upload a PDF or image (max 10 MB)"
+        },
+        {
+          "id": "additional_notes",
+          "label": "Additional Notes",
+          "type": "textarea",
+          "placeholder": "Anything else we should know..."
+        },
+        {
+          "id": "applicant_signature",
+          "label": "Applicant Signature",
+          "type": "signature",
+          "required": true
+        }
+      ]
+    }
+  ]
+}

--- a/templates/field-type-demo.py
+++ b/templates/field-type-demo.py
@@ -1,0 +1,252 @@
+"""
+FormForge DOCX Template: Event Registration (Field Type Demo)
+=============================================================
+Demonstrates all 17 field types, wizard mode, and conditional visibility.
+
+Field type value formats:
+  - text/email/tel/date/select/radio/textarea → str
+  - number/currency → str (e.g. "50", "1250.00")
+  - hidden → str (static default_value from schema)
+  - heading → not passed (skipped in collectFormData)
+  - checkbox → comma-separated str
+  - longtext → str with possible newlines
+  - list → newline-separated str
+  - address → JSON string: {"street","city","state","zip"}
+  - file/signature → base64 data URI str or ""
+  - repeater → JSON array string: [{"field":"value"}, ...]
+"""
+
+import io
+import json
+import base64
+from docx.shared import Inches, Pt
+from docx.enum.text import WD_ALIGN_PARAGRAPH
+from docx.enum.table import WD_TABLE_ALIGNMENT
+
+import _base
+
+
+def generate_docx(data):
+    """
+    Generate an Event Registration document from form data.
+
+    Args:
+        data: dict mapping field IDs to their string values.
+
+    Returns:
+        bytes: The generated .docx file as raw bytes.
+    """
+    name = data.get("full_name", "")
+    email = data.get("email", "")
+    event_date = data.get("event_date", "")
+    form_ver = data.get("form_version", "")
+
+    doc = _base.new_doc(
+        "Event Registration",
+        f"{name} — {event_date}",
+    )
+
+    # ── Step 1: Applicant Info ────────────────────────────
+    _base.add_table_section(
+        doc,
+        "Applicant Info",
+        [
+            ("Full Name", name),
+            ("Email", email),
+            ("Phone", data.get("phone", "")),
+            ("Preferred Date", event_date),
+            ("Form Version", form_ver),
+        ],
+    )
+
+    # ── Step 2: Event Details ─────────────────────────────
+    event_type = data.get("event_type", "")
+    attendance = data.get("attendance_mode", "")
+
+    _base.add_table_section(
+        doc,
+        "Event Details",
+        [
+            ("Event Type", event_type),
+            ("Attendance Mode", attendance),
+        ],
+    )
+
+    # textarea — brief description
+    description = data.get("event_description", "")
+    if description and description.strip():
+        doc.add_heading("Brief Description", level=2)
+        p = doc.add_paragraph()
+        r = p.add_run(description)
+        r.font.size = Pt(10)
+        doc.add_paragraph("")
+
+    # longtext — detailed proposal
+    proposal = data.get("detailed_proposal", "")
+    if proposal and proposal.strip():
+        _base.add_longtext(doc, "Detailed Proposal", proposal)
+
+    # address (conditional — in-person only)
+    raw_addr = data.get("venue_address", "{}")
+    try:
+        addr = json.loads(raw_addr)
+    except (json.JSONDecodeError, TypeError):
+        addr = {}
+
+    if addr.get("street"):
+        doc.add_heading("Venue Address", level=2)
+        p = doc.add_paragraph()
+        lines = [
+            addr.get("street", ""),
+            f"{addr.get('city', '')}, {addr.get('state', '')} {addr.get('zip', '')}".strip(),
+        ]
+        for line in lines:
+            if line.strip() and line.strip() != ",":
+                r = p.add_run(line.strip() + "\n")
+                r.font.size = Pt(10)
+        doc.add_paragraph("")
+
+    # checkbox (conditional — in-person dietary restrictions)
+    dietary = data.get("dietary_restrictions", "")
+    if dietary and dietary.strip():
+        doc.add_heading("Dietary Restrictions", level=2)
+        for item in dietary.split(","):
+            item = item.strip()
+            if item:
+                p = doc.add_paragraph(style="List Bullet")
+                r = p.add_run(item)
+                r.font.size = Pt(10)
+        doc.add_paragraph("")
+
+    # text (conditional — virtual platform)
+    virtual_platform = data.get("virtual_platform", "")
+    if virtual_platform and virtual_platform.strip():
+        doc.add_heading("Virtual Platform", level=2)
+        p = doc.add_paragraph()
+        r = p.add_run(virtual_platform)
+        r.font.size = Pt(10)
+        doc.add_paragraph("")
+
+    # ── Step 3: Budget & Items ────────────────────────────
+    budget = data.get("budget_amount", "0")
+    try:
+        budget_fmt = f"${float(budget):,.2f}"
+    except (ValueError, TypeError):
+        budget_fmt = f"${budget}"
+
+    attendees = data.get("attendee_count", "")
+
+    _base.add_table_section(
+        doc,
+        "Budget & Logistics",
+        [
+            ("Estimated Budget", budget_fmt),
+            ("Expected Attendees", attendees),
+        ],
+    )
+
+    # repeater — expense line items
+    doc.add_heading("Budget Line Items", level=1)
+    raw_items = data.get("expense_items", "[]")
+    try:
+        items = json.loads(raw_items)
+    except (json.JSONDecodeError, TypeError):
+        items = []
+
+    if items:
+        table = doc.add_table(rows=1, cols=4)
+        table.alignment = WD_TABLE_ALIGNMENT.CENTER
+        table.style = "Light Grid Accent 1"
+        for i, header in enumerate(["Item", "Qty", "Unit Cost", "Category"]):
+            cell_p = table.rows[0].cells[i].paragraphs[0]
+            r = cell_p.add_run(header)
+            r.bold = True
+            r.font.size = Pt(10)
+        for item in items:
+            row = table.add_row()
+            row.cells[0].text = item.get("item_name", "")
+            row.cells[1].text = item.get("quantity", "")
+            cost = item.get("unit_cost", "0")
+            try:
+                row.cells[2].text = f"${float(cost):,.2f}"
+            except (ValueError, TypeError):
+                row.cells[2].text = str(cost)
+            row.cells[3].text = item.get("category", "")
+    else:
+        p = doc.add_paragraph()
+        r = p.add_run("No line items provided.")
+        r.italic = True
+        r.font.color.rgb = _base.COLOR_MUTED
+
+    doc.add_paragraph("")
+
+    # list — special requests
+    special = data.get("special_requests", "")
+    if special and special.strip():
+        _base.add_bullet_list(doc, "Special Requests", special)
+
+    # ── Step 4: Attachments & Approval ────────────────────
+
+    # file — supporting document
+    doc.add_heading("Supporting Document", level=1)
+    doc_b64 = data.get("supporting_doc", "")
+    if doc_b64 and "," in doc_b64:
+        try:
+            img_data = doc_b64.split(",")[1]
+            img_bytes = base64.b64decode(img_data)
+            doc.add_picture(io.BytesIO(img_bytes), width=Inches(3))
+        except Exception:
+            p = doc.add_paragraph()
+            r = p.add_run("[Document could not be embedded]")
+            r.italic = True
+            r.font.color.rgb = _base.COLOR_MUTED
+    else:
+        p = doc.add_paragraph()
+        r = p.add_run("No document uploaded.")
+        r.italic = True
+        r.font.color.rgb = _base.COLOR_MUTED
+
+    doc.add_paragraph("")
+
+    # textarea — additional notes
+    notes = data.get("additional_notes", "")
+    if notes and notes.strip():
+        doc.add_heading("Additional Notes", level=1)
+        p = doc.add_paragraph()
+        r = p.add_run(notes)
+        r.font.size = Pt(10)
+        doc.add_paragraph("")
+
+    # signature — applicant signature
+    doc.add_heading("Applicant Signature", level=1)
+    sig_b64 = data.get("applicant_signature", "")
+    if sig_b64 and "," in sig_b64:
+        try:
+            sig_data = sig_b64.split(",")[1]
+            sig_bytes = base64.b64decode(sig_data)
+            doc.add_picture(io.BytesIO(sig_bytes), width=Inches(2.5))
+        except Exception:
+            p = doc.add_paragraph()
+            r = p.add_run("_" * 40)
+    else:
+        p = doc.add_paragraph()
+        r = p.add_run("_" * 40)
+    lp = doc.add_paragraph()
+    lr = lp.add_run("Applicant Signature")
+    lr.font.size = Pt(9)
+    lr.font.color.rgb = _base.COLOR_MUTED
+
+    doc.add_paragraph("")
+
+    # ── Footer ────────────────────────────────────────────
+    fp = doc.add_paragraph()
+    fp.alignment = WD_ALIGN_PARAGRAPH.CENTER
+    fr = fp.add_run(
+        "This document was auto-generated by FormForge. "
+        "Please review all information for accuracy."
+    )
+    fr.font.size = Pt(8)
+    fr.font.color.rgb = _base.COLOR_MUTED
+    fr.italic = True
+
+    return _base.finalize(doc)

--- a/tests/fixtures/field-type-demo_sample.json
+++ b/tests/fixtures/field-type-demo_sample.json
@@ -1,0 +1,21 @@
+{
+  "form_version": "2.0",
+  "full_name": "Jane Doe",
+  "email": "jane@example.com",
+  "phone": "(555) 123-4567",
+  "event_date": "2026-06-15",
+  "event_type": "Conference",
+  "event_description": "Annual technology conference bringing together industry leaders to discuss emerging trends in AI and cloud computing.",
+  "detailed_proposal": "This conference will span two days and feature keynote speakers, panel discussions, and hands-on workshops.\n\nDay 1 focuses on AI/ML advancements, with sessions on large language models, computer vision, and responsible AI practices.\n\nDay 2 covers cloud infrastructure, DevOps best practices, and security in distributed systems.",
+  "attendance_mode": "In-person",
+  "venue_address": "{\"street\":\"100 Convention Center Dr\",\"city\":\"Austin\",\"state\":\"TX\",\"zip\":\"78701\"}",
+  "dietary_restrictions": "Vegetarian,Gluten-free",
+  "virtual_platform": "",
+  "budget_amount": "25000.00",
+  "attendee_count": "150",
+  "expense_items": "[{\"item_name\":\"Venue rental\",\"quantity\":\"1\",\"unit_cost\":\"10000.00\",\"category\":\"Venue\"},{\"item_name\":\"Catering per person\",\"quantity\":\"150\",\"unit_cost\":\"45.00\",\"category\":\"Catering\"},{\"item_name\":\"AV equipment\",\"quantity\":\"1\",\"unit_cost\":\"3000.00\",\"category\":\"Equipment\"},{\"item_name\":\"Printed programs\",\"quantity\":\"200\",\"unit_cost\":\"5.00\",\"category\":\"Marketing\"}]",
+  "special_requests": "Wheelchair-accessible venue\nLive captioning for keynotes\nRecording permission for all sessions",
+  "supporting_doc": "",
+  "additional_notes": "Please ensure the venue has adequate parking for 100+ vehicles. We will also need a dedicated registration desk area near the main entrance.",
+  "applicant_signature": ""
+}

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -49,3 +49,19 @@ def test_expense_report_with_empty_data():
     result = mod.generate_docx({})
     assert isinstance(result, bytes)
     assert result[:2] == b"PK"
+
+
+def test_field_type_demo_generates_valid_docx():
+    data = json.loads((FIXTURES / "field-type-demo_sample.json").read_text())
+    mod = load_template("field-type-demo")
+    result = mod.generate_docx(data)
+    assert isinstance(result, bytes)
+    assert len(result) > 0
+    assert result[:2] == b"PK"
+
+
+def test_field_type_demo_with_empty_data():
+    mod = load_template("field-type-demo")
+    result = mod.generate_docx({})
+    assert isinstance(result, bytes)
+    assert result[:2] == b"PK"


### PR DESCRIPTION
## Summary
- New `schemas/field-type-demo.json` — "Event Registration" 4-step wizard form exercising all 17 field types and 3 `visible_when` conditionals
- New `templates/field-type-demo.py` — template handling all field types (address, repeater, file, signature as JSON/base64)
- New `tests/fixtures/field-type-demo_sample.json` — comprehensive sample data
- 2 new template tests added (46 total, all passing)

### Features demonstrated
| Feature | Details |
|---------|---------|
| **Wizard mode** | 4 steps with `"wizard": true` and `"step"` on each section |
| **visible_when** | 3 conditionals: venue_address + dietary (In-person), virtual_platform (Virtual) |
| **All 17 field types** | text, email, tel, date, textarea, longtext, select, radio, checkbox, list, number, currency, heading, hidden, address, file, signature, repeater |

Closes #19

## Test plan
- [x] `pytest tests/ -v` — 46 tests pass
- [x] Schema validates against `_schema.spec.json`
- [x] Template generates valid DOCX with sample data
- [x] Template generates valid DOCX with empty data
- [ ] Load in web UI — verify wizard navigation between 4 steps
- [ ] Verify conditional fields show/hide when toggling attendance mode
- [ ] Export DOCX with all fields populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)