### PR TITLE
Move disconnect to source card, swap demo with open form button

### DIFF
--- a/docs/DEVLOG.md
+++ b/docs/DEVLOG.md
@@ -18,9 +18,9 @@
 
 Three UX improvements to the Forms tab picker experience:
 
-- **Hide demo button when connected** — "Try the demo form" button is now hidden when a content source is connected and restored on disconnect.
-- **Disconnect action** — Added a "Disconnect" button in the picker header so users can switch sources without refreshing the page. Works for both GitHub and local folder sources.
-- **Accessible "Open Form" action** — Moved "Open Selected Form" button to a sticky picker header (stays visible while scrolling). Added inline "Open Form" button on each selected card for quick access. Double-click and Enter on cards still work.
+- **Demo → Open swap** — "Try the demo form" button swaps to "Open Selected Form" in the same hero position when a source is connected. Restored on disconnect.
+- **Disconnect on source card** — The "Connect a Source" card transforms when connected: shows source name, form count, a "Change Source" button, and a "Disconnect" button in the upper-right corner.
+- **Inline Open Form** — Each picker card shows an "Open Form" button when selected. Double-click and Enter on cards still work.
 
 Refactored `devGhDisconnect()` into a unified `disconnectSource()` that handles both GitHub and local folder cleanup (clears file polling, workspace handle, and base module cache).
 

--- a/index.html
+++ b/index.html
@@ -348,19 +348,16 @@
 
   /* ===== 6. PICKER GRID ===== */
   .picker-section { margin-top: 32px; }
