### PR TITLE
test: improve test coverage with round-trip assertions and edge cases

### DIFF
--- a/docs/DEVLOG.md
+++ b/docs/DEVLOG.md
@@ -14,6 +14,26 @@
 
 ## Log
 
+### 2026-03-10 — Improve test coverage: round-trip assertions, edge cases, visible_when paths (#40)
+**Issues:** #40
+
+Upgraded the test suite from smoke-only checks to meaningful content verification, added missing coverage paths, and modernized test patterns. Test count: 90 → 95.
+
+**Changes:**
+- **`tests/test_schemas.py`:** Refactored all 19 negative tests from `try/except` + `assert False` to idiomatic `pytest.raises`. Added `_collect_all_ids()` helper and `test_no_duplicate_field_ids` test that validates unique field IDs across all sections (including repeater sub-fields) in every schema.
+- **`tests/test_templates.py`:** Added `_full_text()` helper that reads DOCX bytes back via `python-docx` and extracts all paragraph + table cell text. Added 3 round-trip content tests (`test_onboarding_content_round_trip`, `test_expense_report_content_round_trip`, `test_field_type_demo_content_round_trip`) that verify actual field values appear in generated documents. Added `test_field_type_demo_virtual_path` that exercises the `visible_when` hidden-field path (Virtual attendance mode).
+- **`tests/fixtures/expense-report_sample.json`:** Added 1x1 PNG base64 data URI to `receipt_photo` and `employee_signature` fields.
+- **`tests/fixtures/field-type-demo_sample.json`:** Added 1x1 PNG base64 data URI to `applicant_signature` field.
+- **`tests/fixtures/field-type-demo_virtual_sample.json`:** New fixture with `attendance_mode=Virtual`, `virtual_platform=Zoom`, and empty strings for hidden fields (`venue_address`, `dietary_restrictions`).
+- **`docs/PLAN.md`:** Added implementation plan for issue #40.
+
+**Decisions:**
+- Used a minimal 1x1 PNG (~120 chars) for base64 fixtures to keep files small while exercising the image embed code path
+- Kept existing smoke tests (valid ZIP checks) alongside new content tests — they cover different failure modes
+- `_full_text()` scans both paragraphs and table cells since `table_section()` writes to table cells, not standalone paragraphs
+
+---
+
 ### 2026-03-10 — User profile autofill: inline dropdown with multi-profile support (#73, #74, #75)
 **Issues:** #73, #74, #75
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -5,4 +5,52 @@
 
 ---
 
-*No active plans. Use `/plan` to create one.*
+## Issue #40 — Improve Test Coverage
+
+**Branch:** `feature/40-improve-test-coverage`
+**Status:** In Progress
+
+### Overview
+
+Upgrade the test suite from smoke-only checks to meaningful content verification, add missing coverage paths, and modernize test patterns.
+
+### Tasks (in order)
+
+| # | Task | Files | Depends On |
+|---|------|-------|------------|
+| E | Refactor negative schema tests to `pytest.raises` | `tests/test_schemas.py` | — |
+| B | Add duplicate field ID test across all schemas | `tests/test_schemas.py` | — |
+| C | Add base64 image payloads to fixtures | `tests/fixtures/expense-report_sample.json`, `tests/fixtures/field-type-demo_sample.json` | — |
+| A | Add round-trip DOCX content assertions | `tests/test_templates.py` | C |
+| D | Add `visible_when` hidden-field path test | `tests/fixtures/field-type-demo_virtual_sample.json` (new), `tests/test_templates.py` | A |
+
+### Task Details
+
+**Task E — `pytest.raises` refactor**
+Replace all 19 `try/except` + `assert False` blocks in negative schema tests with idiomatic `with pytest.raises(jsonschema.ValidationError)`. Pure mechanical refactor, no logic changes.
+
+**Task B — Duplicate field ID check**
+Add `_collect_all_ids(schema)` helper that walks sections → fields (including repeater sub-fields). Add `test_no_duplicate_field_ids` that iterates all schema files and asserts `len(ids) == len(set(ids))`.
+
+**Task C — Base64 image fixtures**
+Add a minimal 1x1 PNG data URI to:
+- `expense-report_sample.json`: `receipt_photo` and `employee_signature`
+- `field-type-demo_sample.json`: `applicant_signature`
+
+**Task A — Round-trip content tests**
+Add `_full_text(result)` helper that reads DOCX bytes back via `python-docx` and extracts all paragraph + table cell text. Add 3 new tests:
+- `test_onboarding_content_round_trip` — verify `Alice`, `Johnson`, `Engineering`, `Senior Developer`
+- `test_expense_report_content_round_trip` — verify `Jane Doe`, `Engineering`, `Flight to NYC`
+- `test_field_type_demo_content_round_trip` — verify `Jane Doe`, `Conference`, `In-person`
+
+**Task D — `visible_when` hidden path**
+Create `field-type-demo_virtual_sample.json` with `attendance_mode=Virtual`, `virtual_platform=Zoom`, and empty strings for hidden fields. Add `test_field_type_demo_virtual_path` — assert `Zoom` appears, `100 Convention Center Dr` does not.
+
+### Expected Result
+
+| File | Tests Before | Tests After |
+|------|-------------|------------|
+| `test_templates.py` | 6 | 10 |
+| `test_schemas.py` | 34 | 35 |
+| `test_stencils.py` | 50 | 50 |
+| **Total** | **90** | **95** |

