### PR TITLE
fix: miscellaneous cleanup — token masking, listener stacking, schema spec, type hints, docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ FormForge is a **client-side-only** browser application that turns GitHub-hosted
 ## Architecture
 
 - **`index.html`** — The entire frontend: HTML + CSS + JS in one file (~2400 lines). Contains the form builder, GitHub API integration, Pyodide loader, validation, and UI. Do not split this file unless the expansion guide explicitly calls for it.
-- **`schemas/_schema.spec.json`** — JSON Schema (draft 2020-12) that validates all form schemas. Enforces required fields, valid field types (17 enumerated), conditional constraints (e.g., `select` requires `options`, `repeater` requires `fields`), and `additionalProperties: false` at all levels.
+- **`schemas/_schema.spec.json`** — JSON Schema (draft 2020-12) that validates all form schemas. Enforces required fields, valid field types (18 enumerated), conditional constraints (e.g., `select` requires `options`, `repeater` requires `fields`), and `additionalProperties: false` at all levels.
 - **`schemas/*.json`** — Form definitions. Each schema has `title`, `description`, `icon`, `template` (path to .py), and `sections[]` containing `fields[]` with `id`, `label`, `type`, etc.
 - **`templates/stencils.py`** — Shared helper module for all templates. Provides `new_doc()`, `table_section()`, `longtext()`, `bullet_list()`, `signatures()`, `footer()`, `address()`, `image()`, `signature()`, `repeater_table()`, `finalize()`, and a standard color palette. Loaded into Pyodide's virtual filesystem once via `loadBaseModule()` before any template runs.
 - **`templates/*.py`** — Python scripts that export a `generate_docx(data)` function. Called by Pyodide with form data as a dict. Must return DOCX bytes. Uses `python-docx` and `import stencils`.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ form-forge/
 │   ├── DEVLOG.md               ← development journal
 │   ├── SCHEMA_GUIDE.md         ← guide for writing new schemas
 │   ├── TEMPLATE_GUIDE.md       ← guide for writing new templates
