### PR TITLE
feat: improve setup view navigation and organization (#137)

### DIFF
--- a/docs/DEVLOG.md
+++ b/docs/DEVLOG.md
@@ -37,17 +37,18 @@ Added 4 tests. Updated 1 existing test (`test_docx_preview_white_background_css`
 
 Implemented five navigation and organization improvements from a design critique:
 
-1. **Docs accordion** — Wrapped four documentation cards (Schema Guide, Template Guide, Field Types, Example) in a collapsible "For form creators" accordion, collapsed by default. Keeps setup view focused on launch paths for form fillers.
+1. **Docs moved to Dev Mode** — Relocated four documentation cards (Schema Guide, Template Guide, Field Types, Example) from the setup view into a new 4th Dev Mode tab ("Docs"). Form creators find reference docs right next to their editors; form fillers see a cleaner setup view.
 2. **Picker auto-scroll** — After successful GitHub connection, `pickerSection` scrolls into view smoothly so users see their forms immediately.
 3. **Back button rename** — Changed "Back to picker" → "Back" in form view for consistency across all launch paths (demo, local, GitHub).
 4. **Double-click launch** — Double-clicking a picker card now selects and launches the form directly, bypassing the two-step select-then-click flow.
 5. **Profile empty state** — Profile dropdown shows "Save a profile to autofill common fields" hint when no profiles exist.
 
-Added 11 new tests to `test_dev_mode.py` covering all changes. Also cleaned up unused `.docs-source-divider` CSS.
+Added 12 new tests to `test_dev_mode.py` covering all changes. Cleaned up unused `.docs-source-divider` and docs accordion CSS.
 
 **Decisions:**
-- Documentation stays on the setup page but collapsed by default — avoids a separate view for a small amount of content
-- "How It Works" card remains visible outside the accordion since it's useful context for all users
+- Docs live in Dev Mode (not setup) because they target form creators, who are the Dev Mode audience
+- "How It Works" card remains on setup since it's useful context for all users
+- Dev Mode now has 4 tabs: Schema Builder, Template Builder, Workspace, Docs
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -1161,25 +1161,6 @@
   }
   .docs-card-body strong { color: var(--text); }
 
-  .docs-accordion {
-    margin-top: 8px; margin-bottom: 24px;
-    border: 1px solid var(--border); border-radius: var(--radius);
-    background: var(--surface); overflow: hidden;
-  }
-  .docs-accordion-header {
-    display: flex; align-items: center; justify-content: space-between;
-    padding: 14px 20px; cursor: pointer; user-select: none;
-    transition: background var(--transition-fast);
-  }
-  .docs-accordion-header:hover, .docs-accordion-header:focus-visible { background: var(--surface-2); }
-  .docs-accordion-header:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
-  .docs-accordion-label {
-    display: inline-flex; align-items: center; gap: 8px;
-    font-size: var(--text-sm); font-family: var(--font-mono); color: var(--text-muted); font-weight: 500;
-  }
-  .docs-accordion-body { padding: 0 16px 16px; }
-  .docs-accordion-body.collapsed { display: none; }
-
   .docs-code {
     background: var(--bg); border: 1px solid var(--border); border-radius: var(--radius-md);
     padding: 16px; margin: 8px 0 12px; overflow-x: auto;
@@ -1913,6 +1894,10 @@
     <svg width="14" height="14" aria-hidden="true"><use href="#icon-folder"/></svg>
     Workspace
   </button>
+  <button type="button" class="dev-nav-tab" id="tab-dev-docs" data-dev-tab="dev-docs" role="tab" aria-selected="false" aria-controls="view-dev-docs" onclick="showDevTab('dev-docs')">
+    <svg width="14" height="14" aria-hidden="true"><use href="#icon-book"/></svg>
+    Docs
+  </button>
 </nav>
 
 <!-- ==================== SETUP VIEW ==================== -->
@@ -2027,77 +2012,6 @@
     └── my-form.py                 ← Python script with generate_docx(data)</pre>
     </div>
 
-    <div class="docs-accordion" id="docsAccordion">
-      <div class="docs-accordion-header" onclick="toggleDocsAccordion()" tabindex="0" role="button" aria-expanded="false" aria-controls="docsAccordionBody" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleDocsAccordion()}">
-        <span class="docs-accordion-label">
-          <svg width="14" height="14" class="icon-inline"><use href="#icon-book"/></svg>
-          For form creators
-        </span>
-        <span class="docs-toggle" id="docsAccordionToggle">&#9654;</span>
-      </div>
-      <div class="docs-accordion-body collapsed" id="docsAccordionBody">
-        <div class="docs-section" id="docsSection">
-
-          <!-- Dynamic doc slots — populated by JS -->
-          <div class="docs-card">
-            <div class="docs-card-header" onclick="toggleDocs('schemaGuide')" tabindex="0" role="button" aria-expanded="false" aria-controls="schemaGuide" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleDocs('schemaGuide')}">
-              <h3>
-                <svg width="15" height="15" class="icon-inline"><use href="#icon-file"/></svg>
-                <span id="schemaGuideTitle">Schema Guide</span>
-              </h3>
-              <span class="docs-toggle" id="schemaGuideToggle">&#9654;</span>
-            </div>
-            <div class="docs-card-body collapsed" id="schemaGuide">
-              <div class="docs-source-badge" id="schemaGuideSource"></div>
-              <div id="schemaGuideContent"><p>Loading...</p></div>
-            </div>
-          </div>
-
-          <div class="docs-card">
-            <div class="docs-card-header" onclick="toggleDocs('templateGuide')" tabindex="0" role="button" aria-expanded="false" aria-controls="templateGuide" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleDocs('templateGuide')}">
-              <h3>
-                <svg width="15" height="15" class="icon-inline"><use href="#icon-code"/></svg>
-                <span id="templateGuideTitle">Template Guide</span>
-              </h3>
-              <span class="docs-toggle" id="templateGuideToggle">&#9654;</span>
-            </div>
-            <div class="docs-card-body collapsed" id="templateGuide">
-              <div class="docs-source-badge" id="templateGuideSource"></div>
-              <div id="templateGuideContent"><p>Loading...</p></div>
-            </div>
-          </div>
-
-          <div class="docs-card">
-            <div class="docs-card-header" onclick="toggleDocs('fieldTypes')" tabindex="0" role="button" aria-expanded="false" aria-controls="fieldTypes" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleDocs('fieldTypes')}">
-              <h3>
-                <svg width="15" height="15" class="icon-inline"><use href="#icon-grid"/></svg>
-                <span id="fieldTypesTitle">Field Types Reference</span>
-              </h3>
-              <span class="docs-toggle" id="fieldTypesToggle">&#9654;</span>
-            </div>
-            <div class="docs-card-body collapsed" id="fieldTypes">
-              <div class="docs-source-badge" id="fieldTypesSource"></div>
-              <div id="fieldTypesContent"><p>Loading...</p></div>
-            </div>
-          </div>
-
-          <div class="docs-card">
-            <div class="docs-card-header" onclick="toggleDocs('exampleSchema')" tabindex="0" role="button" aria-expanded="false" aria-controls="exampleSchema" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleDocs('exampleSchema')}">
-              <h3>
-                <svg width="15" height="15" class="icon-inline"><use href="#icon-bolt"/></svg>
-                <span id="exampleSchemaTitle">Example Schema &amp; Template</span>
-              </h3>
-              <span class="docs-toggle" id="exampleSchemaToggle">&#9654;</span>
-            </div>
-            <div class="docs-card-body collapsed" id="exampleSchema">
-              <div class="docs-source-badge" id="exampleSchemaSource"></div>
-              <div id="exampleSchemaContent"><p>Loading...</p></div>
-            </div>
-          </div>
-
-        </div>
-      </div>
-    </div>
 
     <!-- Picker appears after connect -->
     <div class="picker-section" id="pickerSection" style="display:none;">
