### PR TITLE
Add ruff linting, dependency pins, and clean up redundant CI steps

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,22 +16,18 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install dependencies
-        run: pip install python-docx jsonschema pytest
+      - name: Cache pip packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements-dev.txt') }}
+          restore-keys: ${{ runner.os }}-pip-
 
-      - name: Validate schemas against spec
-        run: |
-          python -c "
-          import json, jsonschema
-          from pathlib import Path
-          spec = json.loads(Path('schemas/_schema.spec.json').read_text())
-          for f in sorted(Path('schemas').glob('*.json')):
-              if f.name.startswith('_'): continue
-              schema = json.loads(f.read_text())
-              jsonschema.validate(schema, spec)
-              print(f'  ✓ {f.name}')
-          print('All schemas valid.')
-          "
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt
+
+      - name: Lint
+        run: ruff check templates/ tests/
 
       - name: Run tests
         run: PYTHONPATH=. pytest tests/ -v

--- a/docs/DEVLOG.md
+++ b/docs/DEVLOG.md
@@ -14,6 +14,19 @@
 
 ## Log
 
+### 2026-03-04 — CI Improvements: Ruff Linting, Dependency Pins, Cleanup (#41)
+**Issues:** #41
+
+- **Added `ruff check` lint step** to CI workflow — catches lint issues before merge.
+- **Created `requirements-dev.txt`** with version-bounded dependencies: `python-docx>=1.1,<2`, `jsonschema>=4.23,<5`, `pytest>=8,<9`, `ruff>=0.4,<1`. CI now installs from this file.
+- **Removed redundant inline schema validation** step from CI — this duplicated `test_schemas.py::test_validate_all_schemas` with worse error reporting.
+- **Added pip caching** via `actions/cache@v4` keyed on `requirements-dev.txt` hash.
+
+**Decisions:**
+- Used version ranges (not exact pins) to allow patch updates while preventing breaking major/minor changes.
+
+---
+
 ### 2026-03-04 — Extract Duplicated Template Patterns into _base.py (#39)
 **Issues:** #39
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+python-docx>=1.1,<2
+jsonschema>=4.23,<5
+pytest>=8,<9
+ruff>=0.4,<1


### PR DESCRIPTION
## Summary
- **New `requirements-dev.txt`** with version-bounded deps: `python-docx>=1.1,<2`, `jsonschema>=4.23,<5`, `pytest>=8,<9`, `ruff>=0.4,<1`
- **Ruff lint step** added to CI — runs `ruff check templates/ tests/`
- **Pip caching** via `actions/cache@v4` keyed on `requirements-dev.txt` hash
- **Removed redundant inline schema validation** step (duplicated `test_schemas.py::test_validate_all_schemas`)
- CI now installs from `requirements-dev.txt` instead of bare `pip install`

Closes #41

## Test plan
- [x] `ruff check templates/ tests/` passes locally
- [x] All 59 tests pass
- [ ] CI workflow runs successfully on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)