### PR TITLE
fix: Dev Mode DOCX preview hangs at stencils load (#128)

### DIFF
--- a/index.html
+++ b/index.html
@@ -3090,10 +3090,10 @@ function preloadPyodide() {
     });
 }
 
-async function loadBaseModule() {
+async function loadBaseModule({ silent = false } = {}) {
   if (baseModuleLoaded) return;
 
-  showOverlay('Loading shared template stencils...');
+  if (!silent) showOverlay('Loading shared template stencils...');
   log('Loading stencils.py module...', 'info');
 
   try {
@@ -3136,6 +3136,8 @@ async function loadBaseModule() {
     }
   } catch (err) {
     log('Warning: could not load stencils module: ' + err.message, 'error');
+  } finally {
+    if (!silent) hideOverlay();
   }
 }
 
@@ -6479,7 +6481,8 @@ async function devRunPreview() {
       if (pyodidePreloadPromise) await pyodidePreloadPromise;
       if (!pyodideReady) await initPyodide();
     }
-    await loadBaseModule();
+    badgeText.textContent = 'loading stencils...';
+    await loadBaseModule({ silent: true });
 
     // Load template into Pyodide
     badgeText.textContent = 'loading template...';

--- a/tests/test_dev_mode.py
+++ b/tests/test_dev_mode.py
@@ -822,6 +822,33 @@ def test_devrunpreview_uses_pyodide_topy(index_html: str) -> None:
     assert "pyodide.globals.delete(" in body
 
 
+def test_devrunpreview_calls_loadbasemodule_silent(index_html: str) -> None:
+    """devRunPreview calls loadBaseModule with silent: true to skip overlay."""
+    body = _extract_func(index_html, "devRunPreview")
+    assert "silent: true" in body or "silent:true" in body
+
+
+def test_devrunpreview_shows_stencils_badge(index_html: str) -> None:
+    """devRunPreview updates status badge to 'loading stencils...' during load."""
+    body = _extract_func(index_html, "devRunPreview")
+    assert "loading stencils" in body
+
+
+def test_loadbasemodule_has_silent_param(index_html: str) -> None:
+    """loadBaseModule accepts a silent option to suppress the loading overlay."""
+    body = _extract_func(index_html, "loadBaseModule")
+    assert "silent" in body
+    assert "showOverlay" in body
+    assert "hideOverlay" in body
+
+
+def test_loadbasemodule_hides_overlay_in_finally(index_html: str) -> None:
+    """loadBaseModule calls hideOverlay in a finally block for non-silent mode."""
+    body = _extract_func(index_html, "loadBaseModule")
+    assert "finally" in body
+    assert "hideOverlay" in body
+
+
 def test_dev_new_template_resets_to_starter(index_html: str) -> None:
     """devNewTemplate resets content to DEV_STARTER_TEMPLATE."""
     body = _extract_func(index_html, "devNewTemplate")


### PR DESCRIPTION
## Summary
- `loadBaseModule()` now accepts `{ silent: true }` to skip the full-screen loading overlay
- `devRunPreview()` uses silent mode and shows "loading stencils..." via the status badge instead
- Added `finally` block ensuring `hideOverlay()` is always called in non-silent (user-mode) path
- 4 new tests

## Root Cause
`loadBaseModule()` called `showOverlay()` unconditionally, covering the Dev Mode UI with a full-screen overlay. It also never called `hideOverlay()` itself — user-mode callers handled that, but Dev Mode's `devRunPreview()` didn't.

## Test plan
- [x] 359 tests pass
- [ ] Manual: Preview DOCX in Template Builder — no overlay, badge shows "loading stencils..." → "loading template..." → "success"
- [ ] Manual: User-mode export still shows overlay correctly

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)