### PR TITLE
Refactor: DocTheme + cached DOCX template + manual table styling

### DIFF
--- a/docs/DEVLOG.md
+++ b/docs/DEVLOG.md
@@ -14,6 +14,40 @@
 
 ## Log
 
+### 2026-03-10 — Implement DocTheme + cached template + manual table styling (#53)
+**Issues:** #53
+
+Replaced the piecemeal styling system (Palette + font constants + per-run overrides + built-in Word table styles) with a unified `DocTheme` system:
+
+- **`DocTheme` frozen dataclass** with 21 fields: 5 colors, 3 fonts, 8 sizes, 4 page margins. Replaces `Palette` (5 colors only) + `FONT_BODY/HEADING/CAPTION` constants + hardcoded sizes.
+- **3 built-in themes:** `THEME_CLASSIC`, `THEME_MODERN`, `THEME_MINIMAL` — drop-in replacements for the old `PALETTE_*` constants.
+- **Programmatic DOCX template** built once per theme at first use, cached as bytes. `_build_template()` creates a Document, strips all table styles except Normal Table, pre-configures 6 paragraph styles (Title, Heading 1, Heading 2, Subtitle, List Bullet, Normal) with theme colors/fonts/sizes, sets page margins, clears body content, and serializes to bytes. `new_doc()` clones from cache via `Document(io.BytesIO(cached_bytes))`.
+- **Manual table XML formatting** via `_set_table_borders()` and `_shade_cells()` helpers — bypasses python-docx's buggy table style API. Key-value tables are borderless; repeater tables get grid borders with shaded headers.
+- **Updated all templates** (`onboarding.py`, `expense-report.py`, `field-type-demo.py`) from `set_palette()`/`PALETTE_*` to `set_theme()`/`THEME_*`.
+- **Rewrote index.html demo template** from ~120 self-contained lines to ~55 lines using stencils helpers.
+- **80 tests** (up from 70): new tests for template builder (valid bytes, style stripping, style configuration, margins, cache), table XML assertions (borderless, grid, header shading), and theme system.
+- **Updated `TEMPLATE_GUIDE.md`** — replaced "Color palettes" with "Document themes", updated `new_doc` signature, table descriptions, and examples.
+
+**Decisions:**
+- Template cache keyed by frozen DocTheme instance (hashable because all fields are hashable) — different themes get different cached templates.
+- Stripping table styles at build time (not runtime) eliminates Word's theme engine auto-applying accent colors from the ~100 embedded table style definitions in python-docx's default template.
+- Title rendered as `add_heading(level=0)` using the pre-configured Title style, not manual run formatting — style inheritance means `run.font.color.rgb` returns `None` (tests check style, not run).
+
+---
+
+### 2026-03-10 — Plan: DocTheme + cached template + manual table styling (#53)
+**Issues:** #53
+
+Investigated why DOCX tables render with Word's "Light Grid Accent 1" style despite explicit style assignments. Root cause: `python-docx`'s default `Document()` template embeds ~100 table style definitions in `styles.xml` that Word's theme engine resolves with accent colors.
+
+Broader problem: formatting is scattered — colors in Palette, fonts as module constants, sizes hardcoded per-function, heading styles overridden per-run, page layout never set. Not extendable.
+
+**Decision:** Replace `Palette` + font constants + per-run overrides with a unified `DocTheme` dataclass (colors, fonts, sizes, page layout). Build a fully-styled DOCX template programmatically at import time, cache as bytes, clone in `new_doc()`. Table formatting via direct XML helpers (python-docx table style API has known bugs). 4 phases: core infrastructure, stencils refactor, consumer updates (templates + index.html demo), tests & docs.
+
+Abandoned prototype branch `feature/manual-table-styling`.
+
+---
+
 ### 2026-03-10 — Named Color Palettes for stencils.py (#48–#51)
 **Issues:** #48, #49, #50, #51
 

--- a/docs/TEMPLATE_GUIDE.md
+++ b/docs/TEMPLATE_GUIDE.md
@@ -42,18 +42,19 @@ import stencils
 
 This works identically in Pyodide and in standard Python (for local testing).
 
-### `stencils.new_doc(title_text, subtitle_text="", font_name="Calibri", font_size=11, palette=None)`
+### `stencils.new_doc(title_text, subtitle_text="", font_name=None, font_size=None, theme=None)`
 
-Creates a styled `Document` with a centered title and optional subtitle. Sets the Normal style font. Returns the `Document` instance.
+Creates a styled `Document` cloned from a pre-built template. The template has all heading styles, page margins, and base font configured from the active (or given) theme. Returns the `Document` instance.
 
 ```python
 doc = stencils.new_doc("Employee Onboarding Document", f"Prepared for {first} {last}")
 ```
 
-- Title is colored with the active palette's `title` role, centered.
-- Subtitle (if provided) is colored with the `subtitle` role, centered, 12pt.
+- Title uses the pre-configured "Title" style (heading font, title color, centered).
+- Subtitle (if provided) uses the "Subtitle" style (caption font, subtitle color, centered).
 - An empty paragraph spacer follows each.
