### PR TITLE
fix: autofill review findings — TypeError, mobile, ARIA (#172)

### DIFF
--- a/index.html
+++ b/index.html
@@ -821,7 +821,7 @@
     margin-left: auto; display: inline-flex; align-items: center; gap: 6px;
     padding: 7px 12px; background: var(--surface-2); border: 1px solid var(--border);
     border-radius: var(--radius-md); color: var(--text-muted); font-family: var(--font-sans);
-    font-size: var(--text-sm); font-weight: 500; cursor: pointer; transition: all 0.2s;
+    font-size: var(--text-sm); font-weight: 500; cursor: pointer; transition: all var(--transition-base);
     position: relative;
   }
   .autofill-btn:hover { border-color: var(--text-muted); color: var(--text); }
@@ -849,13 +849,13 @@
   .autofill-section-header button {
     background: none; border: none; color: var(--accent); cursor: pointer;
     padding: 2px 4px; font-size: var(--text-sm); line-height: 1; border-radius: var(--radius-xs);
-    transition: all 0.15s; display: inline-flex; align-items: center;
+    transition: all var(--transition-fast); display: inline-flex; align-items: center;
   }
   .autofill-section-header button:hover { background: var(--accent-overlay); }
   .autofill-section-divider { border-top: 1px solid var(--border); margin-top: 4px; }
   .autofill-action-item {
     display: flex; align-items: center; gap: 8px;
-    padding: 9px 14px; cursor: pointer; transition: background 0.15s;
+    padding: 9px 14px; cursor: pointer; transition: background var(--transition-fast);
     font-size: var(--text-sm); color: var(--text); font-weight: 400;
   }
   .autofill-action-item:hover { background: var(--surface-2); }
@@ -1086,6 +1086,14 @@
 
   /* --- Mobile (max 600px) --- */
   @media (max-width: 600px) {
+    /* Autofill dropdown: full-width bottom-sheet on mobile */
+    .autofill-dropdown {
+      position: fixed; bottom: 0; left: 0; right: 0; top: auto;
+      min-width: 0; max-width: none; max-height: 70vh; overflow-y: auto;
+      border-radius: var(--radius) var(--radius) 0 0;
+      animation: none;
+    }
+
     /* Header: tighter padding, hide status text */
     .app-header { padding: 10px 12px; }
     .app-header h1 { font-size: 17px; }
@@ -6765,22 +6773,8 @@ function showPresetEditor(idx) {
   }
 }
 
-let _presetDismissListenerAdded = false;
-
 function setupPresets() {
   updatePresetBadge();
-
-  // Global dismiss on click outside (attach once)
-  if (!_presetDismissListenerAdded) {
-    _presetDismissListenerAdded = true;
-    document.addEventListener('mousedown', (e) => {
-      const dd = document.getElementById('presetDropdown');
-      if (dd.style.display === 'none') return;
-      if (dd.contains(e.target)) return;
-      if (e.target.closest('.preset-btn')) return;
-      hidePresetDropdown();
-    });
-  }
 }
 
 // ============================================================
@@ -6827,7 +6821,7 @@ function showAutofillDropdown() {
     profiles.forEach((p, i) => {
       const name = getProfileDisplayName(p);
       const preview = p.email || '';
-      html += `<div class="profile-dropdown-item" data-profile-index="${i}">
+      html += `<div class="profile-dropdown-item" role="menuitem" data-profile-index="${i}">
         <div class="profile-dropdown-item-info">
           <div class="profile-dropdown-item-name">${escapeHtml(name)}</div>
           ${preview ? `<div class="profile-dropdown-item-preview">${escapeHtml(preview)}</div>` : ''}
@@ -6853,7 +6847,7 @@ function showAutofillDropdown() {
   } else {
     presets.forEach((p, i) => {
       const preview = getPresetPreview(p);
-      html += `<div class="preset-dropdown-item" data-preset-index="${i}" tabindex="-1">
+      html += `<div class="preset-dropdown-item" role="menuitem" data-preset-index="${i}" tabindex="-1">
         <div class="preset-dropdown-item-info">
           <div class="preset-dropdown-item-name">${escapeHtml(p.name)}</div>
           ${preview ? `<div class="preset-dropdown-item-preview">${escapeHtml(preview)}</div>` : ''}
@@ -6868,15 +6862,15 @@ function showAutofillDropdown() {
 
   // --- Actions section ---
   html += '<div class="autofill-section-divider"></div>';
-  html += `<div class="autofill-action-item" data-action="sample">
+  html += `<div class="autofill-action-item" role="menuitem" data-action="sample">
     <svg width="14" height="14"><use href="#icon-file-text"/></svg>
     Load Sample Data
   </div>`;
-  html += `<div class="autofill-action-item" data-action="paste">
+  html += `<div class="autofill-action-item" role="menuitem" data-action="paste">
     <svg width="14" height="14"><use href="#icon-clipboard"/></svg>
     Paste Data\u2026
   </div>`;
-  html += `<div class="autofill-action-item" data-action="file">
+  html += `<div class="autofill-action-item" role="menuitem" data-action="file">
     <svg width="14" height="14"><use href="#icon-upload"/></svg>
     Load from File\u2026
   </div>`;

--- a/tests/test_dev_mode.py
+++ b/tests/test_dev_mode.py
@@ -2071,6 +2071,12 @@ def test_autofill_dropdown_functions_exist(index_html: str) -> None:
     assert "function updateAutofillBadge()" in index_html
 
 
+def test_autofill_closes_profile_dropdown(index_html: str) -> None:
+    """showAutofillDropdown closes the field-level profile dropdown."""
+    body = _extract_func(index_html, "showAutofillDropdown")
+    assert "hideProfileDropdown" in body
+
+
 def test_autofill_dropdown_has_sections(index_html: str) -> None:
     """Autofill dropdown renders profiles, presets, and action sections."""
     body = _extract_func(index_html, "showAutofillDropdown")


### PR DESCRIPTION
## Summary
Follow-up fixes from code review of PR #177:

- **TypeError fix:** Remove dead `setupPresets()` dismiss listener that referenced the removed `presetDropdown` element — would throw on every mousedown
- **Mobile:** Add bottom-sheet CSS for `.autofill-dropdown` on narrow viewports (`max-width: 600px`)
- **ARIA:** Add `role="menuitem"` to all autofill dropdown items for screen reader support
- **Design tokens:** Replace hardcoded transition values with `var(--transition-base)` and `var(--transition-fast)`
- **Test:** Add `test_autofill_closes_profile_dropdown` for mutual exclusion behavior

## Test plan
- [x] 473 tests pass (1 new), lint clean

https://claude.ai/code/session_01TMjfs3JkHE4b8BKQEgPADf