--- a/tests/fixtures/expense-report_sample.json
+++ b/tests/fixtures/expense-report_sample.json
@@ -6,9 +6,9 @@
   "total_amount": "1375.50",
   "line_items": "[{\"description\":\"Flight to NYC\",\"amount\":\"450.00\",\"category\":\"Travel\"},{\"description\":\"Client dinner\",\"amount\":\"125.50\",\"category\":\"Meals\"},{\"description\":\"Hotel 2 nights\",\"amount\":\"800.00\",\"category\":\"Lodging\"}]",
   "item_count": "3",
-  "receipt_photo": "",
+  "receipt_photo": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC",
   "notes": "Business trip for client onsite meeting, March 1-3.",
   "mailing_address": "{\"street\":\"123 Main Street\",\"city\":\"Springfield\",\"state\":\"IL\",\"zip\":\"62701\"}",
-  "employee_signature": "",
+  "employee_signature": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC",
   "manager_signature": ""
 }

--- a/tests/fixtures/field-type-demo_sample.json
+++ b/tests/fixtures/field-type-demo_sample.json
@@ -17,5 +17,5 @@
   "special_requests": "Wheelchair-accessible venue\nLive captioning for keynotes\nRecording permission for all sessions",
   "supporting_doc": "",
   "additional_notes": "Please ensure the venue has adequate parking for 100+ vehicles. We will also need a dedicated registration desk area near the main entrance.",
-  "applicant_signature": ""
+  "applicant_signature": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC"
 }

--- a/tests/fixtures/field-type-demo_virtual_sample.json
+++ b/tests/fixtures/field-type-demo_virtual_sample.json
@@ -1,0 +1,21 @@
+{
+  "form_version": "2.0",
+  "full_name": "John Smith",
+  "email": "john@example.com",
+  "phone": "(555) 987-6543",
+  "event_date": "2026-07-20",
+  "event_type": "Webinar",
+  "event_description": "A virtual workshop on remote collaboration tools and best practices.",
+  "detailed_proposal": "This webinar will cover modern remote work tools, async communication strategies, and virtual team-building exercises.",
+  "attendance_mode": "Virtual",
+  "venue_address": "",
+  "dietary_restrictions": "",
+  "virtual_platform": "Zoom",
+  "budget_amount": "5000.00",
+  "attendee_count": "200",
+  "expense_items": "[{\"item_name\":\"Platform license\",\"quantity\":\"1\",\"unit_cost\":\"2000.00\",\"category\":\"Software\"},{\"item_name\":\"Speaker honorarium\",\"quantity\":\"2\",\"unit_cost\":\"1500.00\",\"category\":\"Speakers\"}]",
+  "special_requests": "Live captioning\nRecording for on-demand access",
+  "supporting_doc": "",
+  "additional_notes": "Ensure breakout room support for interactive sessions.",
+  "applicant_signature": ""
+}

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 import jsonschema
+import pytest
 
 SCHEMAS_DIR = Path(__file__).resolve().parent.parent / "schemas"
 SPEC_PATH = SCHEMAS_DIR / "_schema.spec.json"
