### PR TITLE
Fix: disconnect button invisible when source connected

### DIFF
--- a/index.html
+++ b/index.html
@@ -3721,7 +3721,6 @@ async function connectRepo() {
     loadDocs();
 
     hideConnectDialog();
-    document.getElementById('setupEmptyState').style.display = 'none';
     renderPicker();
     document.getElementById('pickerSection').scrollIntoView({ behavior: 'smooth', block: 'start' });
 
@@ -9644,7 +9643,6 @@ async function connectLocalFolder() {
     document.getElementById('statusText').textContent = `local: ${workspaceHandle.name}`;
 
     hideConnectDialog();
-    document.getElementById('setupEmptyState').style.display = 'none';
     if (repoSchemas.length > 0) {
       renderPicker();
       document.getElementById('pickerSection').scrollIntoView({ behavior: 'smooth', block: 'start' });


### PR DESCRIPTION
## Summary
- `connectRepo()` and `connectLocalFolder()` were hiding the entire `setupEmptyState` card (`display: none`) before `renderPicker()` could transform its inner contents — so the disconnect button, connected info, and "Change Source" button were all invisible.
- Removed the two `setupEmptyState` hide lines. The source card now stays visible, with `renderPicker()` swapping its content between connect prompt and connected info.

Follow-up to #187 / #185

## Test plan
- [x] 487 tests pass
- [ ] Manual: connect a GitHub repo → verify source card shows repo name, form count, Disconnect button in upper-right
- [ ] Manual: connect a local folder → same verification
- [ ] Manual: disconnect → verify card returns to "Connect a Source" prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)