-  .picker-header {
-    display: flex; align-items: center; justify-content: space-between; margin-bottom: 16px;
-    position: sticky; top: 0; z-index: 10; background: var(--bg); padding: 8px 0;
-  }
-  .picker-header h3 { font-size: var(--text-lg); font-weight: 600; margin: 0; }
-  .picker-header-actions { display: flex; align-items: center; gap: 10px; }
-  .btn-disconnect {
+  .picker-section h3 { font-size: var(--text-lg); font-weight: 600; margin-bottom: 16px; }
+  .setup-empty-state { position: relative; }
+  .source-disconnect {
+    position: absolute; top: 12px; right: 12px;
     display: inline-flex; align-items: center; gap: 6px;
     font-size: var(--text-xs); font-family: var(--font-mono); color: var(--text-muted);
     background: none; border: 1px solid var(--border); border-radius: var(--radius-sm);
     padding: 5px 12px; cursor: pointer; transition: all var(--transition-fast);
   }
-  .btn-disconnect:hover { color: var(--error); border-color: var(--error); background: var(--error-subtle); }
+  .source-disconnect:hover { color: var(--error); border-color: var(--error); background: var(--error-subtle); }
   .picker-grid {
     display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: 16px;
   }
@@ -2325,37 +2322,42 @@
       <h2>Forms that build documents</h2>
       <p>Fill out a form, get a formatted DOCX — all in your browser. No servers, no accounts.</p>
       <div class="demo-btn-wrapper" id="demoBtnWrapper">
-        <button type="button" class="btn-primary btn-demo-primary" onclick="launchDemo()">
+        <button type="button" class="btn-primary btn-demo-primary" id="demoBtnAction" onclick="launchDemo()">
           <svg width="15" height="15"><use href="#icon-play"/></svg>
           Try the demo form
+        </button>
+        <button type="button" class="btn-primary btn-demo-primary" id="launchBtn" style="display:none;" disabled onclick="launchForm()">
+          <svg width="15" height="15"><use href="#icon-arrow-right"/></svg>
+          Open Selected Form
         </button>
       </div>
     </div>
 
-    <!-- ===== EMPTY STATE (shown when not connected) ===== -->
+    <!-- ===== SOURCE CARD (connect prompt or connected info) ===== -->
     <div class="setup-empty-state" id="setupEmptyState">
-      <p>No source connected.<br>Connect a GitHub repo or local folder to browse available forms.</p>
-      <button type="button" class="btn-connect" onclick="showConnectDialog()">
-        <svg width="16" height="16"><use href="#icon-link"/></svg>
-        Connect a Source
+      <button type="button" class="btn-disconnect source-disconnect" id="sourceDisconnectBtn" onclick="disconnectSource()" title="Disconnect source" style="display:none;">
+        <svg width="12" height="12"><use href="#icon-unlink"/></svg>
+        Disconnect
       </button>
+      <div id="sourcePrompt">
+        <p>No source connected.<br>Connect a GitHub repo or local folder to browse available forms.</p>
+        <button type="button" class="btn-connect" onclick="showConnectDialog()">
+          <svg width="16" height="16"><use href="#icon-link"/></svg>
+          Connect a Source
+        </button>
+      </div>
+      <div id="sourceConnectedInfo" style="display:none;">
+        <p id="sourceConnectedLabel"></p>
+        <button type="button" class="btn-connect" onclick="showConnectDialog()">
+          <svg width="16" height="16"><use href="#icon-refresh"/></svg>
+          Change Source
+        </button>
+      </div>
     </div>
 
     <!-- Picker appears after connecting any source -->
     <div class="picker-section" id="pickerSection" style="display:none;">
-      <div class="picker-header">
-        <h3>Choose a Form</h3>
-        <div class="picker-header-actions">
-          <button type="button" class="btn-primary" id="launchBtn" disabled onclick="launchForm()">
-            <svg width="16" height="16"><use href="#icon-arrow-right"/></svg>
-            Open Selected Form
-          </button>
-          <button type="button" class="btn-disconnect" onclick="disconnectSource()" title="Disconnect source">
-            <svg width="12" height="12"><use href="#icon-unlink"/></svg>
-            Disconnect
-          </button>
-        </div>
-      </div>
+      <h3>Choose a Form</h3>
       <div class="picker-grid" id="pickerGrid"></div>
     </div>
   </div>
@@ -3739,11 +3741,26 @@ function renderPicker() {
   const section = document.getElementById('pickerSection');
   const grid = document.getElementById('pickerGrid');
   section.style.display = 'block';
-  document.getElementById('setupEmptyState').style.display = 'none';
-  document.getElementById('demoBtnWrapper').style.display = 'none';
+
+  // Transform source card: show connected info + disconnect, hide connect prompt
+  document.getElementById('sourcePrompt').style.display = 'none';
+  document.getElementById('sourceConnectedInfo').style.display = '';
+  document.getElementById('sourceDisconnectBtn').style.display = '';
+  const label = contentSourceType === 'github'
+    ? `Connected to <strong>${escapeHtml(ghOwner + '/' + ghRepo)}</strong>`
+    : contentSourceType === 'local'
+    ? `Connected to <strong>${escapeHtml(workspaceHandle ? workspaceHandle.name : 'local folder')}</strong>`
+    : 'Source connected';
+  document.getElementById('sourceConnectedLabel').innerHTML = label + `<br><span style="color:var(--text-muted);font-size:var(--text-sm)">${repoSchemas.length} form${repoSchemas.length !== 1 ? 's' : ''} available</span>`;
+
+  // Swap demo button → open selected form button
+  document.getElementById('demoBtnAction').style.display = 'none';
+  const launchBtn = document.getElementById('launchBtn');
+  launchBtn.style.display = '';
+  launchBtn.disabled = true;
+
   grid.innerHTML = '';
   selectedSchemaIdx = -1;
-  document.getElementById('launchBtn').disabled = true;
 
   if (repoSchemas.length === 0) {
     grid.innerHTML = '<div class="picker-empty">No schemas found in this repository.</div>';
@@ -10289,8 +10306,15 @@ function disconnectSource() {
   document.getElementById('statusBadge').className = 'status-badge';
   document.getElementById('statusText').textContent = 'not connected';
   document.getElementById('pickerSection').style.display = 'none';
-  document.getElementById('setupEmptyState').style.display = '';
-  document.getElementById('demoBtnWrapper').style.display = '';
+
+  // Restore source card to connect prompt
+  document.getElementById('sourcePrompt').style.display = '';
+  document.getElementById('sourceConnectedInfo').style.display = 'none';
+  document.getElementById('sourceDisconnectBtn').style.display = 'none';
+
+  // Restore demo button, hide open button
+  document.getElementById('demoBtnAction').style.display = '';
+  document.getElementById('launchBtn').style.display = 'none';
 
   // Reset UI
   devGhHideCommitPanel();

--- a/tests/test_dev_mode.py
+++ b/tests/test_dev_mode.py
@@ -2321,10 +2321,10 @@ def test_connect_repo_hides_dialog(index_html: str) -> None:
     assert "hideConnectDialog()" in body
 
 
-def test_disconnect_shows_empty_state(index_html: str) -> None:
-    """disconnectSource should show the empty state after disconnecting."""
+def test_disconnect_shows_source_prompt(index_html: str) -> None:
+    """disconnectSource should restore the source prompt after disconnecting."""
     body = _extract_func(index_html, "disconnectSource")
-    assert "setupEmptyState" in body
+    assert "sourcePrompt" in body
 
 
 # --- Forms Tab UX (#185) ---
@@ -2335,22 +2335,31 @@ def test_demo_button_has_wrapper_id(index_html: str) -> None:
     assert 'id="demoBtnWrapper"' in index_html
 
 
-def test_demo_button_hidden_when_connected(index_html: str) -> None:
-    """renderPicker hides the demo button wrapper."""
+def test_demo_button_swapped_when_connected(index_html: str) -> None:
+    """renderPicker hides the demo button and shows the open button."""
     body = _extract_func(index_html, "renderPicker")
-    assert "demoBtnWrapper" in body
+    assert "demoBtnAction" in body
+    assert "launchBtn" in body
 
 
 def test_demo_button_restored_on_disconnect(index_html: str) -> None:
-    """disconnectSource restores demo button visibility."""
+    """disconnectSource restores demo button and hides open button."""
     body = _extract_func(index_html, "disconnectSource")
-    assert "demoBtnWrapper" in body
+    assert "demoBtnAction" in body
+    assert "launchBtn" in body
 
 
-def test_disconnect_button_in_picker(index_html: str) -> None:
-    """Picker section has a disconnect button."""
-    assert 'class="btn-disconnect"' in index_html
+def test_disconnect_button_on_source_card(index_html: str) -> None:
+    """Source card has a disconnect button in upper-right corner."""
+    assert "source-disconnect" in index_html
     assert "disconnectSource()" in index_html
+
+
+def test_source_card_shows_connected_info(index_html: str) -> None:
+    """renderPicker shows connected info and disconnect on the source card."""
+    body = _extract_func(index_html, "renderPicker")
+    assert "sourceConnectedInfo" in body
+    assert "sourceDisconnectBtn" in body
 
 
 def test_picker_cards_have_open_button(index_html: str) -> None:
@@ -2366,7 +2375,7 @@ def test_open_button_visible_only_when_selected(index_html: str) -> None:
     assert ".picker-card.selected .btn-card-open { display: inline-flex" in index_html
 
 
-def test_picker_header_is_sticky(index_html: str) -> None:
-    """Picker header uses sticky positioning for scroll accessibility."""
-    assert "position: sticky" in index_html
-    assert "picker-header" in index_html
+def test_open_selected_form_replaces_demo(index_html: str) -> None:
+    """Open Selected Form button lives in the demo-btn-wrapper alongside the demo button."""
+    assert 'id="launchBtn"' in index_html
+    assert 'id="demoBtnAction"' in index_html


### PR DESCRIPTION
## Summary
Follow-up to #186 — repositions UI elements per feedback:

- **Disconnect button** moved from picker header to the source card's upper-right corner. The "Connect a Source" card now transforms when connected: shows source name, form count, "Change Source" button, and "Disconnect" button.
- **"Open Selected Form"** replaces "Try the demo form" in the same hero position when a source is connected. Swaps back on disconnect.
- Inline "Open Form" button on selected picker cards retained from v1.

Closes #185

## Test plan
- [x] 487 tests pass (10 new/updated for #185 v2)
- [ ] Manual: connect GitHub repo → verify source card shows repo name, form count, Disconnect in upper-right, and "Open Selected Form" replaces demo button
- [ ] Manual: select a form → verify "Open Selected Form" enables and inline "Open Form" appears on card
- [ ] Manual: click Disconnect → verify demo button returns, source card returns to connect prompt
- [ ] Manual: connect local folder → verify same behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)