@@ -94,21 +95,15 @@ def test_rejects_missing_title():
             {"title": "S", "fields": [{"id": "x", "label": "X", "type": "text"}]}
         ]
     }
-    try:
+    with pytest.raises(jsonschema.ValidationError):
         jsonschema.validate(instance=bad, schema=spec)
-        assert False, "Should have raised ValidationError"
-    except jsonschema.ValidationError:
-        pass
 
 
 def test_rejects_empty_sections():
     spec = _load_spec()
     bad = {"title": "T", "sections": []}
-    try:
+    with pytest.raises(jsonschema.ValidationError):
         jsonschema.validate(instance=bad, schema=spec)
-        assert False, "Should have raised ValidationError"
-    except jsonschema.ValidationError:
-        pass
 
 
 def test_rejects_invalid_field_id():
@@ -122,11 +117,8 @@ def test_rejects_invalid_field_id():
             }
         ],
     }
-    try:
+    with pytest.raises(jsonschema.ValidationError):
         jsonschema.validate(instance=bad, schema=spec)
-        assert False, "Should have raised ValidationError"
-    except jsonschema.ValidationError:
-        pass
 
 
 def test_rejects_unknown_field_type():
@@ -140,11 +132,8 @@ def test_rejects_unknown_field_type():
             }
         ],
     }
-    try:
+    with pytest.raises(jsonschema.ValidationError):
         jsonschema.validate(instance=bad, schema=spec)
-        assert False, "Should have raised ValidationError"
-    except jsonschema.ValidationError:
-        pass
 
 
 def test_rejects_select_without_options():
@@ -158,11 +147,8 @@ def test_rejects_select_without_options():
             }
         ],
     }
-    try:
+    with pytest.raises(jsonschema.ValidationError):
         jsonschema.validate(instance=bad, schema=spec)
-        assert False, "Should have raised ValidationError"
-    except jsonschema.ValidationError:
-        pass
 
 
 def test_rejects_hidden_without_default_value():
@@ -176,11 +162,8 @@ def test_rejects_hidden_without_default_value():
             }
         ],
     }
-    try:
+    with pytest.raises(jsonschema.ValidationError):
         jsonschema.validate(instance=bad, schema=spec)
-        assert False, "Should have raised ValidationError"
-    except jsonschema.ValidationError:
-        pass
 
 
 def test_rejects_repeater_without_fields():
@@ -194,11 +177,8 @@ def test_rejects_repeater_without_fields():
             }
         ],
     }
-    try:
+    with pytest.raises(jsonschema.ValidationError):
         jsonschema.validate(instance=bad, schema=spec)
-        assert False, "Should have raised ValidationError"
-    except jsonschema.ValidationError:
-        pass
 
 
 def test_rejects_options_on_text_field():
@@ -212,11 +192,8 @@ def test_rejects_options_on_text_field():
             }
         ],
     }
-    try:
+    with pytest.raises(jsonschema.ValidationError):
         jsonschema.validate(instance=bad, schema=spec)
-        assert False, "Should have raised ValidationError"
-    except jsonschema.ValidationError:
-        pass
 
 
 def test_rejects_min_on_text_field():
@@ -230,11 +207,8 @@ def test_rejects_min_on_text_field():
             }
         ],
     }
-    try:
+    with pytest.raises(jsonschema.ValidationError):
         jsonschema.validate(instance=bad, schema=spec)
-        assert False, "Should have raised ValidationError"
-    except jsonschema.ValidationError:
-        pass
 
 
 # --- Wizard schema tests ---
@@ -306,11 +280,8 @@ def test_rejects_wizard_non_boolean():
             }
         ],
     }
-    try:
+    with pytest.raises(jsonschema.ValidationError):
         jsonschema.validate(instance=bad, schema=spec)
-        assert False, "Should have raised ValidationError"
-    except jsonschema.ValidationError:
-        pass
 
 
 def test_rejects_step_non_integer():
@@ -327,11 +298,8 @@ def test_rejects_step_non_integer():
             }
         ],
     }
-    try:
+    with pytest.raises(jsonschema.ValidationError):
         jsonschema.validate(instance=bad, schema=spec)
-        assert False, "Should have raised ValidationError"
-    except jsonschema.ValidationError:
-        pass
 
 
 def test_rejects_step_zero():