-│   └── FIELD_TYPES.md          ← reference for all 17 field types
+│   └── FIELD_TYPES.md          ← reference for all 18 field types
 └── .github/workflows/
     └── validate.yml            ← CI: schema validation + pytest
 ```

--- a/docs/DEVLOG.md
+++ b/docs/DEVLOG.md
@@ -14,6 +14,37 @@
 
 ## Log
 
+### 2026-03-10 — Miscellaneous cleanup (#43 → #61–#66)
+**Issues:** #43, #61, #62, #63, #64, #65, #66
+
+Implemented all 6 sub-tasks of the miscellaneous cleanup:
+
+- **#61 Token masking** — Changed `tokenInput` from `type="text"` to `type="password"` so GitHub tokens are masked while typing.
+- **#62 Event listener stacking** — Split `setupConditionalVisibility()` into three functions: `setupConditionalVisibility()` (attaches listeners + evaluates, called only from `buildForm()`), `evaluateAllConditionals()` (re-evaluates without attaching listeners, called from `populateForm()` and `resetForm()`), and `_buildConditionalDependencies()` (shared dependency map builder). Fixes memory leak where N populates caused N copies of evaluate handlers.
+- **#63 Schema spec fixes** — Changed `min`/`max` from `"type": "integer"` to `"type": "number"` in both `field` and `repeaterField` definitions (allows float constraints like `0.5`). Added `allOf` exclusion rules to `repeaterField`: `min`/`max`/`step` restricted to `number`, `currency_symbol` restricted to `currency`, `maxLength` restricted to `text`. 5 new schema tests (90 total).
+- **#64 Field type count** — Updated all references from "17" to "18" in SCHEMA_GUIDE.md, README.md, CLAUDE.md, field-type-demo.py, and field-type-demo.json.
+- **#65 Type hints** — Added `from __future__ import annotations` and type annotations to all public and private function signatures in `stencils.py` (16 functions). Added `generate_docx(data: dict[str, str]) -> bytes` to all 3 templates.
+- **#66 Configurable fallback URL** — Extracted the hardcoded `stencils.py` fallback URL into a `FORMFORGE_FALLBACK` constant (`{ owner, repo, branch }`) in the state section. URL is now derived from the constant via template literal.
+
+---
+
+### 2026-03-10 — Plan: Miscellaneous cleanup (#43 → #61–#66)
+**Issues:** #43, #61, #62, #63, #64, #65, #66
+
+Reviewed issue #43 (created 2026-03-04) for current relevancy. 6 of 8 original items are still applicable; 1 partially relevant (URL renamed from `_base.py` to `stencils.py`), 1 fixed (mid-function imports in `onboarding.py`). Updated issue body to reflect current state.
+
+Broke #43 into 6 independent tasks:
+- **#61** — Token input masking: `type="text"` → `type="password"` (bug, trivial)
+- **#62** — Event listener stacking in `setupConditionalVisibility` (bug, moderate)
+- **#63** — Schema spec: `min`/`max` accept floats + `repeaterField` exclusion rules (bug, moderate)
+- **#64** — Update field type count from "17" to "18" in all docs (documentation, trivial)
+- **#65** — Python type hints on all public function signatures (enhancement, moderate)
+- **#66** — Extract hardcoded stencils.py fallback URL to configurable constant (enhancement, low)
+
+All tasks are independent with no ordering constraints.
+
+---
+
 ### 2026-03-10 — Wizard step indicator: clickable navigation + mobile responsive
 **Issues:** #59
 

--- a/docs/SCHEMA_GUIDE.md
+++ b/docs/SCHEMA_GUIDE.md
@@ -143,7 +143,7 @@ Examples:
 
 ## Field Types
 
-17 types are supported. The `type` value must be exactly one of these strings.
+18 types are supported. The `type` value must be exactly one of these strings.
 
 | Type | Renders As | `options` needed? | Special properties |
 |------|-----------|-------------------|--------------------|

--- a/index.html
+++ b/index.html
@@ -715,7 +715,7 @@
         <div class="config-row">
           <div class="field-grow">
             <label>personal access token</label>
-            <input type="text" id="tokenInput" placeholder="ghp_xxxxxxxxxxxxxxxxxxxx" spellcheck="false" autocomplete="off">
+            <input type="password" id="tokenInput" placeholder="ghp_xxxxxxxxxxxxxxxxxxxx" spellcheck="false" autocomplete="off">
           </div>
         </div>
         <div class="token-hint">Token is only used in-browser and never stored or transmitted elsewhere. Needs <code>repo</code> scope for private repos.</div>
@@ -893,6 +893,9 @@ let ghOwner = '';
 let ghRepo = '';
 let ghBranch = 'main';
 let ghToken = '';
+
+// FormForge repo fallback (used when connected repo lacks stencils.py)
+const FORMFORGE_FALLBACK = { owner: 'ccirone2', repo: 'form-forge', branch: 'develop' };
 
 // ============================================================
 //  VIEW MANAGEMENT
@@ -1578,7 +1581,7 @@ async function loadBaseModule() {
     if (!baseCode) {
       try {
         const resp = await fetch(
-          'https://raw.githubusercontent.com/ccirone2/form-forge/develop/templates/stencils.py?t=' + Date.now()
+          `https://raw.githubusercontent.com/${FORMFORGE_FALLBACK.owner}/${FORMFORGE_FALLBACK.repo}/${FORMFORGE_FALLBACK.branch}/templates/stencils.py?t=${Date.now()}`
         );
         if (resp.ok) {
           baseCode = await resp.text();
@@ -1752,21 +1755,9 @@ function buildForm(schema) {
 
 function setupConditionalVisibility(schema) {
   // Build map: sourceFieldId -> [{targetFieldId, equals}]
-  const dependencies = {};
-  for (const section of schema.sections) {
-    for (const field of section.fields) {
-      if (!field.visible_when) continue;
-      const src = field.visible_when.field;
-      if (!dependencies[src]) dependencies[src] = [];
-      dependencies[src].push({ targetId: field.id, equals: field.visible_when.equals });
+  const dependencies = _buildConditionalDependencies(schema);
 
-      // Set initial hidden state
-      const group = document.getElementById(field.id)?.closest('.field-group');
-      if (group) group.classList.add('conditional-hidden');
-    }
-  }
-
-  // For each source field, attach listeners and evaluate initial state
+  // Attach listeners (only called from buildForm, which recreates DOM elements)
   for (const srcId of Object.keys(dependencies)) {
     const evaluate = () => {
       const srcValue = getFieldValue(srcId);
@@ -1782,7 +1773,6 @@ function setupConditionalVisibility(schema) {
       }
     };
 
-    // Attach to the right elements based on field type
     const srcField = findFieldDef(schema, srcId);
     if (srcField && (srcField.type === 'radio' || srcField.type === 'checkbox')) {
       document.querySelectorAll(`input[name="${srcId}"]`).forEach(el => {
@@ -1799,9 +1789,39 @@ function setupConditionalVisibility(schema) {
       }
     }
 
-    // Evaluate initial state
     evaluate();
   }
+}
+
+function evaluateAllConditionals(schema) {
+  // Re-evaluate visibility without attaching new listeners
+  const dependencies = _buildConditionalDependencies(schema);
+  for (const srcId of Object.keys(dependencies)) {
+    const srcValue = getFieldValue(srcId);
+    for (const dep of dependencies[srcId]) {
+      const targetEl = document.getElementById(dep.targetId);
+      const group = targetEl?.closest('.field-group');
+      if (!group) continue;
+      if (srcValue === dep.equals) {
+        group.classList.remove('conditional-hidden');
+      } else {
+        group.classList.add('conditional-hidden');
+      }
+    }
+  }
+}
+
+function _buildConditionalDependencies(schema) {
+  const dependencies = {};
+  for (const section of schema.sections) {
+    for (const field of section.fields) {
+      if (!field.visible_when) continue;
+      const src = field.visible_when.field;
+      if (!dependencies[src]) dependencies[src] = [];
+      dependencies[src].push({ targetId: field.id, equals: field.visible_when.equals });
+    }
+  }
+  return dependencies;
 }
 
 function getFieldValue(fieldId) {
@@ -2609,8 +2629,8 @@ function populateForm(data, options = {}) {
     }
   }
 
-  // Re-evaluate conditional visibility
-  if (currentSchema) setupConditionalVisibility(currentSchema);
+  // Re-evaluate conditional visibility (no new listeners — buildForm already attached them)
+  if (currentSchema) evaluateAllConditionals(currentSchema);
 
   // Show warning toast if mismatches found
   if (warnings > 0 && !silent) {
@@ -2988,8 +3008,8 @@ function resetForm() {
       }
     }
   }
-  // Re-evaluate conditional visibility after reset
-  if (currentSchema) setupConditionalVisibility(currentSchema);
+  // Re-evaluate conditional visibility after reset (no new listeners)
+  if (currentSchema) evaluateAllConditionals(currentSchema);
   // Clear autosave on reset
   try { localStorage.removeItem(getAutosaveKey()); } catch (e) { /* ignore */ }
   // Remove autosave prompt if visible

--- a/schemas/_schema.spec.json
+++ b/schemas/_schema.spec.json
@@ -102,8 +102,8 @@
           "type": "integer",
           "minimum": 1
         },
-        "min": { "type": "integer" },
-        "max": { "type": "integer" },
+        "min": { "type": "number" },
+        "max": { "type": "number" },
         "step": { "type": "number" },
         "currency_symbol": { "type": "string" },
         "default_value": { "type": "string" },
@@ -269,8 +269,8 @@
           "type": "integer",
           "minimum": 1
         },
-        "min": { "type": "integer" },
-        "max": { "type": "integer" },
+        "min": { "type": "number" },
+        "max": { "type": "number" },
         "step": { "type": "number" },
         "currency_symbol": { "type": "string" }
       },
