### PR TITLE
feat: improve feature discoverability — profiles, autosave, wizard (#110)

### DIFF
--- a/index.html
+++ b/index.html
@@ -248,6 +248,12 @@
   }
   .btn-back:hover { border-color: var(--text-muted); color: var(--text); }
   .form-nav-info { font-size: var(--text-sm); font-family: var(--font-mono); color: var(--text-muted); }
+  .autosave-indicator {
+    display: inline-flex; align-items: center; gap: 4px;
+    font-size: var(--text-xs); font-family: var(--font-mono); color: var(--text-muted);
+    opacity: 0.6; margin-left: auto;
+  }
+  .autosave-indicator svg { opacity: 0.7; }
 
   .form-title { font-size: var(--text-2xl); font-weight: 700; letter-spacing: -0.03em; margin-bottom: 6px; }
   .form-description { color: var(--text-muted); font-size: var(--text-md); margin-bottom: 36px; }
@@ -521,6 +527,9 @@
     padding: 10px 24px; border-radius: var(--radius-md); font-family: var(--font-sans);
     font-size: var(--text-base); font-weight: 600; cursor: pointer; transition: all 0.2s;
   }
+  .wizard-step-count {
+    font-size: var(--text-sm); font-family: var(--font-mono); color: var(--text-muted);
+  }
   .wizard-nav .btn-wizard-back {
     background: transparent; color: var(--text-muted); border: 1px solid var(--border);
   }
@@ -532,6 +541,8 @@
   .wizard-nav .btn-wizard-next:active { transform: scale(0.97); }
   .form-section.wizard-hidden { display: none; }
   .field-group.conditional-hidden { display: none; }
+  .field-group.conditional-visible { animation: fadeInField 0.25s ease-out; }
+  @keyframes fadeInField { from { opacity: 0; transform: translateY(-4px); } to { opacity: 1; transform: translateY(0); } }
 
   /* Field-level validation errors */
   .field-group.field-error input,
@@ -1440,7 +1451,11 @@
         Back to picker
       </button>
       <span class="form-nav-info" id="formNavInfo"></span>
-      <button class="profile-btn" id="profileNavBtn" onclick="toggleProfileNav()" title="Saved Profiles">
+      <span class="autosave-indicator" id="autosaveIndicator" title="Changes are automatically saved to your browser">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M19 21H5a2 2 0 01-2-2V5a2 2 0 012-2h11l5 5v11a2 2 0 01-2 2z"/><polyline points="17 21 17 13 7 13 7 21"/><polyline points="7 3 7 8 15 8"/></svg>
+        Auto-saving
+      </span>
+      <button class="profile-btn" id="profileNavBtn" onclick="toggleProfileNav()" title="Saved profiles — autofill common fields like name, email, and address">
         <svg width="14" height="14"><use href="#icon-person"/></svg>
         Profiles <span class="profile-badge" id="profileBadge" style="display:none">0</span>
       </button>
@@ -2523,6 +2538,11 @@ function buildForm(schema) {
         nav.appendChild(document.createElement('div')); // spacer
       }
 
+      const stepLabel = document.createElement('span');
+      stepLabel.className = 'wizard-step-count';
+      stepLabel.textContent = `Step ${sectionIdx + 1} of ${schema.sections.length}`;
+      nav.appendChild(stepLabel);
+
       if (!isLast) {
         const nextBtn = document.createElement('button');
         nextBtn.type = 'button';
@@ -2573,8 +2593,11 @@ function setupConditionalVisibility(schema) {
         const group = targetEl?.closest('.field-group');
         if (!group) continue;
         if (srcValue === dep.equals) {
+          const wasHidden = group.classList.contains('conditional-hidden');
           group.classList.remove('conditional-hidden');
+          if (wasHidden) group.classList.add('conditional-visible');
         } else {
+          group.classList.remove('conditional-visible');
           group.classList.add('conditional-hidden');
         }
       }


### PR DESCRIPTION
## Summary
- Descriptive tooltip on Profiles button: "Saved profiles — autofill common fields like name, email, and address"
- "Auto-saving" indicator with save icon in form navigation bar
- "Step X of Y" label in wizard navigation between Back/Next buttons
- Fade-in animation for conditional fields when they become visible

Closes #110

## Test plan
- [x] All 104 tests pass
- [ ] Verify Profiles tooltip appears on hover
- [ ] Verify autosave indicator visible in form view
- [ ] Verify "Step X of Y" in wizard navigation
- [ ] Verify conditional fields fade in smoothly

🤖 Generated with [Claude Code](https://claude.com/claude-code)