-- Pass `palette=` to override colors for this document only (see [Color palettes](#color-palettes)).
+- Pass `font_name` / `font_size` to override the base body font for this document.
+- Pass `theme=` to use a different theme for this document (see [Document themes](#document-themes)).
 
 ### `stencils.table_section(doc, heading, rows)`
 
@@ -69,8 +70,8 @@ stencils.table_section(doc, "Personal Information", [
 
 - `rows` is a list of `(label, value)` tuples.
 - Empty/falsy values display as `—` (em dash).
-- Table style: `Light Grid Accent 1`, centered.
-- Both columns use 10pt font; label is bold.
+- Borderless table, centered. Labels use the heading font (semibold).
+- Both columns use the theme's `size_table` (default 10pt).
 
 ### `stencils.longtext(doc, heading, text)`
 
@@ -109,75 +110,83 @@ Serializes the `Document` to bytes and returns them. Always call this as the las
 return stencils.finalize(doc)
 ```
 
-### Color palettes
+### Document themes
 
-Stencils provides a palette system with 3 built-in palettes and support for custom palettes. Each palette defines 5 semantic color roles:
+Stencils uses a `DocTheme` system that bundles colors, fonts, sizes, and page layout into a single frozen dataclass. A pre-built DOCX template is generated from the theme at import time and cached — `new_doc()` clones from it so heading styles, margins, and base fonts are automatic.
 
-| Role | Semantic meaning |
-|---|---|
-| `title` | Main heading text color |
-| `subtitle` | Subtitle text color |
-| `muted` | Empty-state / placeholder text color |
-| `footer` | Footer text color |
-| `accent` | Reserved for heavy emphasis / future use |
+#### Theme fields
 
-#### Built-in palettes
+| Category | Fields | Defaults |
+|---|---|---|
+| **Colors** | `title`, `subtitle`, `muted`, `footer`, `accent` | Varies by theme |
+| **Fonts** | `font_body`, `font_heading`, `font_caption` | Segoe UI / Semibold / Semilight |
+| **Sizes (pt)** | `size_body`, `size_title`, `size_heading1`, `size_heading2`, `size_subtitle`, `size_table`, `size_caption`, `size_footer` | 11, 26, 16, 13, 12, 10, 9, 8 |
+| **Margins (in)** | `margin_top`, `margin_bottom`, `margin_left`, `margin_right` | 1.0 each |
 
-| Palette | Style | Title | Subtitle | Muted | Footer | Accent |
-|---|---|---|---|---|---|---|
-| `PALETTE_CLASSIC` | Bold navy/blue (default) | `#333366` | `#666699` | `#999999` | `#AAAAAA` | `#1A1A3E` |
-| `PALETTE_MINIMAL` | Near-monochrome, extremely restrained | `#1A1A1A` | `#555555` | `#AAAAAA` | `#CCCCCC` | `#000000` |
-| `PALETTE_MODERN` | Contemporary teal/slate | `#1B5E6E` | `#4A8FA3` | `#8FA9B2` | `#B0C4CB` | `#0D3D4A` |
+#### Built-in themes
 
-#### Switching palettes with `set_palette()`
+| Theme | Style | Title | Subtitle | Accent |
+|---|---|---|---|---|
+| `THEME_CLASSIC` | Bold navy/blue | `#333366` | `#666699` | `#1A1A3E` |
+| `THEME_MINIMAL` | Near-monochrome | `#1A1A1A` | `#555555` | `#000000` |
+| `THEME_MODERN` | Contemporary teal/slate (default) | `#1B5E6E` | `#4A8FA3` | `#0D3D4A` |
 
-Call `set_palette()` at the top of your `generate_docx()` to change colors for all subsequent stencils calls:
+#### Switching themes with `set_theme()`
+
+Call `set_theme()` at the top of your `generate_docx()` to configure all document styling:
 
 ```python
 import stencils
 
 def generate_docx(data):
-    stencils.set_palette(stencils.PALETTE_MODERN)
+    stencils.set_theme(stencils.THEME_MODERN)
     doc = stencils.new_doc("My Document", "Subtitle")
     stencils.table_section(doc, "Info", [("Name", data.get("name", ""))])
     stencils.footer(doc)
     return stencils.finalize(doc)
 ```
 
-#### Per-document override with `new_doc(palette=)`
+#### Per-document override with `new_doc(theme=)`
 
-For a one-off palette on just the title/subtitle without changing the module-level palette:
+For a one-off theme on a single document without changing the module-level theme:
 
 ```python
-doc = stencils.new_doc("Title", "Subtitle", palette=stencils.PALETTE_MINIMAL)
+doc = stencils.new_doc("Title", "Subtitle", theme=stencils.THEME_MINIMAL)
 ```
 
-This does **not** affect `footer()`, `longtext()`, or other helpers — they always use the active module-level palette set by `set_palette()`.
+The active theme (set by `set_theme()`) is still used by helpers like `footer()` and `longtext()` within that document.
 
-#### Custom palettes
+#### Custom themes
 
-Define your own palette with any `RGBColor` values:
+Define your own theme with all required fields:
 
 ```python
 from docx.shared import RGBColor
 import stencils
 
-custom = stencils.Palette(
+custom = stencils.DocTheme(
     title=RGBColor(0x8B, 0x00, 0x00),
     subtitle=RGBColor(0xCD, 0x57, 0x00),
     muted=RGBColor(0xAA, 0xAA, 0xAA),
     footer=RGBColor(0xCC, 0xCC, 0xCC),
     accent=RGBColor(0x5C, 0x00, 0x00),
+    font_body="Segoe UI",
+    font_heading="Segoe UI Semibold",
+    font_caption="Segoe UI Semilight",
+    size_body=11, size_title=26, size_heading1=16, size_heading2=13,
+    size_subtitle=12, size_table=10, size_caption=9, size_footer=8,
+    margin_top=1.0, margin_bottom=1.0, margin_left=1.0, margin_right=1.0,
 )
-stencils.set_palette(custom)
+stencils.set_theme(custom)
 ```
 
-#### Accessing colors directly
+#### Accessing theme values directly
 
-To use a palette's color in custom formatting:
+To use a theme's color or font in custom formatting:
 
 ```python
-run.font.color.rgb = stencils.PALETTE_CLASSIC.muted
+run.font.color.rgb = stencils.THEME_CLASSIC.muted
+run.font.name = stencils.THEME_CLASSIC.font_heading
 ```
 
 ## Understanding the Data Dictionary
@@ -390,7 +399,7 @@ fp = doc.add_paragraph()
 fp.alignment = WD_ALIGN_PARAGRAPH.CENTER
 fr = fp.add_run("Auto-generated by FormForge. Review all information for accuracy.")
 fr.font.size = Pt(8)
-fr.font.color.rgb = stencils.PALETTE_CLASSIC.footer
+fr.font.color.rgb = stencils.THEME_CLASSIC.footer
 fr.italic = True
 ```
 
@@ -406,9 +415,25 @@ doc.add_page_break()
 from docx.enum.table import WD_TABLE_ALIGNMENT
 from docx.shared import Pt
 
+from docx.oxml.ns import nsdecls
+from docx.oxml import parse_xml
+
 table = doc.add_table(rows=0, cols=2)
-table.style = "Light Grid Accent 1"
 table.alignment = WD_TABLE_ALIGNMENT.CENTER
+
+# Remove borders for a clean key-value look
+tblPr = table._tbl.tblPr
+borders = parse_xml(
+    f'<w:tblBorders {nsdecls("w")}>'
+    '<w:top w:val="none" w:sz="0" w:space="0" w:color="auto"/>'
+    '<w:bottom w:val="none" w:sz="0" w:space="0" w:color="auto"/>'
+    '<w:left w:val="none" w:sz="0" w:space="0" w:color="auto"/>'
+    '<w:right w:val="none" w:sz="0" w:space="0" w:color="auto"/>'
+    '<w:insideH w:val="none" w:sz="0" w:space="0" w:color="auto"/>'
+    '<w:insideV w:val="none" w:sz="0" w:space="0" w:color="auto"/>'
+    '</w:tblBorders>'
+)
+tblPr.append(borders)
 
 for label, value in [("Name", data.get("name", "")), ("Date", data.get("date", ""))]:
     row = table.add_row()

--- a/index.html
+++ b/index.html
@@ -3020,124 +3020,58 @@ const DEMO_SCHEMA = {
 };
 
 const DEMO_TEMPLATE = `
-import io
-from docx import Document
-from docx.shared import Inches, Pt, RGBColor
-from docx.enum.text import WD_ALIGN_PARAGRAPH
-from docx.enum.table import WD_TABLE_ALIGNMENT
+import stencils
 
 def generate_docx(data):
-    doc = Document()
-    style = doc.styles['Normal']
-    style.font.name = 'Calibri'
-    style.font.size = Pt(11)
+    stencils.set_theme(stencils.THEME_CLASSIC)
 
-    title = doc.add_heading('Employee Onboarding Document', level=0)
-    title.alignment = WD_ALIGN_PARAGRAPH.CENTER
-    for run in title.runs:
-        run.font.color.rgb = RGBColor(0x33, 0x33, 0x66)
+    first = data.get('first_name', '')
+    last = data.get('last_name', '')
+    start = data.get('start_date', 'TBD')
 
-    doc.add_paragraph('')
-    p = doc.add_paragraph()
-    p.alignment = WD_ALIGN_PARAGRAPH.CENTER
-    run = p.add_run(f"Prepared for {data.get('first_name', '')} {data.get('last_name', '')} — Start Date: {data.get('start_date', 'TBD')}")
-    run.font.size = Pt(12)
-    run.font.color.rgb = RGBColor(0x66, 0x66, 0x99)
-    doc.add_paragraph('')
+    doc = stencils.new_doc(
+        'Employee Onboarding Document',
+        f'Prepared for {first} {last} — Start Date: {start}',
+    )
 
-    def add_table_section(title_text, fields):
-        doc.add_heading(title_text, level=1)
-        table = doc.add_table(rows=0, cols=2)
-        table.alignment = WD_TABLE_ALIGNMENT.CENTER
-        table.style = 'Light Grid Accent 1'
-        for label, value in fields:
-            row = table.add_row()
-            lp = row.cells[0].paragraphs[0]
-            lr = lp.add_run(label)
-            lr.bold = True; lr.font.size = Pt(10)
-            vp = row.cells[1].paragraphs[0]
-            vr = vp.add_run(str(value) if value else '\\u2014')
-            vr.font.size = Pt(10)
-        doc.add_paragraph('')
-
-    def add_longtext(title_text, text):
-        doc.add_heading(title_text, level=2)
-        if text and text.strip():
-            for para in text.strip().split('\\n'):
-                if para.strip():
-                    p = doc.add_paragraph()
-                    r = p.add_run(para.strip())
-                    r.font.size = Pt(10)
-        else:
-            p = doc.add_paragraph()
-            r = p.add_run('No information provided.')
-            r.font.size = Pt(10); r.italic = True
-            r.font.color.rgb = RGBColor(0x99, 0x99, 0x99)
-        doc.add_paragraph('')
-
-    def add_list(title_text, items_str):
-        doc.add_heading(title_text, level=2)
-        if items_str and items_str.strip():
-            for item in [i.strip() for i in items_str.split('\\n') if i.strip()]:
-                p = doc.add_paragraph(style='List Bullet')
-                r = p.add_run(item)
-                r.font.size = Pt(10)
-        else:
-            p = doc.add_paragraph()
-            r = p.add_run('No items listed.')
-            r.font.size = Pt(10); r.italic = True
-            r.font.color.rgb = RGBColor(0x99, 0x99, 0x99)
-        doc.add_paragraph('')
-
-    add_table_section('Personal Information', [
-        ('First Name', data.get('first_name', '')), ('Last Name', data.get('last_name', '')),
-        ('Email', data.get('email', '')), ('Phone', data.get('phone', '')),
-        ('Date of Birth', data.get('date_of_birth', '')), ('Start Date', data.get('start_date', '')),
+    stencils.table_section(doc, 'Personal Information', [
+        ('First Name', data.get('first_name', '')),
+        ('Last Name', data.get('last_name', '')),
+        ('Email', data.get('email', '')),
+        ('Phone', data.get('phone', '')),
+        ('Date of Birth', data.get('date_of_birth', '')),
+        ('Start Date', data.get('start_date', '')),
     ])
-    add_table_section('Role & Department', [
-        ('Department', data.get('department', '')), ('Job Title', data.get('job_title', '')),
-        ('Employment Type', data.get('employment_type', '')), ('Reporting Manager', data.get('manager', '')),
+
+    stencils.table_section(doc, 'Role & Department', [
+        ('Department', data.get('department', '')),
+        ('Job Title', data.get('job_title', '')),
+        ('Employment Type', data.get('employment_type', '')),
+        ('Reporting Manager', data.get('manager', '')),
     ])
-    add_table_section('Equipment & Access', [
+
+    stencils.table_section(doc, 'Equipment & Access', [
         ('Laptop', data.get('laptop_preference', '')),
         ('Additional Equipment', data.get('equipment_needs', '') or 'None'),
         ('Software Access', data.get('software_access', '') or 'None'),
     ])
 
     doc.add_heading('Skills & Experience', level=1)
-    add_longtext('Professional Bio', data.get('bio', ''))
-    add_list('Key Skills', data.get('skills', ''))
-    add_list('Certifications', data.get('certifications', ''))
+    stencils.longtext(doc, 'Professional Bio', data.get('bio', ''))
+    stencils.bullet_list(doc, 'Key Skills', data.get('skills', ''))
+    stencils.bullet_list(doc, 'Certifications', data.get('certifications', ''))
 
-    add_table_section('Additional Information', [
+    stencils.table_section(doc, 'Additional Information', [
         ('Emergency Contact', data.get('emergency_contact', '')),
         ('Emergency Phone', data.get('emergency_phone', '')),
         ('Notes', data.get('notes', '')),
     ])
-    add_list('First 90 Days Goals', data.get('onboarding_goals', ''))
+    stencils.bullet_list(doc, 'First 90 Days Goals', data.get('onboarding_goals', ''))
 
-    doc.add_paragraph('')
-    doc.add_heading('Signatures', level=1)
-    sig = doc.add_table(rows=2, cols=2)
-    sig.alignment = WD_TABLE_ALIGNMENT.CENTER
-    for i, lbl in enumerate(['Employee Signature', 'Date', 'HR Representative', 'Date']):
-        cell = sig.rows[i // 2].cells[i % 2]
-        p = cell.paragraphs[0]
-        p.add_run('\\n\\n')
-        p.add_run('_' * 35 + '\\n')
-        r = p.add_run(lbl)
-        r.font.size = Pt(9); r.font.color.rgb = RGBColor(0x99, 0x99, 0x99)
+    stencils.signatures(doc, ['Employee Signature', 'Date', 'HR Representative', 'Date'])
+    stencils.footer(doc)
 
-    doc.add_paragraph('')
-    fp = doc.add_paragraph()
-    fp.alignment = WD_ALIGN_PARAGRAPH.CENTER
-    fr = fp.add_run('Auto-generated by FormForge.')
-    fr.font.size = Pt(8); fr.font.color.rgb = RGBColor(0xAA, 0xAA, 0xAA); fr.italic = True
-
-    buffer = io.BytesIO()
-    doc.save(buffer)
-    buffer.seek(0)
-    return buffer.getvalue()
+    return stencils.finalize(doc)
 `;
 
 // ============================================================

--- a/templates/expense-report.py
+++ b/templates/expense-report.py
@@ -32,7 +32,7 @@ def generate_docx(data):
     Returns:
         bytes: The generated .docx file as raw bytes.
     """
-    stencils.set_palette(stencils.PALETTE_MODERN)
+    stencils.set_theme(stencils.THEME_MODERN)
 
     name = data.get("employee_name", "")
     dept = data.get("department", "")

--- a/templates/field-type-demo.py
+++ b/templates/field-type-demo.py
@@ -32,7 +32,7 @@ def generate_docx(data):
     Returns:
         bytes: The generated .docx file as raw bytes.
     """
-    stencils.set_palette(stencils.PALETTE_MINIMAL)
+    stencils.set_theme(stencils.THEME_MINIMAL)
 
     name = data.get("full_name", "")
     email = data.get("email", "")

--- a/templates/onboarding.py
+++ b/templates/onboarding.py
@@ -28,7 +28,7 @@ def generate_docx(data):
     Returns:
         bytes: The generated .docx file as raw bytes.
     """
-    stencils.set_palette(stencils.PALETTE_CLASSIC)
+    stencils.set_theme(stencils.THEME_CLASSIC)
 
     first = data.get("first_name", "")
     last = data.get("last_name", "")
@@ -84,7 +84,9 @@ def generate_docx(data):
 
     stencils.longtext(doc, "Professional Bio", data.get("bio", ""))
     stencils.bullet_list(doc, "Key Skills", data.get("skills", ""))
-    stencils.bullet_list(doc, "Certifications & Licenses", data.get("certifications", ""))
+    stencils.bullet_list(
+        doc, "Certifications & Licenses", data.get("certifications", "")
+    )
     stencils.longtext(doc, "Notable Prior Projects", data.get("prior_projects", ""))
 
     # ── Section: Additional Information ────────────────────────

--- a/templates/stencils.py
+++ b/templates/stencils.py
@@ -25,123 +25,361 @@ from docx.shared import Inches, Pt, RGBColor
 from docx.enum.text import WD_ALIGN_PARAGRAPH
 from docx.enum.table import WD_TABLE_ALIGNMENT
 from docx.image.exceptions import UnrecognizedImageError
+from docx.oxml.ns import nsdecls, qn
+from docx.oxml import parse_xml
 
 
-# -- Palette system --
+# ---------------------------------------------------------------------------
+#  Theme system
+# ---------------------------------------------------------------------------
 
-_PALETTE_ROLES = ("title", "subtitle", "muted", "footer", "accent")
+_THEME_FIELDS = (
+    "title",
+    "subtitle",
+    "muted",
+    "footer",
+    "accent",
+    "font_body",
+    "font_heading",
+    "font_caption",
+    "size_body",
+    "size_title",
+    "size_heading1",
+    "size_heading2",
+    "size_subtitle",
+    "size_table",
+    "size_caption",
+    "size_footer",
+    "margin_top",
+    "margin_bottom",
+    "margin_left",
+    "margin_right",
+)
 
 
 @dataclass(frozen=True)
-class Palette:
-    """A set of semantic colors for DOCX document styling.
+class DocTheme:
+    """Complete document theme: colors, fonts, sizes, and page layout.
 
-    Roles:
-        title:    Main heading text color.
-        subtitle: Subtitle text color.
+    Colors:
+        title:    Main heading / Heading 1 text color.
+        subtitle: Subtitle / Heading 2 text color.
         muted:    Empty-state / placeholder text color.
         footer:   Footer text color.
-        accent:   Reserved for heavy emphasis / future use.
+        accent:   Table header background / heavy emphasis.
+
+    Fonts:
+        font_body:    Base body font.
+        font_heading: Heading / label font (semibold weight).
+        font_caption: Small print / caption font (light weight).
+
+    Sizes (points):
+        size_body:     Normal body text.
+        size_title:    Title heading (level 0).
+        size_heading1: Level-1 heading.
+        size_heading2: Level-2 heading.
+        size_subtitle: Subtitle text.
+        size_table:    Table cell / section body text.
+        size_caption:  Signature labels / small text.
+        size_footer:   Footer text.
+
+    Page layout (inches):
+        margin_top, margin_bottom, margin_left, margin_right.
     """
 
+    # Colors
     title: RGBColor
     subtitle: RGBColor
     muted: RGBColor
     footer: RGBColor
     accent: RGBColor
+    # Fonts
+    font_body: str
+    font_heading: str
+    font_caption: str
+    # Sizes (pt)
+    size_body: int
+    size_title: int
+    size_heading1: int
+    size_heading2: int
+    size_subtitle: int
+    size_table: int
+    size_caption: int
+    size_footer: int
+    # Page layout (inches)
+    margin_top: float
+    margin_bottom: float
+    margin_left: float
+    margin_right: float
 
 
-# Built-in palettes
-PALETTE_CLASSIC = Palette(
+# Built-in themes ──────────────────────────────────────────────────────────
+
+THEME_CLASSIC = DocTheme(
     title=RGBColor(0x33, 0x33, 0x66),
     subtitle=RGBColor(0x66, 0x66, 0x99),
     muted=RGBColor(0x99, 0x99, 0x99),
     footer=RGBColor(0xAA, 0xAA, 0xAA),
     accent=RGBColor(0x1A, 0x1A, 0x3E),
+    font_body="Segoe UI",
+    font_heading="Segoe UI Semibold",
+    font_caption="Segoe UI Semilight",
+    size_body=11,
+    size_title=26,
+    size_heading1=16,
+    size_heading2=13,
+    size_subtitle=12,
+    size_table=10,
+    size_caption=9,
+    size_footer=8,
+    margin_top=1.0,
+    margin_bottom=1.0,
+    margin_left=1.0,
+    margin_right=1.0,
 )
 
-PALETTE_MINIMAL = Palette(
+THEME_MINIMAL = DocTheme(
     title=RGBColor(0x1A, 0x1A, 0x1A),
     subtitle=RGBColor(0x55, 0x55, 0x55),
     muted=RGBColor(0xAA, 0xAA, 0xAA),
     footer=RGBColor(0xCC, 0xCC, 0xCC),
     accent=RGBColor(0x00, 0x00, 0x00),
+    font_body="Segoe UI",
+    font_heading="Segoe UI Semibold",
+    font_caption="Segoe UI Semilight",
+    size_body=11,
+    size_title=26,
+    size_heading1=16,
+    size_heading2=13,
+    size_subtitle=12,
+    size_table=10,
+    size_caption=9,
+    size_footer=8,
+    margin_top=1.0,
+    margin_bottom=1.0,
+    margin_left=1.0,
+    margin_right=1.0,
 )
 
-PALETTE_MODERN = Palette(
+THEME_MODERN = DocTheme(
     title=RGBColor(0x1B, 0x5E, 0x6E),
     subtitle=RGBColor(0x4A, 0x8F, 0xA3),
     muted=RGBColor(0x8F, 0xA9, 0xB2),
     footer=RGBColor(0xB0, 0xC4, 0xCB),
     accent=RGBColor(0x0D, 0x3D, 0x4A),
+    font_body="Segoe UI",
+    font_heading="Segoe UI Semibold",
+    font_caption="Segoe UI Semilight",
+    size_body=11,
+    size_title=26,
+    size_heading1=16,
+    size_heading2=13,
+    size_subtitle=12,
+    size_table=10,
+    size_caption=9,
+    size_footer=8,
+    margin_top=1.0,
+    margin_bottom=1.0,
+    margin_left=1.0,
+    margin_right=1.0,
 )
 
-_active_palette = PALETTE_MODERN
-
-# -- Font family (Segoe UI, excluding Light and Black) --
-FONT_BODY = "Segoe UI"
-FONT_HEADING = "Segoe UI Semibold"
-FONT_CAPTION = "Segoe UI Semilight"
+_active_theme = THEME_MODERN
 
 
-def set_palette(palette):
-    """Set the active color palette for all subsequent stencils calls.
+def set_theme(theme):
+    """Set the active document theme for all subsequent stencils calls.
 
     Args:
-        palette: A Palette instance (use a built-in PALETTE_* constant or
-                 construct a custom Palette with all five role fields).
+        theme: A DocTheme instance (use a built-in THEME_* constant or
+               construct a custom DocTheme with all required fields).
 
     Raises:
-        ValueError: If palette is missing any required role field.
+        ValueError: If theme is missing any required field.
     """
-    global _active_palette
+    global _active_theme
 
-    missing = [r for r in _PALETTE_ROLES if not hasattr(palette, r)]
+    missing = [f for f in _THEME_FIELDS if not hasattr(theme, f)]
     if missing:
-        raise ValueError(f"Palette missing required roles: {', '.join(missing)}")
+        raise ValueError(f"Theme missing required fields: {', '.join(missing)}")
 
-    _active_palette = palette
+    _active_theme = theme
 
 
-def new_doc(title_text, subtitle_text="", font_name=None, font_size=11, palette=None):
+# ---------------------------------------------------------------------------
+#  Template builder
+# ---------------------------------------------------------------------------
+
+_template_cache = {}
+
+
+def _build_template(theme):
+    """Build a DOCX template with all Word styles configured from a theme.
+
+    The template has no body content — just style definitions, page layout,
+    and a clean style sheet with no built-in table styles.  ``new_doc()``
+    clones from the cached bytes so every document inherits the correct
+    headings, fonts, and margins automatically.
+    """
+    doc = Document()
+
+    # -- Strip all table styles except Normal Table --------------------
+    ns = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+    styles_el = doc.styles.element
+    for style_el in styles_el.findall(f"{{{ns}}}style"):
+        if style_el.get(f"{{{ns}}}type") == "table" and not style_el.get(
+            f"{{{ns}}}default"
+        ):
+            styles_el.remove(style_el)
+
+    # -- Configure paragraph styles ------------------------------------
+    normal = doc.styles["Normal"]
+    normal.font.name = theme.font_body
+    normal.font.size = Pt(theme.size_body)
+
+    title_style = doc.styles["Title"]
+    title_style.font.name = theme.font_heading
+    title_style.font.size = Pt(theme.size_title)
+    title_style.font.color.rgb = theme.title
+    title_style.paragraph_format.alignment = WD_ALIGN_PARAGRAPH.CENTER
+
+    for level, name, size, color in [
+        (1, "Heading 1", theme.size_heading1, theme.title),
+        (2, "Heading 2", theme.size_heading2, theme.subtitle),
+    ]:
+        h = doc.styles[name]
+        h.font.name = theme.font_heading
+        h.font.size = Pt(size)
+        h.font.color.rgb = color
+
+    try:
+        sub = doc.styles["Subtitle"]
+        sub.font.name = theme.font_caption
+        sub.font.size = Pt(theme.size_subtitle)
+        sub.font.color.rgb = theme.subtitle
+        sub.paragraph_format.alignment = WD_ALIGN_PARAGRAPH.CENTER
+    except KeyError:
+        pass  # Handled per-run in new_doc() as fallback
+
+    try:
+        lb = doc.styles["List Bullet"]
+        lb.font.name = theme.font_body
+        lb.font.size = Pt(theme.size_table)
+    except KeyError:
+        pass
+
+    # -- Page layout ---------------------------------------------------
+    for section in doc.sections:
+        section.top_margin = Inches(theme.margin_top)
+        section.bottom_margin = Inches(theme.margin_bottom)
+        section.left_margin = Inches(theme.margin_left)
+        section.right_margin = Inches(theme.margin_right)
+
+    # -- Clear body content (keep sectPr) ------------------------------
+    body = doc.element.body
+    for p in body.findall(qn("w:p")):
+        body.remove(p)
+
+    # -- Serialize -----------------------------------------------------
+    buf = io.BytesIO()
+    doc.save(buf)
+    buf.seek(0)
+    return buf.getvalue()
+
+
+def _get_template(theme):
+    """Return cached template bytes for a theme, building if needed."""
+    if theme not in _template_cache:
+        _template_cache[theme] = _build_template(theme)
+    return _template_cache[theme]
+
+
+# Pre-build the default theme's template at import time
+_template_cache[_active_theme] = _build_template(_active_theme)
+
+
+# ---------------------------------------------------------------------------
+#  Table formatting helpers
+# ---------------------------------------------------------------------------
+
+
+def _set_table_borders(table, val="single", sz=4, color="BFBFBF"):
+    """Apply uniform borders to every edge of a table (or remove them)."""
+    tbl = table._tbl
+    tblPr = tbl.tblPr if tbl.tblPr is not None else tbl._add_tblPr()
+    existing = tblPr.find(qn("w:tblBorders"))
+    if existing is not None:
+        tblPr.remove(existing)
+    borders = parse_xml(
+        f"<w:tblBorders {nsdecls('w')}>"
+        f'<w:top w:val="{val}" w:sz="{sz}" w:space="0" w:color="{color}"/>'
+        f'<w:left w:val="{val}" w:sz="{sz}" w:space="0" w:color="{color}"/>'
+        f'<w:bottom w:val="{val}" w:sz="{sz}" w:space="0" w:color="{color}"/>'
+        f'<w:right w:val="{val}" w:sz="{sz}" w:space="0" w:color="{color}"/>'
+        f'<w:insideH w:val="{val}" w:sz="{sz}" w:space="0" w:color="{color}"/>'
+        f'<w:insideV w:val="{val}" w:sz="{sz}" w:space="0" w:color="{color}"/>'
+        f"</w:tblBorders>"
+    )
+    tblPr.append(borders)
+
+
+def _shade_cells(row, fill_hex):
+    """Apply background shading to every cell in a table row."""
+    for cell in row.cells:
+        shading = parse_xml(
+            f'<w:shd {nsdecls("w")} w:val="clear" w:color="auto" w:fill="{fill_hex}"/>'
+        )
+        cell._tc.get_or_add_tcPr().append(shading)
+
+
+# ---------------------------------------------------------------------------
+#  Public API
+# ---------------------------------------------------------------------------
+
+
+def new_doc(title_text, subtitle_text="", font_name=None, font_size=None, theme=None):
     """
     Create a styled Document with a centered title and optional subtitle.
+
+    The document is cloned from a pre-built template whose heading styles,
+    page margins, and base font are configured from the active (or given)
+    theme.
 
     Args:
         title_text: Main heading text.
         subtitle_text: Optional subtitle displayed below the title.
-        font_name: Base font for the document (default: FONT_BODY / "Segoe UI").
-        font_size: Base font size in points (default: 11).
-        palette: Optional Palette to use for title/subtitle colors.
-                 If None, uses the current active palette.
+        font_name: Override the base body font (default: theme's font_body).
+        font_size: Override the base font size in points (default: theme's
+                   size_body).
+        theme: Optional DocTheme for this document only.
+               If None, uses the current active theme.
 
     Returns:
         A python-docx Document instance.
     """
-    pal = palette if palette is not None else _active_palette
-    base_font = font_name if font_name is not None else FONT_BODY
-    doc = Document()
+    t = theme if theme is not None else _active_theme
+    doc = Document(io.BytesIO(_get_template(t)))
 
-    style = doc.styles["Normal"]
-    style.font.name = base_font
-    style.font.size = Pt(font_size)
+    if font_name is not None or font_size is not None:
+        style = doc.styles["Normal"]
+        if font_name is not None:
+            style.font.name = font_name
+        if font_size is not None:
+            style.font.size = Pt(font_size)
 
-    title = doc.add_heading(title_text, level=0)
-    title.alignment = WD_ALIGN_PARAGRAPH.CENTER
-    for run in title.runs:
-        run.font.name = FONT_HEADING
-        run.font.color.rgb = pal.title
-
+    doc.add_heading(title_text, level=0)
     doc.add_paragraph("")
 
     if subtitle_text:
-        para = doc.add_paragraph()
-        para.alignment = WD_ALIGN_PARAGRAPH.CENTER
-        run = para.add_run(subtitle_text)
-        run.font.name = FONT_CAPTION
-        run.font.size = Pt(12)
-        run.font.color.rgb = pal.subtitle
-
+        try:
+            doc.add_paragraph(subtitle_text, style="Subtitle")
+        except KeyError:
+            para = doc.add_paragraph()
+            para.alignment = WD_ALIGN_PARAGRAPH.CENTER
+            run = para.add_run(subtitle_text)
+            run.font.name = t.font_caption
+            run.font.size = Pt(t.size_subtitle)
+            run.font.color.rgb = t.subtitle
         doc.add_paragraph("")
 
     return doc
@@ -149,31 +387,33 @@ def new_doc(title_text, subtitle_text="", font_name=None, font_size=11, palette=
 
 def table_section(doc, heading, rows):
     """
-    Add a heading followed by a two-column key/value table.
+    Add a heading followed by a borderless two-column key/value table.
+    Labels in the first column use the heading font (semibold).
 
     Args:
         doc: The Document instance.
         heading: Section heading string.
         rows: List of (label, value) tuples.
     """
+    t = _active_theme
     doc.add_heading(heading, level=1)
 
     table = doc.add_table(rows=0, cols=2)
     table.alignment = WD_TABLE_ALIGNMENT.CENTER
-    table.style = "Light Grid"
+    _set_table_borders(table, val="none", sz=0, color="auto")
 
     for label, value in rows:
         row = table.add_row()
 
         lp = row.cells[0].paragraphs[0]
         lr = lp.add_run(label)
-        lr.font.name = FONT_HEADING
-        lr.font.size = Pt(10)
+        lr.font.name = t.font_heading
+        lr.font.size = Pt(t.size_table)
 
         vp = row.cells[1].paragraphs[0]
         display_value = str(value) if value is not None and value != "" else "\u2014"
         vr = vp.add_run(display_value)
-        vr.font.size = Pt(10)
+        vr.font.size = Pt(t.size_table)
 
     doc.add_paragraph("")
 
@@ -188,6 +428,7 @@ def longtext(doc, heading, text):
         heading: Sub-heading string.
         text: The long-form text content (may contain newlines).
     """
+    t = _active_theme
     doc.add_heading(heading, level=2)
 
     if text and text.strip():
@@ -195,13 +436,13 @@ def longtext(doc, heading, text):
             if paragraph_text.strip():
                 p = doc.add_paragraph()
                 run = p.add_run(paragraph_text.strip())
-                run.font.size = Pt(10)
+                run.font.size = Pt(t.size_table)
     else:
         p = doc.add_paragraph()
         run = p.add_run("No information provided.")
-        run.font.size = Pt(10)
+        run.font.size = Pt(t.size_table)
         run.italic = True
-        run.font.color.rgb = _active_palette.muted
+        run.font.color.rgb = t.muted
 
     doc.add_paragraph("")
 
@@ -216,6 +457,7 @@ def bullet_list(doc, heading, items_str):
         heading: Sub-heading string.
         items_str: Newline-separated string of list items.
     """
+    t = _active_theme
     doc.add_heading(heading, level=2)
 
     if items_str and items_str.strip():
@@ -223,13 +465,13 @@ def bullet_list(doc, heading, items_str):
         for item in items:
             p = doc.add_paragraph(style="List Bullet")
             run = p.add_run(item)
-            run.font.size = Pt(10)
+            run.font.size = Pt(t.size_table)
     else:
         p = doc.add_paragraph()
         run = p.add_run("No items listed.")
-        run.font.size = Pt(10)
+        run.font.size = Pt(t.size_table)
         run.italic = True
-        run.font.color.rgb = _active_palette.muted
+        run.font.color.rgb = t.muted
 
     doc.add_paragraph("")
 
@@ -244,6 +486,7 @@ def signatures(doc, labels):
         labels: List of signature label strings (e.g. ["Employee Signature",
                 "Date", "HR Representative", "Date"]).
     """
+    t = _active_theme
     doc.add_paragraph("")
     doc.add_heading("Signatures", level=1)
 
@@ -258,9 +501,9 @@ def signatures(doc, labels):
         p.add_run("\n\n")
         p.add_run("_" * 35 + "\n")
         run = p.add_run(label)
-        run.font.name = FONT_CAPTION
-        run.font.size = Pt(9)
-        run.font.color.rgb = _active_palette.muted
+        run.font.name = t.font_caption
+        run.font.size = Pt(t.size_caption)
+        run.font.color.rgb = t.muted
 
 
 def footer(doc):
@@ -270,6 +513,7 @@ def footer(doc):
     Args:
         doc: The Document instance.
     """
+    t = _active_theme
     doc.add_paragraph("")
     fp = doc.add_paragraph()
     fp.alignment = WD_ALIGN_PARAGRAPH.CENTER
@@ -277,9 +521,9 @@ def footer(doc):
         "This document was auto-generated by FormForge. "
         "Please review all information for accuracy."
     )
-    fr.font.name = FONT_CAPTION
-    fr.font.size = Pt(8)
-    fr.font.color.rgb = _active_palette.footer
+    fr.font.name = t.font_caption
+    fr.font.size = Pt(t.size_footer)
+    fr.font.color.rgb = t.footer
     fr.italic = True
 
 
@@ -294,6 +538,7 @@ def address(doc, heading, raw_json):
         heading: Sub-heading string.
         raw_json: JSON string with address fields, or "{}".
     """
+    t = _active_theme
     doc.add_heading(heading, level=2)
 
     try:
@@ -305,7 +550,7 @@ def address(doc, heading, raw_json):
     if street:
         p = doc.add_paragraph()
         r = p.add_run(street + "\n")
-        r.font.size = Pt(10)
+        r.font.size = Pt(t.size_table)
 
         # Build city/state/zip line, skipping empty parts
         parts = []
@@ -322,12 +567,12 @@ def address(doc, heading, raw_json):
         city_line = " ".join(parts)
         if city_line:
             r = p.add_run(city_line)
-            r.font.size = Pt(10)
+            r.font.size = Pt(t.size_table)
     else:
         p = doc.add_paragraph()
         r = p.add_run("No address provided.")
         r.italic = True
-        r.font.color.rgb = _active_palette.muted
+        r.font.color.rgb = t.muted
 
     doc.add_paragraph("")
 
@@ -354,7 +599,7 @@ def image(doc, b64_str, width_inches=3.0, placeholder="No image uploaded."):
     p = doc.add_paragraph()
     r = p.add_run(placeholder)
     r.italic = True
-    r.font.color.rgb = _active_palette.muted
+    r.font.color.rgb = _active_theme.muted
 
 
 def signature(doc, b64_str, label, width_inches=2.5):
@@ -367,6 +612,7 @@ def signature(doc, b64_str, label, width_inches=2.5):
         label: Label text below the signature (e.g. "Employee Signature").
         width_inches: Signature image width in inches (default: 2.5).
     """
+    t = _active_theme
     p = doc.add_paragraph()
     if b64_str and "," in b64_str:
         try:
@@ -379,14 +625,14 @@ def signature(doc, b64_str, label, width_inches=2.5):
         p.add_run("_" * 40)
     lp = doc.add_paragraph()
     lr = lp.add_run(label)
-    lr.font.name = FONT_CAPTION
-    lr.font.size = Pt(9)
-    lr.font.color.rgb = _active_palette.muted
+    lr.font.name = t.font_caption
+    lr.font.size = Pt(t.size_caption)
+    lr.font.color.rgb = t.muted
 
 
 def repeater_table(doc, headers, items, field_keys, currency_keys=None):
     """
-    Render a repeater field as a headed table.
+    Render a repeater field as a headed table with a shaded header row.
 
     Args:
         doc: The Document instance.
@@ -401,15 +647,22 @@ def repeater_table(doc, headers, items, field_keys, currency_keys=None):
     else:
         currency_keys = set(currency_keys)
 
+    t = _active_theme
+
     if items:
         table = doc.add_table(rows=1, cols=len(headers))
         table.alignment = WD_TABLE_ALIGNMENT.CENTER
-        table.style = "Table Grid"
-        for i, header in enumerate(headers):
-            cell_p = table.rows[0].cells[i].paragraphs[0]
-            r = cell_p.add_run(header)
-            r.font.name = FONT_HEADING
-            r.font.size = Pt(10)
+        _set_table_borders(table, val="single", sz=4, color=str(t.muted))
+
+        header_row = table.rows[0]
+        _shade_cells(header_row, str(t.accent))
+        for i, header_text in enumerate(headers):
+            cell_p = header_row.cells[i].paragraphs[0]
+            r = cell_p.add_run(header_text)
+            r.font.name = t.font_heading
+            r.font.size = Pt(t.size_table)
+            r.font.color.rgb = RGBColor(0xFF, 0xFF, 0xFF)
+
         for item in items:
             row = table.add_row()
             for col_idx, key in enumerate(field_keys):
@@ -419,12 +672,14 @@ def repeater_table(doc, headers, items, field_keys, currency_keys=None):
                         val = f"${float(val):,.2f}"
                     except (ValueError, TypeError):
                         val = str(val)
-                row.cells[col_idx].text = val
+                cell_p = row.cells[col_idx].paragraphs[0]
+                r = cell_p.add_run(str(val))
+                r.font.size = Pt(t.size_table)
     else:
         p = doc.add_paragraph()
         r = p.add_run("No line items provided.")
         r.italic = True
-        r.font.color.rgb = _active_palette.muted
+        r.font.color.rgb = t.muted
 
     doc.add_paragraph("")
 

--- a/tests/test_stencils.py
+++ b/tests/test_stencils.py
@@ -1,7 +1,13 @@
 """Tests for templates/stencils.py shared utilities."""
 
 import sys
+import zipfile
 from pathlib import Path
+
+import pytest
+from docx.shared import RGBColor, Inches
+from docx.oxml.ns import qn
+from lxml import etree
 
 # Add templates/ to path so `import stencils` works
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "templates"))
@@ -9,10 +15,45 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "templates"))
 import stencils
 
 
+# ---------------------------------------------------------------------------
+#  Helpers
+# ---------------------------------------------------------------------------
+
+WNS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+
+
+def _docx_styles_xml(doc):
+    """Save doc to bytes and return parsed styles.xml root."""
+    import io
+
+    buf = io.BytesIO()
+    doc.save(buf)
+    buf.seek(0)
+    with zipfile.ZipFile(buf) as z:
+        return etree.fromstring(z.read("word/styles.xml"))
+
+
+def _table_border_vals(table):
+    """Return a dict of border edge -> val from the table's XML."""
+    tblPr = table._tbl.tblPr
+    borders = tblPr.find(qn("w:tblBorders")) if tblPr is not None else None
+    if borders is None:
+        return {}
+    result = {}
+    for child in borders:
+        tag = child.tag.split("}")[-1]
+        result[tag] = child.get(qn("w:val"))
+    return result
+
+
+# ---------------------------------------------------------------------------
+#  new_doc
+# ---------------------------------------------------------------------------
+
+
 def test_new_doc_creates_document():
     doc = stencils.new_doc("Test Title")
     assert doc is not None
-    # Verify the title heading exists
     assert len(doc.paragraphs) > 0
 
 
@@ -36,17 +77,222 @@ def test_new_doc_custom_font():
     assert style.font.size.pt == 12
 
 
+# ---------------------------------------------------------------------------
+#  Theme tests (replacing palette tests)
+# ---------------------------------------------------------------------------
+
+
+def test_theme_classic_has_all_fields():
+    t = stencils.THEME_CLASSIC
+    for field in stencils._THEME_FIELDS:
+        assert hasattr(t, field), f"Missing field: {field}"
+
+
+def test_theme_minimal_has_all_fields():
+    t = stencils.THEME_MINIMAL
+    for field in stencils._THEME_FIELDS:
+        assert hasattr(t, field), f"Missing field: {field}"
+
+
+def test_theme_modern_has_all_fields():
+    t = stencils.THEME_MODERN
+    for field in stencils._THEME_FIELDS:
+        assert hasattr(t, field), f"Missing field: {field}"
+
+
+def test_classic_theme_matches_legacy_colors():
+    """THEME_CLASSIC colors must match the original PALETTE_CLASSIC values."""
+    assert stencils.THEME_CLASSIC.title == RGBColor(0x33, 0x33, 0x66)
+    assert stencils.THEME_CLASSIC.subtitle == RGBColor(0x66, 0x66, 0x99)
+    assert stencils.THEME_CLASSIC.muted == RGBColor(0x99, 0x99, 0x99)
+    assert stencils.THEME_CLASSIC.footer == RGBColor(0xAA, 0xAA, 0xAA)
+    assert stencils.THEME_CLASSIC.accent == RGBColor(0x1A, 0x1A, 0x3E)
+
+
+def test_set_theme_switches_title_style_color():
+    try:
+        stencils.set_theme(stencils.THEME_MINIMAL)
+        doc = stencils.new_doc("Test")
+        assert doc.styles["Title"].font.color.rgb == stencils.THEME_MINIMAL.title
+    finally:
+        stencils.set_theme(stencils.THEME_MODERN)
+
+
+def test_set_theme_invalid_raises():
+    with pytest.raises(ValueError, match="missing required fields"):
+        stencils.set_theme(object())
+
+
+def test_set_theme_custom_theme():
+    custom = stencils.DocTheme(
+        title=RGBColor(0xFF, 0x00, 0x00),
+        subtitle=RGBColor(0x00, 0xFF, 0x00),
+        muted=RGBColor(0x00, 0x00, 0xFF),
+        footer=RGBColor(0xAA, 0xBB, 0xCC),
+        accent=RGBColor(0x11, 0x22, 0x33),
+        font_body="Arial",
+        font_heading="Arial Bold",
+        font_caption="Arial Narrow",
+        size_body=12,
+        size_title=28,
+        size_heading1=18,
+        size_heading2=14,
+        size_subtitle=13,
+        size_table=11,
+        size_caption=10,
+        size_footer=9,
+        margin_top=0.5,
+        margin_bottom=0.5,
+        margin_left=0.75,
+        margin_right=0.75,
+    )
+    try:
+        stencils.set_theme(custom)
+        doc = stencils.new_doc("Test")
+        assert doc.styles["Title"].font.color.rgb == RGBColor(0xFF, 0x00, 0x00)
+        assert doc.styles["Normal"].font.name == "Arial"
+    finally:
+        stencils.set_theme(stencils.THEME_MODERN)
+
+
+def test_set_theme_restores_default():
+    stencils.set_theme(stencils.THEME_MINIMAL)
+    stencils.set_theme(stencils.THEME_MODERN)
+    assert stencils._active_theme is stencils.THEME_MODERN
+
+
+def test_new_doc_theme_override():
+    """theme= on new_doc overrides styles without changing active theme."""
+    before = stencils._active_theme
+    doc = stencils.new_doc("Test", theme=stencils.THEME_MINIMAL)
+    assert doc.styles["Title"].font.color.rgb == stencils.THEME_MINIMAL.title
+    assert stencils._active_theme is before
+
+
+def test_new_doc_theme_override_does_not_change_active():
+    before = stencils._active_theme
+    stencils.new_doc("Test", theme=stencils.THEME_CLASSIC)
+    assert stencils._active_theme is before
+
+
+def test_new_doc_subtitle_theme_override():
+    doc = stencils.new_doc("T", "Sub", theme=stencils.THEME_MODERN)
+    assert doc.styles["Subtitle"].font.color.rgb == stencils.THEME_MODERN.subtitle
+
+
+def test_new_doc_no_theme_uses_active():
+    try:
+        stencils.set_theme(stencils.THEME_MINIMAL)
+        doc = stencils.new_doc("Test")
+        assert doc.styles["Title"].font.color.rgb == stencils.THEME_MINIMAL.title
+    finally:
+        stencils.set_theme(stencils.THEME_MODERN)
+
+
+# ---------------------------------------------------------------------------
+#  Template builder
+# ---------------------------------------------------------------------------
+
+
+def test_template_bytes_are_valid_docx():
+    raw = stencils._get_template(stencils.THEME_MODERN)
+    assert isinstance(raw, bytes)
+    assert raw[:2] == b"PK"
+
+
+def test_template_has_only_normal_table_style():
+    doc = stencils.new_doc("Test")
+    sroot = _docx_styles_xml(doc)
+    table_styles = [
+        s
+        for s in sroot.findall(f"{{{WNS}}}style")
+        if s.get(f"{{{WNS}}}type") == "table"
+    ]
+    assert len(table_styles) == 1
+    name_el = table_styles[0].find(f"{{{WNS}}}name")
+    assert name_el.get(f"{{{WNS}}}val") == "Normal Table"
+
+
+def test_template_heading1_style_configured():
+    doc = stencils.new_doc("Test", theme=stencils.THEME_CLASSIC)
+    h1 = doc.styles["Heading 1"]
+    assert h1.font.name == "Segoe UI Semibold"
+    assert h1.font.color.rgb == stencils.THEME_CLASSIC.title
+
+
+def test_template_heading2_style_configured():
+    doc = stencils.new_doc("Test", theme=stencils.THEME_CLASSIC)
+    h2 = doc.styles["Heading 2"]
+    assert h2.font.name == "Segoe UI Semibold"
+    assert h2.font.color.rgb == stencils.THEME_CLASSIC.subtitle
+
+
+def test_template_page_margins():
+    doc = stencils.new_doc("Test")
+    section = doc.sections[0]
+    assert section.top_margin == Inches(1.0)
+    assert section.bottom_margin == Inches(1.0)
+    assert section.left_margin == Inches(1.0)
+    assert section.right_margin == Inches(1.0)
+
+
+def test_template_custom_margins():
+    custom = stencils.DocTheme(
+        title=RGBColor(0, 0, 0),
+        subtitle=RGBColor(0, 0, 0),
+        muted=RGBColor(0, 0, 0),
+        footer=RGBColor(0, 0, 0),
+        accent=RGBColor(0, 0, 0),
+        font_body="Arial",
+        font_heading="Arial",
+        font_caption="Arial",
+        size_body=11,
+        size_title=26,
+        size_heading1=16,
+        size_heading2=13,
+        size_subtitle=12,
+        size_table=10,
+        size_caption=9,
+        size_footer=8,
+        margin_top=0.5,
+        margin_bottom=0.75,
+        margin_left=1.25,
+        margin_right=1.5,
+    )
+    doc = stencils.new_doc("Test", theme=custom)
+    section = doc.sections[0]
+    assert section.top_margin == Inches(0.5)
+    assert section.bottom_margin == Inches(0.75)
+    assert section.left_margin == Inches(1.25)
+    assert section.right_margin == Inches(1.5)
+
+
+def test_set_theme_rebuilds_cache():
+    """Changing theme should produce template with new colors."""
+    try:
+        stencils.set_theme(stencils.THEME_CLASSIC)
+        doc = stencils.new_doc("Test")
+        assert doc.styles["Title"].font.color.rgb == stencils.THEME_CLASSIC.title
+
+        stencils.set_theme(stencils.THEME_MINIMAL)
+        doc = stencils.new_doc("Test")
+        assert doc.styles["Title"].font.color.rgb == stencils.THEME_MINIMAL.title
+    finally:
+        stencils.set_theme(stencils.THEME_MODERN)
+
+
+# ---------------------------------------------------------------------------
+#  Table styling
+# ---------------------------------------------------------------------------
+
+
 def test_table_section():
     doc = stencils.new_doc("Test")
     stencils.table_section(
         doc,
         "Info",
-        [
-            ("Name", "Alice"),
-            ("Role", "Developer"),
-        ],
+        [("Name", "Alice"), ("Role", "Developer")],
     )
-    # Should have at least one table
     assert len(doc.tables) >= 1
     table = doc.tables[0]
     assert len(table.rows) == 2
@@ -56,16 +302,97 @@ def test_table_section():
 
 def test_table_section_empty_value():
     doc = stencils.new_doc("Test")
-    stencils.table_section(
-        doc,
-        "Info",
-        [
-            ("Field", ""),
-        ],
-    )
+    stencils.table_section(doc, "Info", [("Field", "")])
     table = doc.tables[0]
-    # Empty values should show em dash
     assert table.rows[0].cells[1].text == "\u2014"
+
+
+def test_table_section_borders_are_none():
+    doc = stencils.new_doc("Test")
+    stencils.table_section(doc, "Info", [("A", "B")])
+    borders = _table_border_vals(doc.tables[0])
+    for edge in ("top", "left", "bottom", "right", "insideH", "insideV"):
+        assert borders.get(edge) == "none", f"{edge} should be 'none'"
+
+
+def test_table_section_zero_value():
+    doc = stencils.new_doc("Test")
+    stencils.table_section(doc, "Info", [("Count", "0")])
+    table = doc.tables[0]
+    assert table.rows[0].cells[1].text == "0"
+
+
+def test_table_section_numeric_zero():
+    doc = stencils.new_doc("Test")
+    stencils.table_section(doc, "Info", [("Count", 0)])
+    table = doc.tables[0]
+    assert table.rows[0].cells[1].text == "0"
+
+
+def test_repeater_table_with_items():
+    doc = stencils.new_doc("Test")
+    items = [
+        {"desc": "Item A", "amount": "100.50"},
+        {"desc": "Item B", "amount": "200"},
+    ]
+    stencils.repeater_table(
+        doc,
+        headers=["Description", "Amount"],
+        items=items,
+        field_keys=["desc", "amount"],
+        currency_keys=["amount"],
+    )
+    assert len(doc.tables) >= 1
+    table = doc.tables[0]
+    assert len(table.rows) == 3
+    assert table.rows[1].cells[0].text == "Item A"
+    assert table.rows[1].cells[1].text == "$100.50"
+    assert table.rows[2].cells[1].text == "$200.00"
+
+
+def test_repeater_table_empty():
+    doc = stencils.new_doc("Test")
+    stencils.repeater_table(
+        doc,
+        headers=["A", "B"],
+        items=[],
+        field_keys=["a", "b"],
+    )
+    texts = [p.text for p in doc.paragraphs]
+    assert any("No line items provided." in t for t in texts)
+
+
+def test_repeater_table_has_grid_borders():
+    doc = stencils.new_doc("Test")
+    stencils.repeater_table(
+        doc,
+        headers=["A"],
+        items=[{"a": "1"}],
+        field_keys=["a"],
+    )
+    borders = _table_border_vals(doc.tables[0])
+    for edge in ("top", "left", "bottom", "right", "insideH", "insideV"):
+        assert borders.get(edge) == "single", f"{edge} should be 'single'"
+
+
+def test_repeater_table_header_is_shaded():
+    doc = stencils.new_doc("Test")
+    stencils.repeater_table(
+        doc,
+        headers=["A"],
+        items=[{"a": "1"}],
+        field_keys=["a"],
+    )
+    header_cell = doc.tables[0].rows[0].cells[0]
+    tcPr = header_cell._tc.tcPr
+    shd = tcPr.find(qn("w:shd")) if tcPr is not None else None
+    assert shd is not None
+    assert shd.get(qn("w:fill")) == str(stencils.THEME_MODERN.accent)
+
+
+# ---------------------------------------------------------------------------
+#  Other stencil functions
+# ---------------------------------------------------------------------------
 
 
 def test_longtext_with_content():
@@ -102,7 +429,6 @@ def test_bullet_list_empty():
 def test_signatures():
     doc = stencils.new_doc("Test")
     stencils.signatures(doc, ["Employee", "Date", "Manager", "Date"])
-    # Should create a table for signatures
     assert len(doc.tables) >= 1
     sig_table = doc.tables[-1]
     assert len(sig_table.rows) == 2
@@ -121,147 +447,7 @@ def test_finalize_returns_valid_docx():
     result = stencils.finalize(doc)
     assert isinstance(result, bytes)
     assert len(result) > 0
-    # DOCX is a ZIP file — starts with PK
     assert result[:2] == b"PK"
-
-
-# ── Palette tests (#48–#51) ─────────────────────────────────
-
-
-def test_palette_classic_exists():
-    p = stencils.PALETTE_CLASSIC
-    assert p is not None
-    assert hasattr(p, "title")
-    assert hasattr(p, "subtitle")
-    assert hasattr(p, "muted")
-    assert hasattr(p, "footer")
-    assert hasattr(p, "accent")
-
-
-def test_palette_minimal_exists():
-    p = stencils.PALETTE_MINIMAL
-    assert p is not None
-    assert hasattr(p, "title")
-    assert hasattr(p, "subtitle")
-    assert hasattr(p, "muted")
-    assert hasattr(p, "footer")
-    assert hasattr(p, "accent")
-
-
-def test_palette_modern_exists():
-    p = stencils.PALETTE_MODERN
-    assert p is not None
-    assert hasattr(p, "title")
-    assert hasattr(p, "subtitle")
-    assert hasattr(p, "muted")
-    assert hasattr(p, "footer")
-    assert hasattr(p, "accent")
-
-
-def test_classic_palette_matches_legacy_constants():
-    """PALETTE_CLASSIC roles must match the original COLOR_* values."""
-    from docx.shared import RGBColor
-
-    assert stencils.PALETTE_CLASSIC.title == RGBColor(0x33, 0x33, 0x66)
-    assert stencils.PALETTE_CLASSIC.subtitle == RGBColor(0x66, 0x66, 0x99)
-    assert stencils.PALETTE_CLASSIC.muted == RGBColor(0x99, 0x99, 0x99)
-    assert stencils.PALETTE_CLASSIC.footer == RGBColor(0xAA, 0xAA, 0xAA)
-    assert stencils.PALETTE_CLASSIC.accent == RGBColor(0x1A, 0x1A, 0x3E)
-
-
-def test_set_palette_switches_title_color():
-    try:
-        stencils.set_palette(stencils.PALETTE_MINIMAL)
-        doc = stencils.new_doc("Test")
-        title_run = doc.paragraphs[0].runs[0]
-        assert title_run.font.color.rgb == stencils.PALETTE_MINIMAL.title
-    finally:
-        stencils.set_palette(stencils.PALETTE_MODERN)
-
-
-def test_set_palette_invalid_raises():
-    import pytest
-
-    with pytest.raises(ValueError, match="missing required roles"):
-        stencils.set_palette(object())
-
-
-def test_set_palette_custom_palette():
-    from docx.shared import RGBColor
-
-    custom = stencils.Palette(
-        title=RGBColor(0xFF, 0x00, 0x00),
-        subtitle=RGBColor(0x00, 0xFF, 0x00),
-        muted=RGBColor(0x00, 0x00, 0xFF),
-        footer=RGBColor(0xAA, 0xBB, 0xCC),
-        accent=RGBColor(0x11, 0x22, 0x33),
-    )
-    try:
-        stencils.set_palette(custom)
-        doc = stencils.new_doc("Test")
-        title_run = doc.paragraphs[0].runs[0]
-        assert title_run.font.color.rgb == RGBColor(0xFF, 0x00, 0x00)
-    finally:
-        stencils.set_palette(stencils.PALETTE_MODERN)
-
-
-def test_set_palette_restores_default():
-    stencils.set_palette(stencils.PALETTE_MINIMAL)
-    stencils.set_palette(stencils.PALETTE_MODERN)
-    assert stencils._active_palette is stencils.PALETTE_MODERN
-
-
-def test_new_doc_palette_override():
-    """palette= on new_doc overrides title color without changing active palette."""
-    before = stencils._active_palette
-    doc = stencils.new_doc("Test", palette=stencils.PALETTE_MINIMAL)
-    title_run = doc.paragraphs[0].runs[0]
-    assert title_run.font.color.rgb == stencils.PALETTE_MINIMAL.title
-    # Active palette unchanged
-    assert stencils._active_palette is before
-
-
-def test_new_doc_palette_override_does_not_change_active():
-    before = stencils._active_palette
-    stencils.new_doc("Test", palette=stencils.PALETTE_CLASSIC)
-    assert stencils._active_palette is before
-
-
-def test_new_doc_subtitle_palette_override():
-    doc = stencils.new_doc("T", "Sub", palette=stencils.PALETTE_MODERN)
-    # Subtitle is the 3rd paragraph (title, spacer, subtitle)
-    subtitle_para = doc.paragraphs[2]
-    assert subtitle_para.runs[0].font.color.rgb == stencils.PALETTE_MODERN.subtitle
-
-
-def test_new_doc_no_palette_uses_active():
-    try:
-        stencils.set_palette(stencils.PALETTE_MINIMAL)
-        doc = stencils.new_doc("Test")
-        title_run = doc.paragraphs[0].runs[0]
-        assert title_run.font.color.rgb == stencils.PALETTE_MINIMAL.title
-    finally:
-        stencils.set_palette(stencils.PALETTE_MODERN)
-
-
-# ── Tests for table_section zero/falsy value fix ─────────────
-
-
-def test_table_section_zero_value():
-    doc = stencils.new_doc("Test")
-    stencils.table_section(doc, "Info", [("Count", "0")])
-    table = doc.tables[0]
-    assert table.rows[0].cells[1].text == "0"
-
-
-def test_table_section_numeric_zero():
-    doc = stencils.new_doc("Test")
-    stencils.table_section(doc, "Info", [("Count", 0)])
-    table = doc.tables[0]
-    assert table.rows[0].cells[1].text == "0"
-
-
-# ── Tests for footer ─────────────────────────────────────────
 
 
 def test_footer():
@@ -269,9 +455,6 @@ def test_footer():
     stencils.footer(doc)
     texts = [p.text for p in doc.paragraphs]
     assert any("auto-generated by FormForge" in t for t in texts)
-
-
-# ── Tests for address ────────────────────────────────────────
 
 
 def test_address_full():
@@ -283,9 +466,7 @@ def test_address_full():
     )
     stencils.address(doc, "Address", addr)
     texts = [p.text for p in doc.paragraphs]
-    # Street should appear
     assert any("123 Main St" in t for t in texts)
-    # City/state/zip should appear
     assert any("Springfield, IL 62701" in t for t in texts)
 
 
@@ -298,7 +479,6 @@ def test_address_empty_city():
     )
     stencils.address(doc, "Address", addr)
     texts = [p.text for p in doc.paragraphs]
-    # Should NOT produce a leading comma
     for t in texts:
         assert not t.strip().startswith(",")
 
@@ -322,9 +502,6 @@ def test_address_empty_json():
     assert any("No address provided." in t for t in texts)
 
 
-# ── Tests for image ──────────────────────────────────────────
-
-
 def test_image_empty():
     doc = stencils.new_doc("Test")
     stencils.image(doc, "", placeholder="No image.")
@@ -337,9 +514,6 @@ def test_image_invalid_b64():
     stencils.image(doc, "data:image/png;base64,NOT_VALID!!!", placeholder="Failed.")
     texts = [p.text for p in doc.paragraphs]
     assert any("Failed." in t for t in texts)
-
-
-# ── Tests for signature ──────────────────────────────────────
 
 
 def test_signature_empty():
@@ -355,42 +529,4 @@ def test_signature_invalid_b64():
     stencils.signature(doc, "data:image/png;base64,BAD_DATA!!!", "Signer")
     texts = [p.text for p in doc.paragraphs]
     assert any("Signer" in t for t in texts)
-    # Falls back to underline
     assert any("_" * 40 in t for t in texts)
-
-
-# ── Tests for repeater_table ─────────────────────────────────
-
-
-def test_repeater_table_with_items():
-    doc = stencils.new_doc("Test")
-    items = [
-        {"desc": "Item A", "amount": "100.50"},
-        {"desc": "Item B", "amount": "200"},
-    ]
-    stencils.repeater_table(
-        doc,
-        headers=["Description", "Amount"],
-        items=items,
-        field_keys=["desc", "amount"],
-        currency_keys=["amount"],
-    )
-    assert len(doc.tables) >= 1
-    table = doc.tables[0]
-    # Header row + 2 data rows
-    assert len(table.rows) == 3
-    assert table.rows[1].cells[0].text == "Item A"
-    assert table.rows[1].cells[1].text == "$100.50"
-    assert table.rows[2].cells[1].text == "$200.00"
-
-
-def test_repeater_table_empty():
-    doc = stencils.new_doc("Test")
-    stencils.repeater_table(
-        doc,
-        headers=["A", "B"],
-        items=[],
-        field_keys=["a", "b"],
-    )
-    texts = [p.text for p in doc.paragraphs]
-    assert any("No line items provided." in t for t in texts)


### PR DESCRIPTION
## Summary
- Replaced `Palette` + font constants + per-run overrides with unified `DocTheme` frozen dataclass (21 fields: colors, fonts, sizes, page margins)
- Programmatically build a fully-styled DOCX template per theme at first use, cache as bytes, clone in `new_doc()` — eliminates Word's theme engine auto-applying accent colors from python-docx's default template
- Manual XML table formatting via `_set_table_borders()` and `_shade_cells()` helpers — bypasses python-docx's buggy table style API
- Updated all templates, index.html demo, TEMPLATE_GUIDE.md, and tests (80 passing, up from 70)

Closes #53

## Test plan
- [x] All 80 tests pass (`PYTHONPATH=. python -m pytest tests/ -v`)
- [x] Ruff lint and format clean
- [ ] Manual test: generate DOCX from each template (onboarding, expense-report, field-type-demo) and verify tables render without Light Grid styling
- [ ] Manual test: verify demo template in browser produces correct DOCX

🤖 Generated with [Claude Code](https://claude.com/claude-code)