### PR TITLE
feat: move connection UI to modal dialog

### DIFF
--- a/docs/DEVLOG.md
+++ b/docs/DEVLOG.md
@@ -14,6 +14,27 @@
 
 ## Log
 
+### 2026-03-15 — Connection UX Moved to Dialog
+
+Moved the GitHub Repository and Local Folder connection cards from the Forms tab into a modal dialog triggered by clicking the header status badge. The Forms tab now shows a clean empty state when not connected and goes straight to the form picker when connected.
+
+- Status badge (`#statusBadge`) changed from `<div>` to `<button>` with chevron indicator
+- New `connect-dialog-overlay` with two-tab switcher (GitHub / Local Folder)
+- Existing connection HTML moved (not duplicated) — all element IDs preserved
+- Empty state card (`#setupEmptyState`) with "Connect a Source" CTA replaces the source-grid
+- Dialog auto-closes on successful connection via `hideConnectDialog()`
+- `devGhDisconnect()` restores the empty state
+- Escape key and backdrop click dismiss the dialog
+- Mobile responsive: bottom-sheet layout on narrow viewports
+- Updated 2 existing tests, added 6 new tests for dialog, tabs, empty state, and status badge
+
+**Decisions:**
+- Moved HTML rather than duplicating to avoid maintaining two copies of input elements
+- Kept `source-grid` and `source-card` CSS classes for potential future reuse
+- Dialog is always available via status badge regardless of current connection state
+
+---
+
 ### 2026-03-15 — Unified Autofill Dropdown (#172)
 **Issues:** #172, #173, #174, #175, #176
 

--- a/index.html
+++ b/index.html
@@ -224,6 +224,64 @@
   .status-dot { width: 7px; height: 7px; border-radius: 50%; background: currentColor; }
   .status-badge.loading .status-dot { animation: pulse 1.2s ease-in-out infinite; }
   @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.3; } }
