### PR TITLE
Refactor index.html for maintainability and extendability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,13 @@ Fields can have an optional `visible_when` object: `{ "field": "<source_id>", "e
 - **Schema field IDs** follow the pattern `^[a-z][a-z0-9_]*$`.
 - **`generate_docx(data)`** is the required entry point for all templates. `data` is a dict keyed by field `id`. All values are strings (complex types like address/repeater are JSON strings).
 - The HTML app fetches schemas/templates from GitHub via the public API — file paths in schemas (e.g., `"template": "templates/onboarding.py"`) are relative to the repo root.
-- Adding a new field type touches three places: `createField()` switch in index.html, `collectFormData()` in index.html, and the template .py file.
+- Adding a new field type touches these places:
+  1. `fieldCreators` map + new `create*Field()` function in index.html
+  2. `collectFormData()` in index.html
+  3. `populateForm()` in index.html
+  4. `validateSection()` in index.html (if the type needs special validation, e.g. address/checkbox/radio)
+  5. `_schema.spec.json` — `fieldType` enum + `allOf` exclusion blocks for type-specific properties
+  6. Template `.py` files, `docs/FIELD_TYPES.md`, and the expected-types set in `tests/test_schemas.py`
 
 ## Development
 

--- a/docs/DEVLOG.md
+++ b/docs/DEVLOG.md
@@ -14,6 +14,20 @@
 
 ## Log
 
+### 2026-03-10 — Refactor index.html for maintainability (#38 → #68–#71)
+**Issues:** #38, #68, #69, #70, #71
+
+Implemented all 4 sub-tasks of the refactor:
+
+- **#68 Eliminate monkey-patching** — Merged the duplicate `launchForm` (line 3230 override → single definition at line 1480). Inlined `loadDocs()` call directly into `connectRepo()` body, removing `_origConnectRepo` monkey-patch. Removed `_originalLaunchForm` and `_origConnectRepo` variables.
+- **#69 Unify validation** — Extracted shared `validateSection(section)` that validates directly from the DOM with explicit radio, checkbox, and address branches. Both `wizardValidateStep()` and `validateForm()` now delegate to it. Fixes divergence where `validateForm` previously lacked radio/checkbox-specific validation.
+- **#70 Extract createField** — Decomposed the 416-line `createField()` into 16 named creator functions (`createTextField`, `createDateField`, etc.) registered in a `fieldCreators` map. `createField()` is now a 28-line dispatcher handling labels, delegation, and hints.
+- **#71 Update CLAUDE.md** — Replaced the "touches three places" bullet with a complete 6-item checklist covering all actual touch points for adding a new field type.
+
+**Net result:** index.html reduced from 3270 → 3234 lines (−36). All 90 tests pass.
+
+---
+
 ### 2026-03-10 — Miscellaneous cleanup (#43 → #61–#66)
 **Issues:** #43, #61, #62, #63, #64, #65, #66
 

--- a/index.html
+++ b/index.html
@@ -1154,16 +1154,6 @@ async function loadDocs() {
   }
 }
 
-// Reload docs when GitHub connects
-const _origConnectRepo = connectRepo;
-connectRepo = async function() {
-  await _origConnectRepo();
-  if (ghOwner && ghRepo && repoSchemas.length > 0) {
-    log('Refreshing docs from GitHub...', 'info');
-    await loadDocs();
-  }
-};
-
 // ============================================================
 //  LOCAL FILE HANDLING
 // ============================================================
@@ -1426,6 +1416,10 @@ async function connectRepo() {
     document.getElementById('statusText').textContent = `${ghOwner}/${ghRepo}`;
 
     renderPicker();
+
+    // Reload docs from connected repo
+    log('Refreshing docs from GitHub...', 'info');
+    await loadDocs();
   } catch (err) {
     statusEl.className = 'repo-status error';
     statusEl.textContent = `Error: ${err.message}`;
@@ -1481,10 +1475,9 @@ async function launchForm() {
   if (selectedSchemaIdx < 0) return;
   const entry = repoSchemas[selectedSchemaIdx];
 
-  showOverlay('Loading template from GitHub...');
+  showOverlay('Loading...');
 
   try {
-    // Fetch the template Python file
     log(`Fetching template: ${entry.templatePath}`, 'info');
     const templateCode = await ghFetchRaw(entry.templatePath);
     log(`Template loaded: ${templateCode.length} chars`, 'success');
@@ -1493,19 +1486,14 @@ async function launchForm() {
     currentSchemaName = (entry.schemaPath || '').replace(/^schemas\//, '').replace(/\.json$/, '');
     currentTemplateCode = templateCode;
 
-    // Build form
     buildForm(currentSchema);
     document.getElementById('formNavInfo').textContent = `${entry.name} · from ${ghOwner}/${ghRepo}`;
     document.getElementById('schemaInfoText').innerHTML =
       `Loaded from GitHub — schema: <strong>${escapeHtml(entry.schemaPath)}</strong> · template: <strong>${escapeHtml(entry.templatePath)}</strong>`;
 
-    // Initialize Pyodide if not already
-    if (!pyodideReady) {
-      await initPyodide();
-    }
+    if (!pyodideReady) await initPyodide();
     await loadBaseModule();
 
-    // Load the template into Pyodide
     showOverlay('Loading template into Pyodide...');
     await pyodide.runPythonAsync(currentTemplateCode);
     log('Template code loaded into Pyodide', 'success');
@@ -1515,7 +1503,7 @@ async function launchForm() {
     postLaunchHook();
   } catch (err) {
     log(`Launch failed: ${err.message}`, 'error');
-    showToast(`Failed to load: ${err.message}`, 'error');
+    showToast(`Failed: ${err.message}`, 'error');
   } finally {
     hideOverlay();
   }
@@ -1852,15 +1840,13 @@ function isFieldConditionallyHidden(fieldId) {
 }
 
 // ============================================================
-//  WIZARD NAVIGATION
+//  VALIDATION (shared by wizard and full-form)
 // ============================================================
 
-function wizardValidateStep(stepIndex) {
-  if (!currentSchema || !currentSchema.sections[stepIndex]) return [];
-  const section = currentSchema.sections[stepIndex];
+function validateSection(section) {
   const missing = [];
   for (const field of section.fields) {
-    if (field.type === 'heading') continue;
+    if (field.type === 'heading' || field.type === 'hidden') continue;
     if (!field.required) continue;
     if (isFieldConditionallyHidden(field.id)) continue;
     if (field.type === 'address') {
@@ -1878,6 +1864,15 @@ function wizardValidateStep(stepIndex) {
     }
   }
   return missing;
+}
+
+// ============================================================
+//  WIZARD NAVIGATION
+// ============================================================
+
+function wizardValidateStep(stepIndex) {
+  if (!currentSchema || !currentSchema.sections[stepIndex]) return [];
+  return validateSection(currentSchema.sections[stepIndex]);
 }
 
 function wizardStepClick(targetStep) {
@@ -1933,6 +1928,408 @@ function wizardGoTo(stepIndex) {
   document.querySelector('.submit-area').style.display = isLast ? '' : 'none';
 }
 
+// ============================================================
+//  PER-TYPE FIELD CREATORS
+// ============================================================
+
+function createTextField(field, group) {
+  const input = document.createElement('input');
+  input.type = field.type; input.id = field.id; input.name = field.id;
+  input.placeholder = field.placeholder || ''; input.required = field.required || false;
+  group.appendChild(input);
+}
+
+function createDateField(field, group) {
+  const input = document.createElement('input');
+  input.type = 'date'; input.id = field.id; input.name = field.id;
+  input.required = field.required || false;
+  group.appendChild(input);
+}
+
+function createTextareaField(field, group) {
+  const ta = document.createElement('textarea');
+  ta.id = field.id; ta.name = field.id; ta.placeholder = field.placeholder || '';
+  ta.required = field.required || false; ta.rows = 3;
+  group.appendChild(ta);
+}
+
+function createLongtextField(field, group) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'longtext-wrapper';
+  const ta = document.createElement('textarea');
+  ta.id = field.id; ta.name = field.id; ta.placeholder = field.placeholder || '';
+  ta.required = field.required || false; ta.rows = 6;
+  const maxLen = field.maxLength || 5000;
+  const counter = document.createElement('div');
+  counter.className = 'longtext-counter';
+  counter.textContent = `0 / ${maxLen} characters`;
+  ta.addEventListener('input', () => {
+    const len = ta.value.length;
+    counter.textContent = `${len} / ${maxLen} characters`;
+    counter.style.color = len > maxLen ? 'var(--error)' : '';
+  });
+  wrapper.appendChild(ta);
+  wrapper.appendChild(counter);
+  group.appendChild(wrapper);
+}
+
+function createSelectField(field, group) {
+  const select = document.createElement('select');
+  select.id = field.id; select.name = field.id; select.required = field.required || false;
+  for (const opt of (field.options || [])) {
+    const option = document.createElement('option');
+    option.value = opt; option.textContent = opt || '— Select —';
+    select.appendChild(option);
+  }
+  group.appendChild(select);
+}
+
+function createRadioField(field, group) {
+  const rg = document.createElement('div'); rg.className = 'radio-group';
+  rg.setAttribute('role', 'group'); rg.setAttribute('aria-labelledby', `${field.id}_group_label`);
+  for (const opt of (field.options || [])) {
+    const item = document.createElement('div'); item.className = 'radio-item';
+    const input = document.createElement('input');
+    input.type = 'radio'; input.name = field.id; input.value = opt;
+    input.id = `${field.id}_${opt.replace(/\s+/g, '_').toLowerCase()}`;
+    const label = document.createElement('label');
+    label.setAttribute('for', input.id); label.textContent = opt;
+    item.appendChild(input); item.appendChild(label); rg.appendChild(item);
+  }
+  group.appendChild(rg);
+}
+
+function createCheckboxField(field, group) {
+  const cg = document.createElement('div'); cg.className = 'checkbox-group';
+  cg.setAttribute('role', 'group'); cg.setAttribute('aria-labelledby', `${field.id}_group_label`);
+  for (const opt of (field.options || [])) {
+    const item = document.createElement('div'); item.className = 'checkbox-item';
+    const input = document.createElement('input');
+    input.type = 'checkbox'; input.name = field.id; input.value = opt;
+    input.id = `${field.id}_${opt.replace(/\s+/g, '_').toLowerCase()}`;
+    const label = document.createElement('label');
+    label.setAttribute('for', input.id); label.textContent = opt;
+    item.appendChild(input); item.appendChild(label); cg.appendChild(item);
+  }
+  group.appendChild(cg);
+}
+
+function createListField(field, group) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'list-entry-wrapper';
+  const itemsContainer = document.createElement('div');
+  itemsContainer.className = 'list-items'; itemsContainer.id = `${field.id}_items`;
+  const countEl = document.createElement('div');
+  countEl.className = 'list-item-count'; countEl.id = `${field.id}_count`; countEl.textContent = '0 items';
+
+  const addBtn = document.createElement('button');
+  addBtn.type = 'button'; addBtn.className = 'btn-add-item';
+  addBtn.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 5v14M5 12h14"/></svg> Add item';
+  addBtn.addEventListener('click', () => {
+    addListItem(field.id, field.placeholder || '', itemsContainer, countEl);
+    const inputs = itemsContainer.querySelectorAll('.list-item-input');
+    inputs[inputs.length - 1].focus();
+  });
+
+  const divider = document.createElement('div');
+  divider.className = 'list-or-divider'; divider.textContent = 'or paste multiple lines';
+
+  const bulkTa = document.createElement('textarea');
+  bulkTa.className = 'list-bulk-textarea'; bulkTa.id = `${field.id}_bulk`;
+  bulkTa.placeholder = 'Paste items here, one per line...'; bulkTa.rows = 3;
+  bulkTa.addEventListener('blur', () => {
+    const lines = bulkTa.value.split('\n').map(l => l.trim()).filter(l => l);
+    if (lines.length > 0) {
+      for (const line of lines) addListItem(field.id, field.placeholder || '', itemsContainer, countEl, line);
+      bulkTa.value = '';
+    }
+  });
+
+  wrapper.appendChild(itemsContainer);
+  wrapper.appendChild(addBtn);
+  wrapper.appendChild(countEl);
+  wrapper.appendChild(divider);
+  wrapper.appendChild(bulkTa);
+  group.appendChild(wrapper);
+  setTimeout(() => addListItem(field.id, field.placeholder || '', itemsContainer, countEl), 0);
+}
+
+function createNumberField(field, group) {
+  const input = document.createElement('input');
+  input.type = 'number'; input.id = field.id; input.name = field.id;
+  input.placeholder = field.placeholder || '';
+  input.required = field.required || false;
+  if (field.min !== undefined) input.min = field.min;
+  if (field.max !== undefined) input.max = field.max;
+  if (field.step !== undefined) input.step = field.step;
+  group.appendChild(input);
+}
+
+function createCurrencyField(field, group) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'currency-wrapper';
+  const prefix = document.createElement('span');
+  prefix.className = 'currency-prefix';
+  prefix.textContent = field.currency_symbol || '$';
+  const input = document.createElement('input');
+  input.type = 'number'; input.id = field.id; input.name = field.id;
+  input.step = '0.01'; input.min = '0';
+  input.placeholder = field.placeholder || '0.00';
+  input.required = field.required || false;
+  wrapper.appendChild(prefix);
+  wrapper.appendChild(input);
+  group.appendChild(wrapper);
+}
+
+function createHeadingField(field, group) {
+  const h = document.createElement('div');
+  h.className = 'field-heading';
+  h.textContent = field.label;
+  group.appendChild(h);
+  if (field.hint) {
+    const hintEl = document.createElement('div');
+    hintEl.className = 'field-heading-hint';
+    hintEl.textContent = field.hint;
+    group.appendChild(hintEl);
+  }
+}
+
+function createHiddenField(field, group) {
+  const input = document.createElement('input');
+  input.type = 'hidden'; input.id = field.id; input.name = field.id;
+  input.value = field.default_value || '';
+  group.style.display = 'none';
+  group.appendChild(input);
+}
+
+function createAddressField(field, group) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'address-group';
+  const streetInput = document.createElement('input');
+  streetInput.type = 'text'; streetInput.id = `${field.id}_street`; streetInput.name = `${field.id}_street`;
+  streetInput.placeholder = 'Street address';
+  wrapper.appendChild(streetInput);
+  const row = document.createElement('div');
+  row.className = 'address-row';
+  const cityInput = document.createElement('input');
+  cityInput.type = 'text'; cityInput.id = `${field.id}_city`; cityInput.name = `${field.id}_city`;
+  cityInput.placeholder = 'City';
+  const stateInput = document.createElement('input');
+  stateInput.type = 'text'; stateInput.id = `${field.id}_state`; stateInput.name = `${field.id}_state`;
+  stateInput.placeholder = 'State';
+  const zipInput = document.createElement('input');
+  zipInput.type = 'text'; zipInput.id = `${field.id}_zip`; zipInput.name = `${field.id}_zip`;
+  zipInput.placeholder = 'ZIP code';
+  row.appendChild(cityInput); row.appendChild(stateInput); row.appendChild(zipInput);
+  wrapper.appendChild(row);
+  group.appendChild(wrapper);
+}
+
+function createFileField(field, group) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'file-upload-wrapper';
+  const fileInput = document.createElement('input');
+  fileInput.type = 'file'; fileInput.id = `${field.id}_input`;
+  fileInput.accept = field.accept || 'image/*';
+  const hiddenInput = document.createElement('input');
+  hiddenInput.type = 'hidden'; hiddenInput.id = field.id;
+  const preview = document.createElement('img');
+  preview.className = 'file-preview'; preview.id = `${field.id}_preview`;
+  const info = document.createElement('div');
+  info.className = 'file-info'; info.id = `${field.id}_info`;
+  const maxMb = field.max_size_mb || 5;
+  fileInput.addEventListener('change', () => {
+    const file = fileInput.files[0];
+    if (!file) { hiddenInput.value = ''; preview.style.display = 'none'; info.textContent = ''; return; }
+    if (file.size > maxMb * 1024 * 1024) {
+      showToast(`File too large (max ${maxMb}MB)`, 'error');
+      fileInput.value = ''; hiddenInput.value = ''; return;
+    }
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      hiddenInput.value = e.target.result;
+      if (file.type.startsWith('image/')) { preview.src = e.target.result; preview.style.display = 'block'; }
+      else { preview.style.display = 'none'; }
+      info.textContent = `${file.name} (${(file.size / 1024).toFixed(1)} KB)`;
+    };
+    reader.readAsDataURL(file);
+  });
+  wrapper.appendChild(fileInput);
+  wrapper.appendChild(preview);
+  wrapper.appendChild(info);
+  wrapper.appendChild(hiddenInput);
+  group.appendChild(wrapper);
+}
+
+function createSignatureField(field, group) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'signature-pad-wrapper';
+  const canvas = document.createElement('canvas');
+  canvas.className = 'signature-canvas'; canvas.id = `${field.id}_canvas`;
+  canvas.width = 400; canvas.height = 150;
+  canvas.setAttribute('aria-label', 'Signature pad \u2014 draw your signature with mouse or touch');
+  const hiddenInput = document.createElement('input');
+  hiddenInput.type = 'hidden'; hiddenInput.id = field.id;
+  let drawing = false;
+  function getPos(e) {
+    const rect = canvas.getBoundingClientRect();
+    const scaleX = canvas.width / rect.width;
+    const scaleY = canvas.height / rect.height;
+    if (e.touches) {
+      return { x: (e.touches[0].clientX - rect.left) * scaleX, y: (e.touches[0].clientY - rect.top) * scaleY };
+    }
+    return { x: (e.clientX - rect.left) * scaleX, y: (e.clientY - rect.top) * scaleY };
+  }
+  const ctx = canvas.getContext('2d');
+  ctx.lineWidth = 2; ctx.lineCap = 'round'; ctx.lineJoin = 'round'; ctx.strokeStyle = '#000';
+  function startDraw(e) { e.preventDefault(); drawing = true; const p = getPos(e); ctx.beginPath(); ctx.moveTo(p.x, p.y); }
+  function moveDraw(e) { if (!drawing) return; e.preventDefault(); const p = getPos(e); ctx.lineTo(p.x, p.y); ctx.stroke(); }
+  function isCanvasBlank(c) {
+    const d = c.getContext('2d').getImageData(0, 0, c.width, c.height).data;
+    return !d.some((val, i) => i % 4 === 3 && val !== 0);
+  }
+  function endDraw() { if (!drawing) return; drawing = false; hiddenInput.value = isCanvasBlank(canvas) ? '' : canvas.toDataURL('image/png'); }
+  canvas.addEventListener('mousedown', startDraw);
+  canvas.addEventListener('mousemove', moveDraw);
+  canvas.addEventListener('mouseup', endDraw);
+  canvas.addEventListener('mouseleave', endDraw);
+  canvas.addEventListener('touchstart', startDraw);
+  canvas.addEventListener('touchmove', moveDraw);
+  canvas.addEventListener('touchend', endDraw);
+  const actions = document.createElement('div');
+  actions.className = 'signature-actions';
+  const clearBtn = document.createElement('button');
+  clearBtn.type = 'button'; clearBtn.className = 'btn-clear-sig'; clearBtn.textContent = 'Clear';
+  clearBtn.addEventListener('click', () => {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    hiddenInput.value = '';
+  });
+  actions.appendChild(clearBtn);
+  wrapper.appendChild(canvas);
+  wrapper.appendChild(actions);
+  wrapper.appendChild(hiddenInput);
+  group.appendChild(wrapper);
+}
+
+function createRepeaterField(field, group) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'repeater-wrapper'; wrapper.id = `${field.id}_repeater`;
+  const rowsContainer = document.createElement('div');
+  rowsContainer.id = `${field.id}_rows`;
+  const minRows = field.min_rows || 1;
+  const maxRows = field.max_rows || 10;
+  const subFields = field.fields || [];
+  let rowCount = 0;
+
+  function addRepeaterRow() {
+    if (rowCount >= maxRows) return;
+    const rowIdx = rowCount++;
+    const row = document.createElement('div');
+    row.className = 'repeater-row'; row.dataset.rowIdx = rowIdx;
+    const header = document.createElement('div');
+    header.className = 'repeater-row-header';
+    const rowLabel = document.createElement('span');
+    rowLabel.textContent = `#${rowIdx + 1}`;
+    const removeBtn = document.createElement('button');
+    removeBtn.type = 'button'; removeBtn.className = 'btn-remove-row'; removeBtn.innerHTML = '&times;';
+    removeBtn.addEventListener('click', () => {
+      if (rowsContainer.children.length <= minRows) return;
+      row.remove();
+      updateRepeaterNumbers();
+      updateAddBtn();
+    });
+    header.appendChild(rowLabel); header.appendChild(removeBtn);
+    const fieldsDiv = document.createElement('div');
+    fieldsDiv.className = 'repeater-row-fields';
+    for (const sf of subFields) {
+      const subId = `${field.id}_r${rowIdx}_${sf.id}`;
+      const fg = document.createElement('div');
+      fg.className = 'field-group';
+      const lbl = document.createElement('label');
+      lbl.className = 'field-label'; lbl.setAttribute('for', subId);
+      lbl.textContent = sf.label;
+      fg.appendChild(lbl);
+      if (sf.type === 'select') {
+        const sel = document.createElement('select');
+        sel.id = subId; sel.name = subId;
+        for (const opt of (sf.options || [])) {
+          const o = document.createElement('option');
+          o.value = opt; o.textContent = opt || '— Select —';
+          sel.appendChild(o);
+        }
+        fg.appendChild(sel);
+      } else if (sf.type === 'currency') {
+        const cw = document.createElement('div'); cw.className = 'currency-wrapper';
+        const pfx = document.createElement('span'); pfx.className = 'currency-prefix';
+        pfx.textContent = sf.currency_symbol || '$';
+        const inp = document.createElement('input');
+        inp.type = 'number'; inp.id = subId; inp.name = subId;
+        inp.step = '0.01'; inp.min = '0'; inp.placeholder = sf.placeholder || '0.00';
+        cw.appendChild(pfx); cw.appendChild(inp);
+        fg.appendChild(cw);
+      } else if (sf.type === 'number') {
+        const inp = document.createElement('input');
+        inp.type = 'number'; inp.id = subId; inp.name = subId;
+        inp.placeholder = sf.placeholder || '';
+        if (sf.min !== undefined) inp.min = sf.min;
+        if (sf.max !== undefined) inp.max = sf.max;
+        if (sf.step !== undefined) inp.step = sf.step;
+        fg.appendChild(inp);
+      } else {
+        const inp = document.createElement('input');
+        inp.type = sf.type === 'email' ? 'email' : sf.type === 'tel' ? 'tel' : 'text';
+        inp.id = subId; inp.name = subId; inp.placeholder = sf.placeholder || '';
+        fg.appendChild(inp);
+      }
+      fieldsDiv.appendChild(fg);
+    }
+    row.appendChild(header);
+    row.appendChild(fieldsDiv);
+    rowsContainer.appendChild(row);
+    updateAddBtn();
+  }
+
+  function updateRepeaterNumbers() {
+    Array.from(rowsContainer.children).forEach((row, i) => {
+      const label = row.querySelector('.repeater-row-header span');
+      if (label) label.textContent = `#${i + 1}`;
+    });
+  }
+
+  const actionsDiv = document.createElement('div');
+  actionsDiv.className = 'repeater-actions';
+  const addBtn = document.createElement('button');
+  addBtn.type = 'button'; addBtn.className = 'btn-add-item';
+  addBtn.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 5v14M5 12h14"/></svg> Add row';
+  addBtn.addEventListener('click', addRepeaterRow);
+  function updateAddBtn() { addBtn.disabled = rowsContainer.children.length >= maxRows; }
+
+  wrapper.appendChild(rowsContainer);
+  actionsDiv.appendChild(addBtn);
+  wrapper.appendChild(actionsDiv);
+  group.appendChild(wrapper);
+
+  // Store subFields config on wrapper for collectFormData
+  wrapper.dataset.subFields = JSON.stringify(subFields);
+  wrapper.dataset.fieldId = field.id;
+
+  setTimeout(() => { for (let i = 0; i < minRows; i++) addRepeaterRow(); }, 0);
+}
+
+// Field type → creator function map
+const fieldCreators = {
+  text: createTextField, email: createTextField, tel: createTextField,
+  date: createDateField, textarea: createTextareaField, longtext: createLongtextField,
+  select: createSelectField, radio: createRadioField, checkbox: createCheckboxField,
+  list: createListField, number: createNumberField, currency: createCurrencyField,
+  heading: createHeadingField, hidden: createHiddenField, address: createAddressField,
+  file: createFileField, signature: createSignatureField, repeater: createRepeaterField
+};
+
+// ============================================================
+//  CREATE FIELD (dispatcher)
+// ============================================================
+
 function createField(field) {
   const group = document.createElement('div');
   group.className = 'field-group';
@@ -1954,392 +2351,11 @@ function createField(field) {
     group.appendChild(label);
   }
 
-  switch (field.type) {
-    case 'text': case 'email': case 'tel': {
-      const input = document.createElement('input');
-      input.type = field.type; input.id = field.id; input.name = field.id;
-      input.placeholder = field.placeholder || ''; input.required = field.required || false;
-      group.appendChild(input);
-      break;
-    }
-    case 'date': {
-      const input = document.createElement('input');
-      input.type = 'date'; input.id = field.id; input.name = field.id;
-      input.required = field.required || false;
-      group.appendChild(input);
-      break;
-    }
-    case 'textarea': {
-      const ta = document.createElement('textarea');
-      ta.id = field.id; ta.name = field.id; ta.placeholder = field.placeholder || '';
-      ta.required = field.required || false; ta.rows = 3;
-      group.appendChild(ta);
-      break;
-    }
-    case 'longtext': {
-      const wrapper = document.createElement('div');
-      wrapper.className = 'longtext-wrapper';
-      const ta = document.createElement('textarea');
-      ta.id = field.id; ta.name = field.id; ta.placeholder = field.placeholder || '';
-      ta.required = field.required || false; ta.rows = 6;
-      const maxLen = field.maxLength || 5000;
-      const counter = document.createElement('div');
-      counter.className = 'longtext-counter';
-      counter.textContent = `0 / ${maxLen} characters`;
-      ta.addEventListener('input', () => {
-        const len = ta.value.length;
-        counter.textContent = `${len} / ${maxLen} characters`;
-        counter.style.color = len > maxLen ? 'var(--error)' : '';
-      });
-      wrapper.appendChild(ta);
-      wrapper.appendChild(counter);
-      group.appendChild(wrapper);
-      break;
-    }
-    case 'select': {
-      const select = document.createElement('select');
-      select.id = field.id; select.name = field.id; select.required = field.required || false;
-      for (const opt of (field.options || [])) {
-        const option = document.createElement('option');
-        option.value = opt; option.textContent = opt || '— Select —';
-        select.appendChild(option);
-      }
-      group.appendChild(select);
-      break;
-    }
-    case 'radio': {
-      const rg = document.createElement('div'); rg.className = 'radio-group';
-      rg.setAttribute('role', 'group'); rg.setAttribute('aria-labelledby', `${field.id}_group_label`);
-      for (const opt of (field.options || [])) {
-        const item = document.createElement('div'); item.className = 'radio-item';
-        const input = document.createElement('input');
-        input.type = 'radio'; input.name = field.id; input.value = opt;
-        input.id = `${field.id}_${opt.replace(/\s+/g, '_').toLowerCase()}`;
-        const label = document.createElement('label');
-        label.setAttribute('for', input.id); label.textContent = opt;
-        item.appendChild(input); item.appendChild(label); rg.appendChild(item);
-      }
-      group.appendChild(rg);
-      break;
-    }
-    case 'checkbox': {
-      const cg = document.createElement('div'); cg.className = 'checkbox-group';
-      cg.setAttribute('role', 'group'); cg.setAttribute('aria-labelledby', `${field.id}_group_label`);
-      for (const opt of (field.options || [])) {
-        const item = document.createElement('div'); item.className = 'checkbox-item';
-        const input = document.createElement('input');
-        input.type = 'checkbox'; input.name = field.id; input.value = opt;
-        input.id = `${field.id}_${opt.replace(/\s+/g, '_').toLowerCase()}`;
-        const label = document.createElement('label');
-        label.setAttribute('for', input.id); label.textContent = opt;
-        item.appendChild(input); item.appendChild(label); cg.appendChild(item);
-      }
-      group.appendChild(cg);
-      break;
-    }
-    case 'list': {
-      const wrapper = document.createElement('div');
-      wrapper.className = 'list-entry-wrapper';
-      const itemsContainer = document.createElement('div');
-      itemsContainer.className = 'list-items'; itemsContainer.id = `${field.id}_items`;
-      const countEl = document.createElement('div');
-      countEl.className = 'list-item-count'; countEl.id = `${field.id}_count`; countEl.textContent = '0 items';
+  const creator = fieldCreators[field.type];
+  if (creator) creator(field, group);
 
-      const addBtn = document.createElement('button');
-      addBtn.type = 'button'; addBtn.className = 'btn-add-item';
-      addBtn.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 5v14M5 12h14"/></svg> Add item';
-      addBtn.addEventListener('click', () => {
-        addListItem(field.id, field.placeholder || '', itemsContainer, countEl);
-        const inputs = itemsContainer.querySelectorAll('.list-item-input');
-        inputs[inputs.length - 1].focus();
-      });
-
-      const divider = document.createElement('div');
-      divider.className = 'list-or-divider'; divider.textContent = 'or paste multiple lines';
-
-      const bulkTa = document.createElement('textarea');
-      bulkTa.className = 'list-bulk-textarea'; bulkTa.id = `${field.id}_bulk`;
-      bulkTa.placeholder = 'Paste items here, one per line...'; bulkTa.rows = 3;
-      bulkTa.addEventListener('blur', () => {
-        const lines = bulkTa.value.split('\n').map(l => l.trim()).filter(l => l);
-        if (lines.length > 0) {
-          for (const line of lines) addListItem(field.id, field.placeholder || '', itemsContainer, countEl, line);
-          bulkTa.value = '';
-        }
-      });
-
-      wrapper.appendChild(itemsContainer);
-      wrapper.appendChild(addBtn);
-      wrapper.appendChild(countEl);
-      wrapper.appendChild(divider);
-      wrapper.appendChild(bulkTa);
-      group.appendChild(wrapper);
-      setTimeout(() => addListItem(field.id, field.placeholder || '', itemsContainer, countEl), 0);
-      break;
-    }
-    case 'number': {
-      const input = document.createElement('input');
-      input.type = 'number'; input.id = field.id; input.name = field.id;
-      input.placeholder = field.placeholder || '';
-      input.required = field.required || false;
-      if (field.min !== undefined) input.min = field.min;
-      if (field.max !== undefined) input.max = field.max;
-      if (field.step !== undefined) input.step = field.step;
-      group.appendChild(input);
-      break;
-    }
-    case 'currency': {
-      const wrapper = document.createElement('div');
-      wrapper.className = 'currency-wrapper';
-      const prefix = document.createElement('span');
-      prefix.className = 'currency-prefix';
-      prefix.textContent = field.currency_symbol || '$';
-      const input = document.createElement('input');
-      input.type = 'number'; input.id = field.id; input.name = field.id;
-      input.step = '0.01'; input.min = '0';
-      input.placeholder = field.placeholder || '0.00';
-      input.required = field.required || false;
-      wrapper.appendChild(prefix);
-      wrapper.appendChild(input);
-      group.appendChild(wrapper);
-      break;
-    }
-    case 'heading': {
-      const h = document.createElement('div');
-      h.className = 'field-heading';
-      h.textContent = field.label;
-      group.appendChild(h);
-      if (field.hint) {
-        const hintEl = document.createElement('div');
-        hintEl.className = 'field-heading-hint';
-        hintEl.textContent = field.hint;
-        group.appendChild(hintEl);
-      }
-      return group; // skip the default hint logic below
-    }
-    case 'hidden': {
-      const input = document.createElement('input');
-      input.type = 'hidden'; input.id = field.id; input.name = field.id;
-      input.value = field.default_value || '';
-      group.style.display = 'none';
-      group.appendChild(input);
-      break;
-    }
-    case 'address': {
-      const wrapper = document.createElement('div');
-      wrapper.className = 'address-group';
-      const streetInput = document.createElement('input');
-      streetInput.type = 'text'; streetInput.id = `${field.id}_street`; streetInput.name = `${field.id}_street`;
-      streetInput.placeholder = 'Street address';
-      wrapper.appendChild(streetInput);
-      const row = document.createElement('div');
-      row.className = 'address-row';
-      const cityInput = document.createElement('input');
-      cityInput.type = 'text'; cityInput.id = `${field.id}_city`; cityInput.name = `${field.id}_city`;
-      cityInput.placeholder = 'City';
-      const stateInput = document.createElement('input');
-      stateInput.type = 'text'; stateInput.id = `${field.id}_state`; stateInput.name = `${field.id}_state`;
-      stateInput.placeholder = 'State';
-      const zipInput = document.createElement('input');
-      zipInput.type = 'text'; zipInput.id = `${field.id}_zip`; zipInput.name = `${field.id}_zip`;
-      zipInput.placeholder = 'ZIP code';
-      row.appendChild(cityInput); row.appendChild(stateInput); row.appendChild(zipInput);
-      wrapper.appendChild(row);
-      group.appendChild(wrapper);
-      break;
-    }
-    case 'file': {
-      const wrapper = document.createElement('div');
-      wrapper.className = 'file-upload-wrapper';
-      const fileInput = document.createElement('input');
-      fileInput.type = 'file'; fileInput.id = `${field.id}_input`;
-      fileInput.accept = field.accept || 'image/*';
-      const hiddenInput = document.createElement('input');
-      hiddenInput.type = 'hidden'; hiddenInput.id = field.id;
-      const preview = document.createElement('img');
-      preview.className = 'file-preview'; preview.id = `${field.id}_preview`;
-      const info = document.createElement('div');
-      info.className = 'file-info'; info.id = `${field.id}_info`;
-      const maxMb = field.max_size_mb || 5;
-      fileInput.addEventListener('change', () => {
-        const file = fileInput.files[0];
-        if (!file) { hiddenInput.value = ''; preview.style.display = 'none'; info.textContent = ''; return; }
-        if (file.size > maxMb * 1024 * 1024) {
-          showToast(`File too large (max ${maxMb}MB)`, 'error');
-          fileInput.value = ''; hiddenInput.value = ''; return;
-        }
-        const reader = new FileReader();
-        reader.onload = (e) => {
-          hiddenInput.value = e.target.result;
-          if (file.type.startsWith('image/')) { preview.src = e.target.result; preview.style.display = 'block'; }
-          else { preview.style.display = 'none'; }
-          info.textContent = `${file.name} (${(file.size / 1024).toFixed(1)} KB)`;
-        };
-        reader.readAsDataURL(file);
-      });
-      wrapper.appendChild(fileInput);
-      wrapper.appendChild(preview);
-      wrapper.appendChild(info);
-      wrapper.appendChild(hiddenInput);
-      group.appendChild(wrapper);
-      break;
-    }
-    case 'signature': {
-      const wrapper = document.createElement('div');
-      wrapper.className = 'signature-pad-wrapper';
-      const canvas = document.createElement('canvas');
-      canvas.className = 'signature-canvas'; canvas.id = `${field.id}_canvas`;
-      canvas.width = 400; canvas.height = 150;
-      canvas.setAttribute('aria-label', 'Signature pad \u2014 draw your signature with mouse or touch');
-      const hiddenInput = document.createElement('input');
-      hiddenInput.type = 'hidden'; hiddenInput.id = field.id;
-      let drawing = false;
-      function getPos(e) {
-        const rect = canvas.getBoundingClientRect();
-        const scaleX = canvas.width / rect.width;
-        const scaleY = canvas.height / rect.height;
-        if (e.touches) {
-          return { x: (e.touches[0].clientX - rect.left) * scaleX, y: (e.touches[0].clientY - rect.top) * scaleY };
-        }
-        return { x: (e.clientX - rect.left) * scaleX, y: (e.clientY - rect.top) * scaleY };
-      }
-      const ctx = canvas.getContext('2d');
-      ctx.lineWidth = 2; ctx.lineCap = 'round'; ctx.lineJoin = 'round'; ctx.strokeStyle = '#000';
-      function startDraw(e) { e.preventDefault(); drawing = true; const p = getPos(e); ctx.beginPath(); ctx.moveTo(p.x, p.y); }
-      function moveDraw(e) { if (!drawing) return; e.preventDefault(); const p = getPos(e); ctx.lineTo(p.x, p.y); ctx.stroke(); }
-      function isCanvasBlank(c) {
-        const d = c.getContext('2d').getImageData(0, 0, c.width, c.height).data;
-        return !d.some((val, i) => i % 4 === 3 && val !== 0);
-      }
-      function endDraw() { if (!drawing) return; drawing = false; hiddenInput.value = isCanvasBlank(canvas) ? '' : canvas.toDataURL('image/png'); }
-      canvas.addEventListener('mousedown', startDraw);
-      canvas.addEventListener('mousemove', moveDraw);
-      canvas.addEventListener('mouseup', endDraw);
-      canvas.addEventListener('mouseleave', endDraw);
-      canvas.addEventListener('touchstart', startDraw);
-      canvas.addEventListener('touchmove', moveDraw);
-      canvas.addEventListener('touchend', endDraw);
-      const actions = document.createElement('div');
-      actions.className = 'signature-actions';
-      const clearBtn = document.createElement('button');
-      clearBtn.type = 'button'; clearBtn.className = 'btn-clear-sig'; clearBtn.textContent = 'Clear';
-      clearBtn.addEventListener('click', () => {
-        ctx.clearRect(0, 0, canvas.width, canvas.height);
-        hiddenInput.value = '';
-      });
-      actions.appendChild(clearBtn);
-      wrapper.appendChild(canvas);
-      wrapper.appendChild(actions);
-      wrapper.appendChild(hiddenInput);
-      group.appendChild(wrapper);
-      break;
-    }
-    case 'repeater': {
-      const wrapper = document.createElement('div');
-      wrapper.className = 'repeater-wrapper'; wrapper.id = `${field.id}_repeater`;
-      const rowsContainer = document.createElement('div');
-      rowsContainer.id = `${field.id}_rows`;
-      const minRows = field.min_rows || 1;
-      const maxRows = field.max_rows || 10;
-      const subFields = field.fields || [];
-      let rowCount = 0;
-
-      function addRepeaterRow() {
-        if (rowCount >= maxRows) return;
-        const rowIdx = rowCount++;
-        const row = document.createElement('div');
-        row.className = 'repeater-row'; row.dataset.rowIdx = rowIdx;
-        const header = document.createElement('div');
-        header.className = 'repeater-row-header';
-        const rowLabel = document.createElement('span');
-        rowLabel.textContent = `#${rowIdx + 1}`;
-        const removeBtn = document.createElement('button');
-        removeBtn.type = 'button'; removeBtn.className = 'btn-remove-row'; removeBtn.innerHTML = '&times;';
-        removeBtn.addEventListener('click', () => {
-          if (rowsContainer.children.length <= minRows) return;
-          row.remove();
-          updateRepeaterNumbers();
-          updateAddBtn();
-        });
-        header.appendChild(rowLabel); header.appendChild(removeBtn);
-        const fieldsDiv = document.createElement('div');
-        fieldsDiv.className = 'repeater-row-fields';
-        for (const sf of subFields) {
-          const subId = `${field.id}_r${rowIdx}_${sf.id}`;
-          const fg = document.createElement('div');
-          fg.className = 'field-group';
-          const lbl = document.createElement('label');
-          lbl.className = 'field-label'; lbl.setAttribute('for', subId);
-          lbl.textContent = sf.label;
-          fg.appendChild(lbl);
-          if (sf.type === 'select') {
-            const sel = document.createElement('select');
-            sel.id = subId; sel.name = subId;
-            for (const opt of (sf.options || [])) {
-              const o = document.createElement('option');
-              o.value = opt; o.textContent = opt || '— Select —';
-              sel.appendChild(o);
-            }
-            fg.appendChild(sel);
-          } else if (sf.type === 'currency') {
-            const cw = document.createElement('div'); cw.className = 'currency-wrapper';
-            const pfx = document.createElement('span'); pfx.className = 'currency-prefix';
-            pfx.textContent = sf.currency_symbol || '$';
-            const inp = document.createElement('input');
-            inp.type = 'number'; inp.id = subId; inp.name = subId;
-            inp.step = '0.01'; inp.min = '0'; inp.placeholder = sf.placeholder || '0.00';
-            cw.appendChild(pfx); cw.appendChild(inp);
-            fg.appendChild(cw);
-          } else if (sf.type === 'number') {
-            const inp = document.createElement('input');
-            inp.type = 'number'; inp.id = subId; inp.name = subId;
-            inp.placeholder = sf.placeholder || '';
-            if (sf.min !== undefined) inp.min = sf.min;
-            if (sf.max !== undefined) inp.max = sf.max;
-            if (sf.step !== undefined) inp.step = sf.step;
-            fg.appendChild(inp);
-          } else {
-            const inp = document.createElement('input');
-            inp.type = sf.type === 'email' ? 'email' : sf.type === 'tel' ? 'tel' : 'text';
-            inp.id = subId; inp.name = subId; inp.placeholder = sf.placeholder || '';
-            fg.appendChild(inp);
-          }
-          fieldsDiv.appendChild(fg);
-        }
-        row.appendChild(header);
-        row.appendChild(fieldsDiv);
-        rowsContainer.appendChild(row);
-        updateAddBtn();
-      }
-
-      function updateRepeaterNumbers() {
-        Array.from(rowsContainer.children).forEach((row, i) => {
-          const label = row.querySelector('.repeater-row-header span');
-          if (label) label.textContent = `#${i + 1}`;
-        });
-      }
-
-      const actionsDiv = document.createElement('div');
-      actionsDiv.className = 'repeater-actions';
-      const addBtn = document.createElement('button');
-      addBtn.type = 'button'; addBtn.className = 'btn-add-item';
-      addBtn.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 5v14M5 12h14"/></svg> Add row';
-      addBtn.addEventListener('click', addRepeaterRow);
-      function updateAddBtn() { addBtn.disabled = rowsContainer.children.length >= maxRows; }
-
-      wrapper.appendChild(rowsContainer);
-      actionsDiv.appendChild(addBtn);
-      wrapper.appendChild(actionsDiv);
-      group.appendChild(wrapper);
-
-      // Store subFields config on wrapper for collectFormData
-      wrapper.dataset.subFields = JSON.stringify(subFields);
-      wrapper.dataset.fieldId = field.id;
-
-      setTimeout(() => { for (let i = 0; i < minRows; i++) addRepeaterRow(); }, 0);
-      break;
-    }
-  }
+  // Heading handles its own hint inline
+  if (field.type === 'heading') return group;
 
   if (field.hint) {
     const hint = document.createElement('div');
@@ -2957,22 +2973,10 @@ function postLaunchHook() {
 //  VALIDATE
 // ============================================================
 function validateForm() {
+  if (!currentSchema) return [];
   const missing = [];
-  const data = collectFormData();
-  if (!currentSchema) return missing;
   for (const section of currentSchema.sections) {
-    for (const field of section.fields) {
-      if (field.type === 'heading') continue; // non-input, skip
-      if (!field.required) continue;
-      if (isFieldConditionallyHidden(field.id)) continue;
-      if (field.type === 'address') {
-        const addr = JSON.parse(data[field.id] || '{}');
-        if (!addr.street || !addr.street.trim()) missing.push(field.label);
-      } else {
-        const val = data[field.id];
-        if (!val || val.trim() === '') missing.push(field.label);
-      }
-    }
+    missing.push(...validateSection(section));
   }
   return missing;
 }
@@ -3225,46 +3229,6 @@ document.addEventListener('DOMContentLoaded', () => {
   // Load docs with embedded fallbacks (will reload from GitHub after connect)
   loadDocs();
 });
-
-// Override launchForm to handle GitHub picker entries
-const _originalLaunchForm = launchForm;
-launchForm = async function() {
-  if (selectedSchemaIdx < 0) return;
-  const entry = repoSchemas[selectedSchemaIdx];
-
-  showOverlay('Loading...');
-
-  try {
-    log(`Fetching template: ${entry.templatePath}`, 'info');
-    const templateCode = await ghFetchRaw(entry.templatePath);
-    log(`Template loaded: ${templateCode.length} chars`, 'success');
-
-    currentSchema = entry.schema;
-    currentSchemaName = (entry.schemaPath || '').replace(/^schemas\//, '').replace(/\.json$/, '');
-    currentTemplateCode = templateCode;
-
-    buildForm(currentSchema);
-    document.getElementById('formNavInfo').textContent = `${entry.name} · from ${ghOwner}/${ghRepo}`;
-    document.getElementById('schemaInfoText').innerHTML =
-      `Loaded from GitHub — schema: <strong>${escapeHtml(entry.schemaPath)}</strong> · template: <strong>${escapeHtml(entry.templatePath)}</strong>`;
-
-    if (!pyodideReady) await initPyodide();
-    await loadBaseModule();
-
-    showOverlay('Loading template into Pyodide...');
-    await pyodide.runPythonAsync(currentTemplateCode);
-    log('Template code loaded into Pyodide', 'success');
-
-    document.getElementById('exportBtn').disabled = false;
-    showView('form');
-    postLaunchHook();
-  } catch (err) {
-    log(`Launch failed: ${err.message}`, 'error');
-    showToast(`Failed: ${err.message}`, 'error');
-  } finally {
-    hideOverlay();
-  }
-};
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- **#68** Eliminate monkey-patching — merged duplicate `launchForm` into single definition; inlined `loadDocs()` into `connectRepo` body; removed `_originalLaunchForm` and `_origConnectRepo` variables
- **#69** Unify validation — extracted shared `validateSection(section)` used by both `wizardValidateStep()` and `validateForm()`; fixes radio/checkbox validation divergence
- **#70** Extract `createField` — decomposed 416-line switch into 16 named creator functions + `fieldCreators` dispatch map; dispatcher is now 28 lines
- **#71** Update CLAUDE.md — replaced "touches three places" with complete 6-item checklist

Net result: index.html reduced from 3270 → 3234 lines. All 90 tests pass.

Closes #38, closes #68, closes #69, closes #70, closes #71

## Test plan
- [x] All 90 existing tests pass (`PYTHONPATH=. pytest tests/ -v`)
- [ ] Manual: Open index.html, connect a GitHub repo, launch a form — verify all field types render correctly
- [ ] Manual: Test wizard form — verify step validation works (required radio/checkbox fields caught)
- [ ] Manual: Test full-form validation on submit — verify same fields are caught
- [ ] Manual: Verify docs reload after connecting a GitHub repo (loadDocs in connectRepo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)