@@ -291,6 +291,41 @@
           },
           "then": {
             "not": { "required": ["options"] }
+          }
+        },
+        {
+          "if": {
+            "properties": { "type": { "enum": ["text", "email", "tel", "currency", "select"] } },
+            "required": ["type"]
+          },
+          "then": {
+            "properties": {
+              "min": false,
+              "max": false,
+              "step": false
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": { "type": { "enum": ["text", "email", "tel", "number", "select"] } },
+            "required": ["type"]
+          },
+          "then": {
+            "properties": {
+              "currency_symbol": false
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": { "type": { "enum": ["email", "tel", "number", "currency", "select"] } },
+            "required": ["type"]
+          },
+          "then": {
+            "properties": {
+              "maxLength": false
+            }
           }
         }
       ],

--- a/schemas/field-type-demo.json
+++ b/schemas/field-type-demo.json
@@ -1,6 +1,6 @@
 {
   "title": "Event Registration",
-  "description": "Register for an upcoming event. This demo exercises all 17 field types, wizard mode, and conditional visibility.",
+  "description": "Register for an upcoming event. This demo exercises all 18 field types, wizard mode, and conditional visibility.",
   "icon": "🎪",
   "template": "templates/field-type-demo.py",
   "wizard": true,

--- a/templates/expense-report.py
+++ b/templates/expense-report.py
@@ -22,7 +22,7 @@ import json
 import stencils
 
 
-def generate_docx(data):
+def generate_docx(data: dict[str, str]) -> bytes:
     """
     Generate an Expense Report Document from form data.
 

--- a/templates/field-type-demo.py
+++ b/templates/field-type-demo.py
@@ -1,7 +1,7 @@
 """
 FormForge DOCX Template: Event Registration (Field Type Demo)
 =============================================================
-Demonstrates all 17 field types, wizard mode, and conditional visibility.
+Demonstrates all 18 field types, wizard mode, and conditional visibility.
 
 Field type value formats:
   - text/email/tel/date/select/radio/textarea → str
@@ -22,7 +22,7 @@ from docx.shared import Pt
 import stencils
 
 
-def generate_docx(data):
+def generate_docx(data: dict[str, str]) -> bytes:
     """
     Generate an Event Registration document from form data.
 

--- a/templates/onboarding.py
+++ b/templates/onboarding.py
@@ -18,7 +18,7 @@ Field type notes:
 import stencils
 
 
-def generate_docx(data):
+def generate_docx(data: dict[str, str]) -> bytes:
     """
     Generate an Employee Onboarding Document from form data.
 

--- a/templates/stencils.py
+++ b/templates/stencils.py
@@ -15,6 +15,8 @@ Usage in templates:
     return stencils.finalize(doc)
 """
 
+from __future__ import annotations
+
 import io
 import json
 import base64
@@ -211,7 +213,7 @@ THEME_MODERN = DocTheme(
 _active_theme = THEME_MODERN
 
 
-def set_theme(theme):
+def set_theme(theme: DocTheme) -> None:
     """Set the active document theme for all subsequent stencils calls.
 
     Args:
@@ -237,7 +239,7 @@ def set_theme(theme):
 _template_cache = {}
 
 
-def _set_style_font(style, font_name):
+def _set_style_font(style: object, font_name: str) -> None:
     """Set font on a style and strip theme-linked font attributes.
 
     Word's built-in styles (Title, Heading 1-4, Subtitle, etc.) carry
@@ -252,11 +254,16 @@ def _set_style_font(style, font_name):
     if rPr is not None:
         rFonts = rPr.find(qn("w:rFonts"))
         if rFonts is not None:
-            for attr in ("w:asciiTheme", "w:hAnsiTheme", "w:cstheme", "w:eastAsiaTheme"):
+            for attr in (
+                "w:asciiTheme",
+                "w:hAnsiTheme",
+                "w:cstheme",
+                "w:eastAsiaTheme",
+            ):
                 rFonts.attrib.pop(qn(attr), None)
 
 
-def _clear_bold(style):
+def _clear_bold(style: object) -> None:
     """Explicitly disable bold on a style, including complex-script bold.
 
     Word's built-in heading styles carry ``<w:bCs/>`` (bold complex script)
@@ -273,7 +280,7 @@ def _clear_bold(style):
         rPr.append(parse_xml(f'<w:bCs {nsdecls("w")} w:val="0"/>'))
 
 
-def _build_template(theme):
+def _build_template(theme: DocTheme) -> bytes:
     """Build a DOCX template with all Word styles configured from a theme.
 
     The template has no body content — just style definitions, page layout,
@@ -287,7 +294,9 @@ def _build_template(theme):
     ns = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
     styles_el = doc.styles.element
     for style_el in styles_el.findall(f"{{{ns}}}style"):
-        if style_el.get(f"{{{ns}}}type") == "table" and not style_el.get(f"{{{ns}}}default"):
+        if style_el.get(f"{{{ns}}}type") == "table" and not style_el.get(
+            f"{{{ns}}}default"
+        ):
             styles_el.remove(style_el)
 
     # -- Configure paragraph styles ------------------------------------
@@ -305,7 +314,7 @@ def _build_template(theme):
     title_pPr = title_style.element.get_or_add_pPr()
     title_pPr.append(
         parse_xml(
-            f'<w:pBdr {nsdecls("w")}>'
+            f"<w:pBdr {nsdecls('w')}>"
             f'<w:bottom w:val="single" w:sz="4" w:space="1"'
             f' w:color="{theme.color_subtitle}"/>'
             f"</w:pBdr>"
@@ -334,7 +343,7 @@ def _build_template(theme):
     h1_pPr = doc.styles["Heading 1"].element.get_or_add_pPr()
     h1_pPr.append(
         parse_xml(
-            f'<w:pBdr {nsdecls("w")}>'
+            f"<w:pBdr {nsdecls('w')}>"
             f'<w:bottom w:val="single" w:sz="4" w:space="1"'
             f' w:color="{theme.color_subtitle}"/>'
             f"</w:pBdr>"
@@ -376,7 +385,7 @@ def _build_template(theme):
     return buf.getvalue()
 
 
-def _get_template(theme):
+def _get_template(theme: DocTheme) -> bytes:
     """Return cached template bytes for a theme, building if needed."""
     if theme not in _template_cache:
         _template_cache[theme] = _build_template(theme)
@@ -392,7 +401,9 @@ _template_cache[_active_theme] = _build_template(_active_theme)
 # ---------------------------------------------------------------------------
 
 
-def _set_cell_margins(table, top=None, bottom=None):
+def _set_cell_margins(
+    table: object, top: float | None = None, bottom: float | None = None
+) -> None:
     """Set default top/bottom cell margins for all cells in a table (inches)."""
     tbl = table._tbl
     tblPr = tbl.tblPr if tbl.tblPr is not None else tbl._add_tblPr()
@@ -410,7 +421,7 @@ def _set_cell_margins(table, top=None, bottom=None):
     tblPr.append(parse_xml("".join(parts)))
 
 
-def _set_cell_left_margin(cell, inches):
+def _set_cell_left_margin(cell: object, inches: float) -> None:
     """Set left margin on an individual cell (overrides table default)."""
     twips = int(inches * 1440)
     tc = cell._tc
@@ -419,11 +430,15 @@ def _set_cell_left_margin(cell, inches):
     if existing is not None:
         tcPr.remove(existing)
     tcPr.append(
-        parse_xml(f'<w:tcMar {nsdecls("w")}>' f'<w:left w:w="{twips}" w:type="dxa"/>' f"</w:tcMar>")
+        parse_xml(
+            f'<w:tcMar {nsdecls("w")}><w:left w:w="{twips}" w:type="dxa"/></w:tcMar>'
+        )
     )
 
 
-def _set_table_borders(table, val="single", sz=4, color="BFBFBF"):
+def _set_table_borders(
+    table: object, val: str = "single", sz: int = 4, color: str = "BFBFBF"
+) -> None:
     """Apply uniform borders to every edge of a table (or remove them)."""
     tbl = table._tbl
     tblPr = tbl.tblPr if tbl.tblPr is not None else tbl._add_tblPr()
@@ -443,7 +458,7 @@ def _set_table_borders(table, val="single", sz=4, color="BFBFBF"):
     tblPr.append(borders)
 
 
-def _shade_cells(row, fill_hex):
+def _shade_cells(row: object, fill_hex: str) -> None:
     """Apply background shading to every cell in a table row."""
     for cell in row.cells:
         shading = parse_xml(
@@ -457,7 +472,13 @@ def _shade_cells(row, fill_hex):
 # ---------------------------------------------------------------------------
 
 
-def new_doc(title_text, subtitle_text="", font_name=None, font_size=None, theme=None):
+def new_doc(
+    title_text: str,
+    subtitle_text: str = "",
+    font_name: str | None = None,
+    font_size: int | None = None,
+    theme: DocTheme | None = None,
+) -> Document:
     """
     Create a styled Document with a centered title and optional subtitle.
 
@@ -505,7 +526,7 @@ def new_doc(title_text, subtitle_text="", font_name=None, font_size=None, theme=
     return doc
 
 
-def table_section(doc, heading, rows):
+def table_section(doc: Document, heading: str, rows: list[tuple[str, str]]) -> None:
     """
     Add a heading followed by a borderless two-column key/value table.
     Labels in the first column use the heading font (semibold).
@@ -540,7 +561,7 @@ def table_section(doc, heading, rows):
     doc.add_paragraph("")
 
 
-def longtext(doc, heading, text):
+def longtext(doc: Document, heading: str, text: str) -> None:
     """
     Add a sub-heading followed by one or more paragraphs of body text.
     Respects newline characters as paragraph breaks.
@@ -569,7 +590,7 @@ def longtext(doc, heading, text):
     doc.add_paragraph("")
 
 
-def bullet_list(doc, heading, items_str):
+def bullet_list(doc: Document, heading: str, items_str: str) -> None:
     """
     Add a sub-heading followed by a bulleted list.
     Items are expected as a newline-separated string.
@@ -591,7 +612,9 @@ def bullet_list(doc, heading, items_str):
             existing_ind = pPr.find(qn("w:ind"))
             if existing_ind is not None:
                 pPr.remove(existing_ind)
-            pPr.append(parse_xml(f'<w:ind {nsdecls("w")} w:left="720" w:hanging="360"/>'))
+            pPr.append(
+                parse_xml(f'<w:ind {nsdecls("w")} w:left="720" w:hanging="360"/>')
+            )
             run = p.add_run(item)
             run.font.size = Pt(t.size_table)
     else:
@@ -604,7 +627,7 @@ def bullet_list(doc, heading, items_str):
     doc.add_paragraph("")
 
 
-def signatures(doc, labels):
+def signatures(doc: Document, labels: list[str]) -> None:
     """
     Add a signature block with underlines and labels in a grid layout.
     Labels are arranged in pairs (two per row).
@@ -635,7 +658,7 @@ def signatures(doc, labels):
         run.font.color.rgb = t.color_muted
 
 
-def footer(doc):
+def footer(doc: Document) -> None:
     """
     Add the standard FormForge auto-generated footer paragraph.
 
@@ -656,7 +679,7 @@ def footer(doc):
     fr.italic = True
 
 
-def address(doc, heading, raw_json):
+def address(doc: Document, heading: str, raw_json: str) -> None:
     """
     Add a formatted mailing address block under a heading.
     Parses a JSON string with keys: street, city, state, zip.
@@ -706,7 +729,12 @@ def address(doc, heading, raw_json):
     doc.add_paragraph("")
 
 
-def image(doc, b64_str, width_inches=3.0, placeholder="No image uploaded."):
+def image(
+    doc: Document,
+    b64_str: str,
+    width_inches: float = 3.0,
+    placeholder: str = "No image uploaded.",
+) -> None:
     """
     Embed a base64 data-URI image or render a placeholder if absent/invalid.
 
@@ -731,7 +759,9 @@ def image(doc, b64_str, width_inches=3.0, placeholder="No image uploaded."):
     r.font.color.rgb = _active_theme.color_muted
 
 
-def signature(doc, b64_str, label, width_inches=2.5):
+def signature(
+    doc: Document, b64_str: str, label: str, width_inches: float = 2.5
+) -> None:
     """
     Add a signature image (or placeholder underline) with a label beneath.
 
@@ -759,7 +789,13 @@ def signature(doc, b64_str, label, width_inches=2.5):
     lr.font.color.rgb = t.color_muted
 
 
-def repeater_table(doc, headers, items, field_keys, currency_keys=None):
+def repeater_table(
+    doc: Document,
+    headers: list[str],
+    items: list[dict[str, str]],
+    field_keys: list[str],
+    currency_keys: list[str] | None = None,
+) -> None:
     """
     Render a repeater field as a headed table with a shaded header row.
 
@@ -771,10 +807,7 @@ def repeater_table(doc, headers, items, field_keys, currency_keys=None):
         currency_keys: Optional set/list of field_keys that should be
                        formatted as currency (e.g. ["amount", "unit_cost"]).
     """
-    if currency_keys is None:
-        currency_keys = set()
-    else:
-        currency_keys = set(currency_keys)
+    _currency_set = set(currency_keys) if currency_keys else set()
 
     t = _active_theme
 
@@ -814,7 +847,7 @@ def repeater_table(doc, headers, items, field_keys, currency_keys=None):
             row = table.add_row()
             for col_idx, key in enumerate(field_keys):
                 val = item.get(key, "")
-                if key in currency_keys:
+                if key in _currency_set:
                     try:
                         val = f"${float(val):,.2f}"
                     except (ValueError, TypeError):
@@ -831,7 +864,7 @@ def repeater_table(doc, headers, items, field_keys, currency_keys=None):
     doc.add_paragraph("")
 
 
-def finalize(doc):
+def finalize(doc: Document) -> bytes:
     """
     Serialize a Document to bytes.
 

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -488,9 +488,7 @@ def _minimal_schema():
         "sections": [
             {
                 "title": "Section 1",
-                "fields": [
-                    {"id": "name", "label": "Name", "type": "text"}
-                ],
+                "fields": [{"id": "name", "label": "Name", "type": "text"}],
             }
         ],
     }
@@ -522,3 +520,168 @@ def test_rejects_sample_data_non_object():
         assert False, "Should have raised ValidationError"
     except jsonschema.ValidationError:
         pass
+
+
+# ---------------------------------------------------------------------------
+#  min/max float support
+# ---------------------------------------------------------------------------
+
+
+def test_number_field_accepts_float_min_max():
+    """min/max on a number field should accept float values like 0.5."""
+    spec = _load_spec()
+    schema = {
+        "title": "T",
+        "sections": [
+            {
+                "title": "S",
+                "fields": [
+                    {
+                        "id": "rating",
+                        "label": "Rating",
+                        "type": "number",
+                        "min": 0.5,
+                        "max": 9.5,
+                        "step": 0.5,
+                    }
+                ],
+            }
+        ],
+    }
+    jsonschema.validate(instance=schema, schema=spec)
+
+
+# ---------------------------------------------------------------------------
+#  repeaterField exclusion rules
+# ---------------------------------------------------------------------------
+
+
+def test_rejects_min_on_select_repeater_field():
+    """min is not allowed on a select repeater sub-field."""
+    spec = _load_spec()
+    bad = {
+        "title": "T",
+        "sections": [
+            {
+                "title": "S",
+                "fields": [
+                    {
+                        "id": "items",
+                        "label": "Items",
+                        "type": "repeater",
+                        "fields": [
+                            {
+                                "id": "cat",
+                                "label": "Category",
+                                "type": "select",
+                                "options": ["A", "B"],
+                                "min": 1,
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+    try:
+        jsonschema.validate(instance=bad, schema=spec)
+        assert False, "Should have raised ValidationError"
+    except jsonschema.ValidationError:
+        pass
+
+
+def test_rejects_currency_symbol_on_text_repeater_field():
+    """currency_symbol is not allowed on a text repeater sub-field."""
+    spec = _load_spec()
+    bad = {
+        "title": "T",
+        "sections": [
+            {
+                "title": "S",
+                "fields": [
+                    {
+                        "id": "items",
+                        "label": "Items",
+                        "type": "repeater",
+                        "fields": [
+                            {
+                                "id": "name",
+                                "label": "Name",
+                                "type": "text",
+                                "currency_symbol": "$",
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+    try:
+        jsonschema.validate(instance=bad, schema=spec)
+        assert False, "Should have raised ValidationError"
+    except jsonschema.ValidationError:
+        pass
+
+
+def test_rejects_max_length_on_number_repeater_field():
+    """maxLength is not allowed on a number repeater sub-field."""
+    spec = _load_spec()
+    bad = {
+        "title": "T",
+        "sections": [
+            {
+                "title": "S",
+                "fields": [
+                    {
+                        "id": "items",
+                        "label": "Items",
+                        "type": "repeater",
+                        "fields": [
+                            {
+                                "id": "qty",
+                                "label": "Qty",
+                                "type": "number",
+                                "maxLength": 5,
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+    try:
+        jsonschema.validate(instance=bad, schema=spec)
+        assert False, "Should have raised ValidationError"
+    except jsonschema.ValidationError:
+        pass
+
+
+def test_repeater_number_field_accepts_min_max():
+    """min/max/step should be allowed on a number repeater sub-field."""
+    spec = _load_spec()
+    schema = {
+        "title": "T",
+        "sections": [
+            {
+                "title": "S",
+                "fields": [
+                    {
+                        "id": "items",
+                        "label": "Items",
+                        "type": "repeater",
+                        "fields": [
+                            {
+                                "id": "qty",
+                                "label": "Qty",
+                                "type": "number",
+                                "min": 1,
+                                "max": 100,
+                                "step": 1,
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+    jsonschema.validate(instance=schema, schema=spec)


### PR DESCRIPTION
## Summary
- **Token masking (#61):** `tokenInput` uses `type="password"` to hide GitHub PAT while typing
- **Listener stacking fix (#62):** Split `setupConditionalVisibility` into `setupConditionalVisibility()` (listeners, called once in `buildForm`) + `evaluateAllConditionals()` (re-evaluation only, called from `populateForm`/`resetForm`). Fixes memory leak where N populates stacked N copies of evaluate handlers.
- **Schema spec fixes (#63):** `min`/`max` widened from `integer` to `number` (accepts floats). Added `allOf` exclusion rules to `repeaterField` mirroring top-level field rules (`min`/`max`/`step` → number only, `currency_symbol` → currency only, `maxLength` → text only).
- **Field type count (#64):** Updated all docs from "17" to "18" field types (SCHEMA_GUIDE, README, CLAUDE.md, field-type-demo schema/template)
- **Type hints (#65):** Added `from __future__ import annotations` + type annotations to all 16 functions in `stencils.py` and all `generate_docx` signatures in templates
- **Configurable fallback URL (#66):** Extracted hardcoded stencils.py fallback URL to `FORMFORGE_FALLBACK` constant

## Test plan
- [x] All 90 tests pass (5 new schema tests for float min/max, repeaterField exclusions)
- [x] `ruff check` and `ruff format` clean
- [x] All existing schemas validate against updated spec
- [ ] Manual: verify token input is masked in browser
- [ ] Manual: verify conditional visibility still works after populate/reset

Closes #61, closes #62, closes #63, closes #64, closes #65, closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)