+  .status-badge { cursor: pointer; }
+  .status-badge:hover { border-color: var(--text-muted); }
+  .status-badge.ready:hover { border-color: var(--success); }
+  .status-chevron { font-size: var(--text-2xs); margin-left: 2px; opacity: 0.6; }
+
+  /* ===== 3b. CONNECT DIALOG ===== */
+  .connect-dialog-overlay {
+    position: fixed; inset: 0; z-index: 1000;
+    background: rgba(0,0,0,0.5); display: none;
+    align-items: flex-start; justify-content: center;
+    padding-top: 80px;
+  }
+  .connect-dialog-overlay.visible { display: flex; }
+  .connect-dialog {
+    background: var(--surface); border: 1px solid var(--border);
+    border-radius: var(--radius); padding: 28px;
+    width: 480px; max-width: 90vw; max-height: 80vh; overflow-y: auto;
+    box-shadow: var(--shadow-xl); animation: dialogIn 0.2s ease;
+  }
+  @keyframes dialogIn { from { opacity: 0; transform: translateY(-8px); } to { opacity: 1; transform: translateY(0); } }
+  .connect-dialog-header {
+    display: flex; align-items: center; justify-content: space-between; margin-bottom: 20px;
+  }
+  .connect-dialog-header h3 { font-size: var(--text-lg); font-weight: 600; margin: 0; }
+  .connect-dialog-close {
+    background: none; border: none; color: var(--text-muted); cursor: pointer;
+    font-size: var(--text-xl); line-height: 1; padding: 4px 8px; border-radius: var(--radius-sm);
+    transition: color var(--transition-fast);
+  }
+  .connect-dialog-close:hover { color: var(--text); }
+  .connect-tabs {
+    display: flex; gap: 4px; margin-bottom: 20px;
+    background: var(--surface-2); border-radius: var(--radius-md); padding: 3px;
+  }
+  .connect-tab {
+    flex: 1; padding: 8px 12px; text-align: center; border: none;
+    background: transparent; color: var(--text-muted); font-family: var(--font-sans);
+    font-size: var(--text-sm); font-weight: 500; border-radius: var(--radius-sm);
+    cursor: pointer; transition: all var(--transition-fast);
+  }
+  .connect-tab:hover { color: var(--text); }
+  .connect-tab.active { background: var(--surface); color: var(--text); box-shadow: var(--shadow-sm); }
+  .connect-tab-content { display: none; }
+  .connect-tab-content.active { display: block; }
+  .connect-dialog-footer { margin-top: 20px; text-align: right; }
+  .connect-dialog-footer .btn-secondary { padding: 8px 16px; }
+  @media (max-width: 600px) {
+    .connect-dialog-overlay { align-items: flex-end; padding-top: 0; }
+    .connect-dialog { width: 100%; max-width: 100%; border-radius: var(--radius) var(--radius) 0 0; }
+  }
+
+  /* ===== 3c. EMPTY STATE ===== */
+  .setup-empty-state {
+    background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius);
+    padding: 48px 28px; text-align: center; margin-bottom: 24px;
+  }
+  .setup-empty-state p { color: var(--text-muted); font-size: var(--text-base); margin-bottom: 20px; line-height: 1.6; }
+  .setup-empty-state .btn-connect { margin: 0 auto; }
 
   /* ===== 4. VIEWS & LAYOUT ===== */
   body {
@@ -2099,12 +2157,106 @@
 <header class="app-header">
   <h1><button type="button" class="h1-home-btn" onclick="showTab('forms')"><span>&#9632;</span> FormForge</button></h1>
   <div class="header-right">
-    <div class="status-badge" id="statusBadge">
+    <button type="button" class="status-badge" id="statusBadge" onclick="showConnectDialog()" title="Connection settings">
       <div class="status-dot" aria-hidden="true"></div>
       <span id="statusText">not connected</span>
-    </div>
+      <span class="status-chevron" aria-hidden="true">&#9662;</span>
+    </button>
   </div>
 </header>
+
+<!-- ==================== CONNECT DIALOG ==================== -->
+<div class="connect-dialog-overlay" id="connectDialogOverlay" onclick="if(event.target===this)hideConnectDialog()">
+  <div class="connect-dialog" role="dialog" aria-label="Connect a source">
+    <div class="connect-dialog-header">
+      <h3>Connect a Source</h3>
+      <button type="button" class="connect-dialog-close" onclick="hideConnectDialog()" aria-label="Close">&times;</button>
+    </div>
+    <div class="connect-tabs">
+      <button type="button" class="connect-tab active" id="connectTabBtnGithub" onclick="switchConnectTab('github')">
+        <svg width="14" height="14" class="icon-inline"><use href="#icon-github"/></svg>
+        GitHub
+      </button>
+      <button type="button" class="connect-tab" id="connectTabBtnLocal" onclick="switchConnectTab('local')">
+        <svg width="14" height="14" class="icon-inline"><use href="#icon-folder"/></svg>
+        Local Folder
+      </button>
+    </div>
+    <!-- GitHub tab -->
+    <div class="connect-tab-content active" id="connectTabGithub">
+      <p class="config-card-description" style="font-size:var(--text-sm);color:var(--text-muted);margin-bottom:16px;line-height:1.5">Connect to a repo with <code style="font-family:var(--font-mono);font-size:var(--text-xs);background:var(--surface-2);padding:2px 5px;border-radius:var(--radius-xs)">schemas/</code> and <code style="font-family:var(--font-mono);font-size:var(--text-xs);background:var(--surface-2);padding:2px 5px;border-radius:var(--radius-xs)">templates/</code> directories.</p>
+      <div class="config-row">
+        <div class="field-grow">
+          <label>Repository</label>
+          <input type="text" id="repoInput" placeholder="myorg/form-templates" spellcheck="false" autocomplete="off">
+        </div>
+        <button type="button" class="btn-connect" id="connectBtn" onclick="connectRepo()">
+          <svg width="16" height="16"><use href="#icon-github"/></svg>
+          Connect
+        </button>
+      </div>
+      <div class="repo-status" id="repoStatus"></div>
+      <div class="token-toggle" onclick="toggleToken()">&#9656; Advanced options (branch, access token)</div>
+      <div class="token-row hidden" id="tokenRow">
+        <div class="config-row">
+          <div class="field-grow branch-input-wrapper">
+            <label>branch (optional)</label>
+            <input type="text" id="branchInput" placeholder="main" spellcheck="false">
+          </div>
+        </div>
+        <div class="config-row" style="margin-top:8px">
+          <div class="field-grow">
+            <label>personal access token</label>
+            <input type="password" id="tokenInput" placeholder="ghp_xxxxxxxxxxxxxxxxxxxx" spellcheck="false" autocomplete="off">
+          </div>
+        </div>
+        <div class="token-hint">Token is only used in-browser and never stored or transmitted elsewhere. Needs <code>repo</code> scope for private repos.</div>
+      </div>
+    </div>
+    <!-- Local Folder tab -->
+    <div class="connect-tab-content" id="connectTabLocal">
+      <p class="config-card-description" style="font-size:var(--text-sm);color:var(--text-muted);margin-bottom:16px;line-height:1.5">Open a folder with <code style="font-family:var(--font-mono);font-size:var(--text-xs);background:var(--surface-2);padding:2px 5px;border-radius:var(--radius-xs)">schemas/</code> and <code style="font-family:var(--font-mono);font-size:var(--text-xs);background:var(--surface-2);padding:2px 5px;border-radius:var(--radius-xs)">templates/</code> directories.</p>
+      <button type="button" class="btn-connect" id="btnOpenFolderSetup" onclick="connectLocalFolder()" style="margin-bottom:12px">
+        <svg width="16" height="16"><use href="#icon-folder"/></svg>
+        Open Folder
+      </button>
+      <div class="local-folder-status" id="localFolderStatus"></div>
+      <div class="token-toggle" onclick="toggleLocalCard()">&#9656; Or load individual files</div>
+      <div class="local-card-body" id="localCardBody" style="display:none">
+        <div class="local-upload-row">
+          <div class="drop-zone" id="schemaDropZone" tabindex="0">
+            <input type="file" id="localSchemaFile" accept=".json" hidden>
+            <div class="drop-zone-icon">
+              <svg width="28" height="28"><use href="#icon-file-upload"/></svg>
+            </div>
+            <div class="drop-zone-label">Form Definition</div>
+            <div class="drop-zone-hint">Drop .json or click</div>
+            <div class="drop-zone-file" id="schemaFileName"></div>
+          </div>
+          <div class="drop-zone" id="templateDropZone" tabindex="0">
+            <input type="file" id="localTemplateFile" accept=".py" hidden>
+            <div class="drop-zone-icon">
+              <svg width="28" height="28"><use href="#icon-file-code"/></svg>
+            </div>
+            <div class="drop-zone-label">Document Template</div>
+            <div class="drop-zone-hint">Drop .py or click</div>
+            <div class="drop-zone-file" id="templateFileName"></div>
+          </div>
+        </div>
+        <div class="local-launch-row">
+          <button type="button" class="btn-connect" id="localLaunchBtn" disabled onclick="launchLocal()">
+            <svg width="16" height="16"><use href="#icon-arrow-right"/></svg>
+            Open Form
+          </button>
+          <span class="local-status" id="localStatus"></span>
+        </div>
+      </div>
+    </div>
+    <div class="connect-dialog-footer">
+      <button type="button" class="btn-secondary" onclick="hideConnectDialog()">Cancel</button>
+    </div>
+  </div>
+</div>
 
 <!-- Primary Navigation -->
 <nav class="dev-nav" id="mainNav" role="tablist" aria-label="Main navigation">
@@ -2157,88 +2309,13 @@
       </div>
     </div>
 
-    <!-- ===== SOURCE CARDS (equal weight) ===== -->
-    <div class="source-grid">
-      <!-- GitHub card -->
-      <div class="config-card source-card">
-        <h3>
-          <svg width="16" height="16" class="icon-inline"><use href="#icon-github"/></svg>
-          GitHub Repository
-        </h3>
-        <p class="config-card-description">Connect to a repo with <code>schemas/</code> and <code>templates/</code> directories. Shared, version-controlled.</p>
-        <div class="config-row">
-          <div class="field-grow">
-            <label>Repository</label>
-            <input type="text" id="repoInput" placeholder="myorg/form-templates" spellcheck="false" autocomplete="off">
-          </div>
-          <button type="button" class="btn-connect" id="connectBtn" onclick="connectRepo()">
-            <svg width="16" height="16"><use href="#icon-github"/></svg>
-            Connect
-          </button>
-        </div>
-        <div class="repo-status" id="repoStatus"></div>
-        <div class="token-toggle" onclick="toggleToken()">&#9656; Advanced options (branch, access token)</div>
-        <div class="token-row hidden" id="tokenRow">
-          <div class="config-row">
-            <div class="field-grow branch-input-wrapper">
-              <label>branch (optional)</label>
-              <input type="text" id="branchInput" placeholder="main" spellcheck="false">
-            </div>
-          </div>
-          <div class="config-row" style="margin-top:8px">
-            <div class="field-grow">
-              <label>personal access token</label>
-              <input type="password" id="tokenInput" placeholder="ghp_xxxxxxxxxxxxxxxxxxxx" spellcheck="false" autocomplete="off">
-            </div>
-          </div>
-          <div class="token-hint">Token is only used in-browser and never stored or transmitted elsewhere. Needs <code>repo</code> scope for private repos.</div>
-        </div>
-      </div>
-
-      <!-- Local Folder card -->
-      <div class="config-card source-card" id="localCard">
-        <h3>
-          <svg width="16" height="16" class="icon-inline"><use href="#icon-folder"/></svg>
-          Local Folder
-        </h3>
-        <p class="config-card-description">Open a folder with <code>schemas/</code> and <code>templates/</code> directories. Private, works offline.</p>
-        <button type="button" class="btn-connect" id="btnOpenFolderSetup" onclick="connectLocalFolder()" style="margin-bottom:12px">
-          <svg width="16" height="16"><use href="#icon-folder"/></svg>
-          Open Folder
-        </button>
-        <div class="local-folder-status" id="localFolderStatus"></div>
-
-        <div class="token-toggle" onclick="toggleLocalCard()">&#9656; Or load individual files</div>
-        <div class="local-card-body" id="localCardBody" style="display:none">
-          <div class="local-upload-row">
-            <div class="drop-zone" id="schemaDropZone" tabindex="0">
-              <input type="file" id="localSchemaFile" accept=".json" hidden>
-              <div class="drop-zone-icon">
-                <svg width="28" height="28"><use href="#icon-file-upload"/></svg>
-              </div>
-              <div class="drop-zone-label">Form Definition</div>
-              <div class="drop-zone-hint">Drop .json or click</div>
-              <div class="drop-zone-file" id="schemaFileName"></div>
-            </div>
-            <div class="drop-zone" id="templateDropZone" tabindex="0">
-              <input type="file" id="localTemplateFile" accept=".py" hidden>
-              <div class="drop-zone-icon">
-                <svg width="28" height="28"><use href="#icon-file-code"/></svg>
-              </div>
-              <div class="drop-zone-label">Document Template</div>
-              <div class="drop-zone-hint">Drop .py or click</div>
-              <div class="drop-zone-file" id="templateFileName"></div>
-            </div>
-          </div>
-          <div class="local-launch-row">
-            <button type="button" class="btn-connect" id="localLaunchBtn" disabled onclick="launchLocal()">
-              <svg width="16" height="16"><use href="#icon-arrow-right"/></svg>
-              Open Form
-            </button>
-            <span class="local-status" id="localStatus"></span>
-          </div>
-        </div>
-      </div>
+    <!-- ===== EMPTY STATE (shown when not connected) ===== -->
+    <div class="setup-empty-state" id="setupEmptyState">
+      <p>No source connected.<br>Connect a GitHub repo or local folder to browse available forms.</p>
+      <button type="button" class="btn-connect" onclick="showConnectDialog()">
+        <svg width="16" height="16"><use href="#icon-link"/></svg>
+        Connect a Source
+      </button>
     </div>
 
     <!-- Picker appears after connecting any source -->
@@ -3589,6 +3666,8 @@ async function connectRepo() {
     devGhFetchBranches();
     updateGitToolbar();
 
+    hideConnectDialog();
+    document.getElementById('setupEmptyState').style.display = 'none';
     renderPicker();
     document.getElementById('pickerSection').scrollIntoView({ behavior: 'smooth', block: 'start' });
 
@@ -3608,6 +3687,7 @@ function renderPicker() {
   const section = document.getElementById('pickerSection');
   const grid = document.getElementById('pickerGrid');
   section.style.display = 'block';
+  document.getElementById('setupEmptyState').style.display = 'none';
   grid.innerHTML = '';
   selectedSchemaIdx = -1;
   document.getElementById('launchBtn').disabled = true;
@@ -9482,6 +9562,8 @@ async function connectLocalFolder() {
     document.getElementById('statusBadge').className = 'status-badge ready';
     document.getElementById('statusText').textContent = `local: ${workspaceHandle.name}`;
 
+    hideConnectDialog();
+    document.getElementById('setupEmptyState').style.display = 'none';
     if (repoSchemas.length > 0) {
       renderPicker();
       document.getElementById('pickerSection').scrollIntoView({ behavior: 'smooth', block: 'start' });
@@ -10136,6 +10218,7 @@ function devGhDisconnect() {
   document.getElementById('statusBadge').className = 'status-badge';
   document.getElementById('statusText').textContent = 'not connected';
   document.getElementById('pickerSection').style.display = 'none';
+  document.getElementById('setupEmptyState').style.display = '';
 
   // Reset UI
   devGhHideCommitPanel();
@@ -10143,6 +10226,30 @@ function devGhDisconnect() {
   updateGitToolbar();
 
   showToast('Disconnected from GitHub repo');
+}
+
+// ============================================================
+//  CONNECT DIALOG
+// ============================================================
+function showConnectDialog() {
+  document.getElementById('connectDialogOverlay').classList.add('visible');
+  document.addEventListener('keydown', connectDialogKeyHandler);
+}
+
+function hideConnectDialog() {
+  document.getElementById('connectDialogOverlay').classList.remove('visible');
+  document.removeEventListener('keydown', connectDialogKeyHandler);
+}
+
+function connectDialogKeyHandler(e) {
+  if (e.key === 'Escape') { hideConnectDialog(); e.stopPropagation(); }
+}
+
+function switchConnectTab(tab) {
+  document.getElementById('connectTabBtnGithub').classList.toggle('active', tab === 'github');
+  document.getElementById('connectTabBtnLocal').classList.toggle('active', tab === 'local');
+  document.getElementById('connectTabGithub').classList.toggle('active', tab === 'github');
+  document.getElementById('connectTabLocal').classList.toggle('active', tab === 'local');
 }
 
 // ============================================================

--- a/tests/test_dev_mode.py
+++ b/tests/test_dev_mode.py
@@ -121,9 +121,10 @@ def test_no_dev_mode_variable(index_html: str) -> None:
     assert "let devMode" not in index_html
 
 
-def test_source_grid_exists(index_html: str) -> None:
-    """Source grid CSS class should be defined."""
-    assert ".source-grid" in index_html
+def test_connect_dialog_exists(index_html: str) -> None:
+    """Connection dialog overlay and panel should exist."""
+    assert 'id="connectDialogOverlay"' in index_html
+    assert "connect-dialog" in index_html
 
 
 def test_connect_local_folder_exists(index_html: str) -> None:
@@ -1568,14 +1569,14 @@ def test_profile_empty_state_hint(index_html: str) -> None:
     assert "Save a profile to autofill common fields" in index_html
 
 
-def test_picker_after_source_grid(index_html: str) -> None:
-    """Picker section should appear after the source grid in setup view."""
+def test_picker_after_empty_state(index_html: str) -> None:
+    """Picker section should appear after the empty state in setup view."""
     setup_start = index_html.index('id="view-setup"')
     setup_end = index_html.index("<main", setup_start + 1)
     setup_html = index_html[setup_start:setup_end]
-    grid_pos = setup_html.index("source-grid")
+    empty_pos = setup_html.index('id="setupEmptyState"')
     picker_pos = setup_html.index('id="pickerSection"')
-    assert picker_pos > grid_pos, "Picker section should appear after source grid"
+    assert picker_pos > empty_pos, "Picker section should appear after empty state"
 
 
 def test_local_files_collapsed_by_default(index_html: str) -> None:
@@ -2276,3 +2277,54 @@ def test_bundle_import_updates_editors(index_html: str) -> None:
 def test_bundle_toast_has_action_css(index_html: str) -> None:
     """Toast action link CSS exists for download action."""
     assert ".toast-action" in index_html
+
+
+# ============================================================
+#  Connection Dialog UX
+# ============================================================
+
+
+def test_connect_dialog_has_tabs(index_html: str) -> None:
+    """Connect dialog should have GitHub and Local Folder tabs."""
+    assert 'id="connectTabBtnGithub"' in index_html
+    assert 'id="connectTabBtnLocal"' in index_html
+    assert 'id="connectTabGithub"' in index_html
+    assert 'id="connectTabLocal"' in index_html
+
+
+def test_status_badge_is_button(index_html: str) -> None:
+    """Status badge should be a clickable button element."""
+    start = index_html.index('id="statusBadge"')
+    tag_start = index_html.rfind("<", 0, start)
+    tag = index_html[tag_start : start + 20]
+    assert "<button" in tag, "Status badge should be a <button> element"
+    assert "showConnectDialog()" in index_html
+
+
+def test_empty_state_exists(index_html: str) -> None:
+    """Setup view should have an empty state with Connect a Source button."""
+    assert 'id="setupEmptyState"' in index_html
+    setup_start = index_html.index('id="view-setup"')
+    setup_end = index_html.index("<main", setup_start + 1)
+    setup_html = index_html[setup_start:setup_end]
+    assert "setupEmptyState" in setup_html
+    assert "Connect a Source" in setup_html
+
+
+def test_connect_dialog_functions_exist(index_html: str) -> None:
+    """showConnectDialog, hideConnectDialog, switchConnectTab should exist."""
+    assert "function showConnectDialog()" in index_html
+    assert "function hideConnectDialog()" in index_html
+    assert "function switchConnectTab(" in index_html
+
+
+def test_connect_repo_hides_dialog(index_html: str) -> None:
+    """connectRepo should hide the connect dialog on success."""
+    body = _extract_func(index_html, "connectRepo")
+    assert "hideConnectDialog()" in body
+
+
+def test_disconnect_shows_empty_state(index_html: str) -> None:
+    """devGhDisconnect should show the empty state after disconnecting."""
+    body = _extract_func(index_html, "devGhDisconnect")
+    assert "setupEmptyState" in body


### PR DESCRIPTION
## Summary
- Moved GitHub Repository and Local Folder connection cards from the Forms tab into a modal dialog triggered by clicking the header status badge
- Forms tab now shows a clean empty state with "Connect a Source" CTA when not connected, and goes straight to the form picker when connected
- Status badge changed from `<div>` to clickable `<button>` with chevron indicator

## Changes
- **Dialog overlay** with two-tab switcher (GitHub / Local Folder) — existing HTML moved, not duplicated, so all element IDs and event handlers are preserved
- **Empty state card** (`#setupEmptyState`) replaces the old `source-grid` in the Forms tab
- **New JS functions:** `showConnectDialog()`, `hideConnectDialog()`, `switchConnectTab()`
- **Updated functions:** `connectRepo()`, `connectLocalFolder()`, `renderPicker()`, `devGhDisconnect()` to manage dialog/empty state visibility
- Escape key and backdrop click dismiss the dialog
- Mobile responsive: bottom-sheet layout on narrow viewports

## Test plan
- [x] All 479 existing tests pass
- [x] 2 tests updated for new structure, 6 new tests added
- [x] Lint clean (`ruff check` + `ruff format`)
- [ ] Manual: fresh load shows hero + empty state with CTA
- [ ] Manual: clicking status badge or CTA opens dialog with GitHub/Local tabs
- [ ] Manual: successful connection closes dialog, shows picker
- [ ] Manual: disconnect restores empty state
- [ ] Manual: Escape key and backdrop click close dialog

https://claude.ai/code/session_01TMjfs3JkHE4b8BKQEgPADf