@@ -2355,6 +2269,71 @@
   </div>
 </main>
 
+<!-- ==================== DEV: DOCS VIEW ==================== -->
+<main class="view" id="view-dev-docs" role="tabpanel" aria-labelledby="tab-dev-docs">
+  <div class="main-container">
+    <div class="docs-section" id="docsSection">
+
+      <div class="docs-card">
+        <div class="docs-card-header" onclick="toggleDocs('schemaGuide')" tabindex="0" role="button" aria-expanded="false" aria-controls="schemaGuide" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleDocs('schemaGuide')}">
+          <h3>
+            <svg width="15" height="15" class="icon-inline"><use href="#icon-file"/></svg>
+            <span id="schemaGuideTitle">Schema Guide</span>
+          </h3>
+          <span class="docs-toggle" id="schemaGuideToggle">&#9654;</span>
+        </div>
+        <div class="docs-card-body collapsed" id="schemaGuide">
+          <div class="docs-source-badge" id="schemaGuideSource"></div>
+          <div id="schemaGuideContent"><p>Loading...</p></div>
+        </div>
+      </div>
+
+      <div class="docs-card">
+        <div class="docs-card-header" onclick="toggleDocs('templateGuide')" tabindex="0" role="button" aria-expanded="false" aria-controls="templateGuide" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleDocs('templateGuide')}">
+          <h3>
+            <svg width="15" height="15" class="icon-inline"><use href="#icon-code"/></svg>
+            <span id="templateGuideTitle">Template Guide</span>
+          </h3>
+          <span class="docs-toggle" id="templateGuideToggle">&#9654;</span>
+        </div>
+        <div class="docs-card-body collapsed" id="templateGuide">
+          <div class="docs-source-badge" id="templateGuideSource"></div>
+          <div id="templateGuideContent"><p>Loading...</p></div>
+        </div>
+      </div>
+
+      <div class="docs-card">
+        <div class="docs-card-header" onclick="toggleDocs('fieldTypes')" tabindex="0" role="button" aria-expanded="false" aria-controls="fieldTypes" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleDocs('fieldTypes')}">
+          <h3>
+            <svg width="15" height="15" class="icon-inline"><use href="#icon-grid"/></svg>
+            <span id="fieldTypesTitle">Field Types Reference</span>
+          </h3>
+          <span class="docs-toggle" id="fieldTypesToggle">&#9654;</span>
+        </div>
+        <div class="docs-card-body collapsed" id="fieldTypes">
+          <div class="docs-source-badge" id="fieldTypesSource"></div>
+          <div id="fieldTypesContent"><p>Loading...</p></div>
+        </div>
+      </div>
+
+      <div class="docs-card">
+        <div class="docs-card-header" onclick="toggleDocs('exampleSchema')" tabindex="0" role="button" aria-expanded="false" aria-controls="exampleSchema" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleDocs('exampleSchema')}">
+          <h3>
+            <svg width="15" height="15" class="icon-inline"><use href="#icon-bolt"/></svg>
+            <span id="exampleSchemaTitle">Example Schema &amp; Template</span>
+          </h3>
+          <span class="docs-toggle" id="exampleSchemaToggle">&#9654;</span>
+        </div>
+        <div class="docs-card-body collapsed" id="exampleSchema">
+          <div class="docs-source-badge" id="exampleSchemaSource"></div>
+          <div id="exampleSchemaContent"><p>Loading...</p></div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</main>
+
 <!-- GitHub Connect Repo Modal -->
 <div class="gh-connect-modal" id="ghConnectModal" role="dialog" aria-labelledby="ghConnectTitle" aria-modal="true">
   <div class="gh-connect-panel">