@@ -348,11 +316,8 @@ def test_rejects_step_zero():
             }
         ],
     }
-    try:
+    with pytest.raises(jsonschema.ValidationError):
         jsonschema.validate(instance=bad, schema=spec)
-        assert False, "Should have raised ValidationError"
-    except jsonschema.ValidationError:
-        pass
 
 
 # --- visible_when tests ---
@@ -405,11 +370,8 @@ def test_rejects_visible_when_missing_field():
             }
         ],
     }
-    try:
+    with pytest.raises(jsonschema.ValidationError):
         jsonschema.validate(instance=bad, schema=spec)
-        assert False, "Should have raised ValidationError"
-    except jsonschema.ValidationError:
-        pass
 
 
 def test_rejects_visible_when_missing_equals():
@@ -431,11 +393,8 @@ def test_rejects_visible_when_missing_equals():
             }
         ],
     }
-    try:
+    with pytest.raises(jsonschema.ValidationError):
         jsonschema.validate(instance=bad, schema=spec)
-        assert False, "Should have raised ValidationError"
-    except jsonschema.ValidationError:
-        pass
 
 
 def test_rejects_visible_when_extra_property():
@@ -461,11 +420,8 @@ def test_rejects_visible_when_extra_property():
             }
         ],
     }
-    try:
+    with pytest.raises(jsonschema.ValidationError):
         jsonschema.validate(instance=bad, schema=spec)
-        assert False, "Should have raised ValidationError"
-    except jsonschema.ValidationError:
-        pass
 
 
 def test_existing_schemas_still_validate_after_visible_when():
@@ -515,11 +471,8 @@ def test_rejects_sample_data_non_object():
     spec = _load_spec()
     schema = _minimal_schema()
     schema["sampleData"] = "not an object"
-    try:
+    with pytest.raises(jsonschema.ValidationError):
         jsonschema.validate(instance=schema, schema=spec)
-        assert False, "Should have raised ValidationError"
-    except jsonschema.ValidationError:
-        pass
 
 
 # ---------------------------------------------------------------------------
@@ -583,11 +536,8 @@ def test_rejects_min_on_select_repeater_field():
             }
         ],
     }
-    try:
+    with pytest.raises(jsonschema.ValidationError):
         jsonschema.validate(instance=bad, schema=spec)
-        assert False, "Should have raised ValidationError"
-    except jsonschema.ValidationError:
-        pass
 
 
 def test_rejects_currency_symbol_on_text_repeater_field():
@@ -616,11 +566,8 @@ def test_rejects_currency_symbol_on_text_repeater_field():
             }
         ],
     }
-    try:
+    with pytest.raises(jsonschema.ValidationError):
         jsonschema.validate(instance=bad, schema=spec)
-        assert False, "Should have raised ValidationError"
-    except jsonschema.ValidationError:
-        pass
 
 
 def test_rejects_max_length_on_number_repeater_field():
@@ -649,11 +596,8 @@ def test_rejects_max_length_on_number_repeater_field():
             }
         ],
     }
-    try:
+    with pytest.raises(jsonschema.ValidationError):
         jsonschema.validate(instance=bad, schema=spec)
-        assert False, "Should have raised ValidationError"
-    except jsonschema.ValidationError:
-        pass
 
 
 def test_repeater_number_field_accepts_min_max():
@@ -685,3 +629,28 @@ def test_repeater_number_field_accepts_min_max():
         ],
     }
     jsonschema.validate(instance=schema, schema=spec)
+
+
+# ---------------------------------------------------------------------------
+#  Duplicate field ID check
+# ---------------------------------------------------------------------------
+
+
+def _collect_all_ids(schema):
+    """Collect all field IDs from a schema, including repeater sub-fields."""
+    ids = []
+    for section in schema.get("sections", []):
+        for field in section.get("fields", []):
+            ids.append(field["id"])
+            for sub in field.get("fields", []):
+                ids.append(sub["id"])
+    return ids
+
+
+def test_no_duplicate_field_ids():
+    """Every schema must have unique field IDs across all sections."""
+    for path in _schema_files():
+        schema = json.loads(path.read_text(encoding="utf-8"))
+        ids = _collect_all_ids(schema)
+        dupes = [i for i in ids if ids.count(i) > 1]
+        assert len(ids) == len(set(ids)), f"Duplicate field IDs in {path.name}: {dupes}"

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -3,7 +3,10 @@
 import json
 import sys
 import importlib.util
+from io import BytesIO
 from pathlib import Path
+
+from docx import Document
 
 FIXTURES = Path(__file__).resolve().parent / "fixtures"
 TEMPLATES = Path(__file__).resolve().parent.parent / "templates"
@@ -17,6 +20,22 @@ def load_template(name):
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     return mod
+
+
+def _full_text(docx_bytes):
+    """Read DOCX bytes back and extract all text from paragraphs and table cells."""
+    doc = Document(BytesIO(docx_bytes))
+    parts = [p.text for p in doc.paragraphs]
+    for table in doc.tables:
+        for row in table.rows:
+            for cell in row.cells:
+                parts.append(cell.text)
+    return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+#  Smoke tests (valid ZIP / non-empty)
+# ---------------------------------------------------------------------------
 
 
 def test_onboarding_generates_valid_docx():
@@ -65,3 +84,58 @@ def test_field_type_demo_with_empty_data():
     result = mod.generate_docx({})
     assert isinstance(result, bytes)
     assert result[:2] == b"PK"
+
+
+# ---------------------------------------------------------------------------
+#  Round-trip content assertions
+# ---------------------------------------------------------------------------
+
+
+def test_onboarding_content_round_trip():
+    data = json.loads((FIXTURES / "onboarding_sample.json").read_text())
+    mod = load_template("onboarding")
+    result = mod.generate_docx(data)
+    text = _full_text(result)
+    assert "Alice" in text
+    assert "Johnson" in text
+    assert "Engineering" in text
+    assert "Senior Developer" in text
+
+
+def test_expense_report_content_round_trip():
+    data = json.loads((FIXTURES / "expense-report_sample.json").read_text())
+    mod = load_template("expense-report")
+    result = mod.generate_docx(data)
+    text = _full_text(result)
+    assert "Jane Doe" in text
+    assert "Engineering" in text
+    assert "Flight to NYC" in text
+    assert "$1,375.50" in text
+
+
+def test_field_type_demo_content_round_trip():
+    data = json.loads((FIXTURES / "field-type-demo_sample.json").read_text())
+    mod = load_template("field-type-demo")
+    result = mod.generate_docx(data)
+    text = _full_text(result)
+    assert "Jane Doe" in text
+    assert "Conference" in text
+    assert "In-person" in text
+    assert "100 Convention Center Dr" in text
+
+
+# ---------------------------------------------------------------------------
+#  visible_when hidden-field path
+# ---------------------------------------------------------------------------
+
+
+def test_field_type_demo_virtual_path():
+    """When attendance_mode is Virtual, venue/dietary are hidden (empty)
+    and virtual_platform appears in the output."""
+    data = json.loads((FIXTURES / "field-type-demo_virtual_sample.json").read_text())
+    mod = load_template("field-type-demo")
+    result = mod.generate_docx(data)
+    text = _full_text(result)
+    assert "Zoom" in text
+    assert "100 Convention Center Dr" not in text
+    assert "Vegetarian" not in text


### PR DESCRIPTION
## Summary
- **Round-trip content assertions** — 3 new tests read back generated DOCX with `python-docx` and verify field values appear in paragraphs and table cells
- **Duplicate field ID check** — new `test_no_duplicate_field_ids` iterates all schemas and asserts unique IDs (including repeater sub-fields)
- **`visible_when` hidden-field path** — new fixture (`field-type-demo_virtual_sample.json`) with `attendance_mode=Virtual` and test verifying hidden fields are absent from output
- **Base64 image fixtures** — 1x1 PNG data URIs added to `expense-report` and `field-type-demo` fixtures to exercise image/signature embed paths
- **`pytest.raises` refactor** — all 19 negative schema tests converted from `try/except` antipattern to idiomatic `pytest.raises`
- Test count: **90 → 95** (all passing)

Closes #40

## Test plan
- [x] `PYTHONPATH=. python -m pytest tests/ -v` — 95 passed
- [x] `ruff check templates/ tests/` — all checks passed
- [x] `ruff format templates/ tests/` — all formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)