@@ -2587,15 +2566,6 @@ function updateProgressStep(stepNum, state) {
 
 function toggleToken() {
   document.getElementById('tokenRow').classList.toggle('hidden');
-}
-
-function toggleDocsAccordion() {
-  const body = document.getElementById('docsAccordionBody');
-  const toggle = document.getElementById('docsAccordionToggle');
-  body.classList.toggle('collapsed');
-  toggle.classList.toggle('open');
-  const header = body.previousElementSibling;
-  header.setAttribute('aria-expanded', !body.classList.contains('collapsed'));
 }
 
 function toggleDocs(id) {
@@ -6045,7 +6015,7 @@ async function toggleDevMode() {
   }
 }
 
-const VALID_DEV_TABS = new Set(['dev-schema', 'dev-template', 'dev-workspace']);
+const VALID_DEV_TABS = new Set(['dev-schema', 'dev-template', 'dev-workspace', 'dev-docs']);
 
 function showDevTab(viewName) {
   if (!VALID_DEV_TABS.has(viewName)) viewName = 'dev-schema';

--- a/tests/test_dev_mode.py
+++ b/tests/test_dev_mode.py
@@ -85,8 +85,8 @@ def test_dev_nav_exists(index_html: str) -> None:
     assert 'class="dev-nav-tab' in index_html
 
 
-def test_dev_nav_has_three_tabs(index_html: str) -> None:
-    assert index_html.count('class="dev-nav-tab') == 3
+def test_dev_nav_has_four_tabs(index_html: str) -> None:
+    assert index_html.count('class="dev-nav-tab') == 4
 
 
 def test_view_dev_schema_exists(index_html: str) -> None:
@@ -1726,35 +1726,45 @@ def test_back_button_label(index_html: str) -> None:
     assert btn_text == "Back", f"Expected 'Back', got '{btn_text}'"
 
 
-def test_docs_accordion_exists(index_html: str) -> None:
-    """Documentation cards should be wrapped in a collapsible accordion."""
-    assert 'id="docsAccordion"' in index_html
-    assert 'id="docsAccordionBody"' in index_html
+def test_dev_docs_tab_exists(index_html: str) -> None:
+    """Dev Mode should have a Docs tab."""
+    assert 'id="tab-dev-docs"' in index_html
+    assert 'data-dev-tab="dev-docs"' in index_html
 
 
-def test_docs_accordion_contains_doc_cards(index_html: str) -> None:
-    """All four doc cards should be children of the accordion body."""
-    # Extract the accordion body content
-    start = index_html.index('id="docsAccordionBody"')
-    # Find docsSection inside it
-    section_start = index_html.index('id="docsSection"', start)
-    assert section_start > start, "docsSection should be inside docsAccordionBody"
+def test_dev_docs_view_exists(index_html: str) -> None:
+    """A dev-docs view panel should exist."""
+    assert 'id="view-dev-docs"' in index_html
+
+
+def test_dev_docs_contains_doc_cards(index_html: str) -> None:
+    """All four doc cards should be inside the dev-docs view."""
+    start = index_html.index('id="view-dev-docs"')
     for doc_id in ["schemaGuide", "templateGuide", "fieldTypes", "exampleSchema"]:
         pos = index_html.index(f'id="{doc_id}"', start)
-        assert pos > start, f"{doc_id} should be inside the accordion"
+        assert pos > start, f"{doc_id} should be inside the dev-docs view"
 
 
-def test_docs_accordion_default_collapsed(index_html: str) -> None:
-    """The docs accordion body should start collapsed."""
-    assert 'class="docs-accordion-body collapsed" id="docsAccordionBody"' in index_html
+def test_dev_docs_in_valid_tabs(index_html: str) -> None:
+    """dev-docs should be in VALID_DEV_TABS."""
+    assert "'dev-docs'" in index_html or '"dev-docs"' in index_html
+    # Check it's in the Set definition
+    assert "dev-docs" in index_html
 
 
-def test_how_it_works_outside_accordion(index_html: str) -> None:
-    """The 'How It Works' card should remain outside the docs accordion."""
-    hiw_pos = index_html.index("how-it-works-card")
-    accordion_pos = index_html.index('id="docsAccordion"')
-    assert hiw_pos < accordion_pos, (
-        "How It Works card should appear before the accordion"
+def test_how_it_works_on_setup(index_html: str) -> None:
+    """The 'How It Works' card should remain on the setup view, not in dev-docs."""
+    setup_start = index_html.index('id="view-setup"')
+    setup_end = index_html.index("<main", setup_start + 1)
+    setup_html = index_html[setup_start:setup_end]
+    assert "how-it-works-card" in setup_html, (
+        "How It Works card should be in setup view"
+    )
+    dev_start = index_html.index('id="view-dev-docs"')
+    dev_end = index_html.index("</main>", dev_start)
+    dev_html = index_html[dev_start:dev_end]
+    assert "how-it-works-card" not in dev_html, (
+        "How It Works card should not be in dev-docs view"
     )
 
 
@@ -1776,15 +1786,12 @@ def test_picker_auto_scroll_on_connect(index_html: str) -> None:
     assert "scrollIntoView" in body, "connectRepo should scroll to picker"
 
 
-def test_toggle_docs_accordion_function(index_html: str) -> None:
-    """toggleDocsAccordion function should exist and toggle the accordion body."""
-    body = _extract_func(index_html, "toggleDocsAccordion")
-    assert "docsAccordionBody" in body
-    assert "docsAccordionToggle" in body
-
-
-def test_docs_accordion_css(index_html: str) -> None:
-    """CSS classes for docs accordion should exist."""
-    assert ".docs-accordion " in index_html or ".docs-accordion{" in index_html
-    assert ".docs-accordion-header" in index_html
-    assert ".docs-accordion-body.collapsed" in index_html
+def test_docs_not_on_setup_view(index_html: str) -> None:
+    """Documentation cards should not be on the setup view."""
+    setup_start = index_html.index('id="view-setup"')
+    # Find the end of setup view (next <main)
+    setup_end = index_html.index("<main", setup_start + 1)
+    setup_html = index_html[setup_start:setup_end]
+    assert 'id="docsSection"' not in setup_html, (
+        "docsSection should not be in the setup view"
+    )


### PR DESCRIPTION
## Summary

- Move four documentation cards (Schema Guide, Template Guide, Field Types, Example) from setup view into a new 4th Dev Mode tab ("Docs") — keeps setup focused on launch paths, puts reference docs next to editors
- Auto-scroll to picker section after successful GitHub repo connection
- Rename "Back to picker" → "Back" for consistency across demo/local/GitHub launch paths
- Add double-click on picker cards for instant form launch (single-click still selects)
- Add empty-state hint ("Save a profile to autofill common fields") to profile dropdown
- Fix wizard preview navigation — Next/Back buttons and step indicator clicks now work in schema builder preview
- Fix `.dev-errors.hidden` CSS rule — error panel no longer shows a persistent red line
- Extract `devUpdateSchemaValidation()` for instant error clearing on keypress (preview still debounces at 300ms)
- Add drag-to-reorder on wizard step indicators in schema builder preview
- Scope add-section (+) buttons to adjacent steps only in wizard preview mode
- Clean up unused `.docs-source-divider` CSS rule

## Test plan

- [x] 20 new tests added to `test_dev_mode.py` (312 → 332 tests in file)
- [x] Full suite passes: 430 passed, 1 skipped
- [ ] Manual: open `index.html`, verify docs are in Dev Mode Docs tab (not setup view)
- [ ] Manual: connect to a GitHub repo, verify picker scrolls into view
- [ ] Manual: launch a form via demo/local/GitHub, verify back button says "Back"
- [ ] Manual: double-click a picker card, verify form launches directly
- [ ] Manual: open profile dropdown with no profiles, verify hint text appears
- [ ] Manual: add `"wizard": true` in schema builder, verify Next/Back/step clicks work in preview
- [ ] Manual: drag wizard step indicators to reorder sections
- [ ] Manual: verify only adjacent (+) buttons show in wizard preview

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)