### PR TITLE
Move disconnect to connect dialog, hide source card when connected

### DIFF
--- a/docs/DEVLOG.md
+++ b/docs/DEVLOG.md
@@ -16,11 +16,12 @@
 
 ### 2026-03-15 — Forms Tab UX Improvements (#185)
 
-Three UX improvements to the Forms tab picker experience:
+UX improvements to the Forms tab and connection management:
 
 - **Demo → Open swap** — "Try the demo form" button swaps to "Open Selected Form" in the same hero position when a source is connected. Restored on disconnect.
-- **Disconnect on source card** — The "Connect a Source" card transforms when connected: shows source name, form count, a "Change Source" button, and a "Disconnect" button in the upper-right corner.
+- **Disconnect moved to connect dialog** — When a source is connected, the connect dialog (opened via the status badge) shows a status banner with the connected source name, form count, and a Disconnect button. The source card on the Forms tab is hidden entirely when connected.
 - **Inline Open Form** — Each picker card shows an "Open Form" button when selected. Double-click and Enter on cards still work.
+- **Clean Forms tab** — When connected, the Forms tab shows only the hero area and picker grid. The "Connect a Source" empty state card reappears on disconnect.
 
 Refactored `devGhDisconnect()` into a unified `disconnectSource()` that handles both GitHub and local folder cleanup (clears file polling, workspace handle, and base module cache).
 

--- a/index.html
+++ b/index.html
@@ -254,6 +254,26 @@
     transition: color var(--transition-fast);
   }
   .connect-dialog-close:hover { color: var(--text); }
+  .connect-dialog-status {
+    display: none; align-items: center; gap: 10px;
+    padding: 10px 14px; margin-bottom: 16px;
+    background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius-md);
+  }
+  .connect-dialog-status.visible { display: flex; }
+  .connect-dialog-status .status-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--success); flex-shrink: 0; }
+  .connect-dialog-status-info { flex: 1; min-width: 0; }
+  .connect-dialog-status-label {
+    font-size: var(--text-sm); font-weight: 500; color: var(--text);
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  }
+  .connect-dialog-status-meta { font-size: var(--text-xs); font-family: var(--font-mono); color: var(--text-muted); margin-top: 2px; }
+  .connect-dialog-status .btn-disconnect {
+    display: inline-flex; align-items: center; gap: 6px;
+    font-size: var(--text-xs); font-family: var(--font-mono); color: var(--text-muted);
+    background: none; border: 1px solid var(--border); border-radius: var(--radius-sm);
+    padding: 5px 12px; cursor: pointer; transition: all var(--transition-fast); flex-shrink: 0;
+  }
+  .connect-dialog-status .btn-disconnect:hover { color: var(--error); border-color: var(--error); background: var(--error-subtle); }
   .connect-tabs {
     display: flex; gap: 4px; margin-bottom: 20px;
     background: var(--surface-2); border-radius: var(--radius-md); padding: 3px;
@@ -349,15 +369,6 @@
   /* ===== 6. PICKER GRID ===== */
   .picker-section { margin-top: 32px; }
   .picker-section h3 { font-size: var(--text-lg); font-weight: 600; margin-bottom: 16px; }
-  .setup-empty-state { position: relative; }
-  .source-disconnect {
-    position: absolute; top: 12px; right: 12px;
-    display: inline-flex; align-items: center; gap: 6px;
-    font-size: var(--text-xs); font-family: var(--font-mono); color: var(--text-muted);
-    background: none; border: 1px solid var(--border); border-radius: var(--radius-sm);
-    padding: 5px 12px; cursor: pointer; transition: all var(--transition-fast);
-  }
-  .source-disconnect:hover { color: var(--error); border-color: var(--error); background: var(--error-subtle); }
   .picker-grid {
     display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: 16px;
   }
@@ -2192,6 +2203,17 @@
       <h3>Connect a Source</h3>
       <button type="button" class="connect-dialog-close" onclick="hideConnectDialog()" aria-label="Close">&times;</button>
     </div>
+    <div class="connect-dialog-status" id="connectDialogStatus">
+      <div class="status-dot" aria-hidden="true"></div>
+      <div class="connect-dialog-status-info">
+        <div class="connect-dialog-status-label" id="connectDialogStatusLabel"></div>
+        <div class="connect-dialog-status-meta" id="connectDialogStatusMeta"></div>
+      </div>
+      <button type="button" class="btn-disconnect" onclick="disconnectSource(); updateConnectDialogStatus();">
+        <svg width="12" height="12"><use href="#icon-unlink"/></svg>
+        Disconnect
+      </button>
+    </div>
     <div class="connect-tabs">
       <button type="button" class="connect-tab active" id="connectTabBtnGithub" onclick="switchConnectTab('github')">
         <svg width="14" height="14" class="icon-inline"><use href="#icon-github"/></svg>
@@ -2333,26 +2355,13 @@
       </div>
     </div>
 
-    <!-- ===== SOURCE CARD (connect prompt or connected info) ===== -->
+    <!-- ===== EMPTY STATE (shown when not connected) ===== -->
     <div class="setup-empty-state" id="setupEmptyState">
-      <button type="button" class="btn-disconnect source-disconnect" id="sourceDisconnectBtn" onclick="disconnectSource()" title="Disconnect source" style="display:none;">
-        <svg width="12" height="12"><use href="#icon-unlink"/></svg>
-        Disconnect
+      <p>No source connected.<br>Connect a GitHub repo or local folder to browse available forms.</p>
+      <button type="button" class="btn-connect" onclick="showConnectDialog()">
+        <svg width="16" height="16"><use href="#icon-link"/></svg>
+        Connect a Source
       </button>
-      <div id="sourcePrompt">
-        <p>No source connected.<br>Connect a GitHub repo or local folder to browse available forms.</p>
-        <button type="button" class="btn-connect" onclick="showConnectDialog()">
-          <svg width="16" height="16"><use href="#icon-link"/></svg>
-          Connect a Source
-        </button>
-      </div>
-      <div id="sourceConnectedInfo" style="display:none;">
-        <p id="sourceConnectedLabel"></p>
-        <button type="button" class="btn-connect" onclick="showConnectDialog()">
-          <svg width="16" height="16"><use href="#icon-refresh"/></svg>
-          Change Source
-        </button>
-      </div>
     </div>
 
     <!-- Picker appears after connecting any source -->
@@ -3740,17 +3749,7 @@ function renderPicker() {
   const section = document.getElementById('pickerSection');
   const grid = document.getElementById('pickerGrid');
   section.style.display = 'block';
-
-  // Transform source card: show connected info + disconnect, hide connect prompt
-  document.getElementById('sourcePrompt').style.display = 'none';
-  document.getElementById('sourceConnectedInfo').style.display = '';
-  document.getElementById('sourceDisconnectBtn').style.display = '';
-  const label = contentSourceType === 'github'
-    ? `Connected to <strong>${escapeHtml(ghOwner + '/' + ghRepo)}</strong>`
-    : contentSourceType === 'local'
-    ? `Connected to <strong>${escapeHtml(workspaceHandle ? workspaceHandle.name : 'local folder')}</strong>`
-    : 'Source connected';
-  document.getElementById('sourceConnectedLabel').innerHTML = label + `<br><span style="color:var(--text-muted);font-size:var(--text-sm)">${repoSchemas.length} form${repoSchemas.length !== 1 ? 's' : ''} available</span>`;
+  document.getElementById('setupEmptyState').style.display = 'none';
 
   // Swap demo button → open selected form button
   document.getElementById('demoBtnAction').style.display = 'none';
@@ -10304,11 +10303,7 @@ function disconnectSource() {
   document.getElementById('statusBadge').className = 'status-badge';
   document.getElementById('statusText').textContent = 'not connected';
   document.getElementById('pickerSection').style.display = 'none';
-
-  // Restore source card to connect prompt
-  document.getElementById('sourcePrompt').style.display = '';
-  document.getElementById('sourceConnectedInfo').style.display = 'none';
-  document.getElementById('sourceDisconnectBtn').style.display = 'none';
+  document.getElementById('setupEmptyState').style.display = '';
 
   // Restore demo button, hide open button
   document.getElementById('demoBtnAction').style.display = '';
@@ -10334,6 +10329,7 @@ function devGhDisconnect() {
 //  CONNECT DIALOG
 // ============================================================
 function showConnectDialog() {
+  updateConnectDialogStatus();
   document.getElementById('connectDialogOverlay').classList.add('visible');
   document.addEventListener('keydown', connectDialogKeyHandler);
 }
@@ -10345,6 +10341,23 @@ function hideConnectDialog() {
 
 function connectDialogKeyHandler(e) {
   if (e.key === 'Escape') { hideConnectDialog(); e.stopPropagation(); }
+}
+
+function updateConnectDialogStatus() {
+  const el = document.getElementById('connectDialogStatus');
+  if (!contentSourceType || contentSourceType === 'demo') {
+    el.classList.remove('visible');
+    return;
+  }
+  el.classList.add('visible');
+  const labelEl = document.getElementById('connectDialogStatusLabel');
+  const metaEl = document.getElementById('connectDialogStatusMeta');
+  if (contentSourceType === 'github') {
+    labelEl.textContent = ghOwner + '/' + ghRepo;
+  } else if (contentSourceType === 'local') {
+    labelEl.textContent = 'local: ' + (workspaceHandle ? workspaceHandle.name : 'folder');
+  }
+  metaEl.textContent = repoSchemas.length + ' form' + (repoSchemas.length !== 1 ? 's' : '') + ' available';
 }
 
 function switchConnectTab(tab) {

--- a/tests/test_dev_mode.py
+++ b/tests/test_dev_mode.py
@@ -2321,10 +2321,10 @@ def test_connect_repo_hides_dialog(index_html: str) -> None:
     assert "hideConnectDialog()" in body
 
 
-def test_disconnect_shows_source_prompt(index_html: str) -> None:
-    """disconnectSource should restore the source prompt after disconnecting."""
+def test_disconnect_restores_empty_state(index_html: str) -> None:
+    """disconnectSource should restore the empty state after disconnecting."""
     body = _extract_func(index_html, "disconnectSource")
-    assert "sourcePrompt" in body
+    assert "setupEmptyState" in body
 
 
 # --- Forms Tab UX (#185) ---
@@ -2349,17 +2349,31 @@ def test_demo_button_restored_on_disconnect(index_html: str) -> None:
     assert "launchBtn" in body
 
 
-def test_disconnect_button_on_source_card(index_html: str) -> None:
-    """Source card has a disconnect button in upper-right corner."""
-    assert "source-disconnect" in index_html
+def test_empty_state_hidden_when_connected(index_html: str) -> None:
+    """renderPicker hides the empty state card."""
+    body = _extract_func(index_html, "renderPicker")
+    assert "setupEmptyState" in body
+
+
+def test_disconnect_in_connect_dialog(index_html: str) -> None:
+    """Connect dialog has a status banner with disconnect button."""
+    assert 'id="connectDialogStatus"' in index_html
+    assert "connect-dialog-status" in index_html
     assert "disconnectSource()" in index_html
 
 
-def test_source_card_shows_connected_info(index_html: str) -> None:
-    """renderPicker shows connected info and disconnect on the source card."""
-    body = _extract_func(index_html, "renderPicker")
-    assert "sourceConnectedInfo" in body
-    assert "sourceDisconnectBtn" in body
+def test_connect_dialog_status_updated_on_open(index_html: str) -> None:
+    """showConnectDialog calls updateConnectDialogStatus before opening."""
+    body = _extract_func(index_html, "showConnectDialog")
+    assert "updateConnectDialogStatus()" in body
+
+
+def test_update_connect_dialog_status_function(index_html: str) -> None:
+    """updateConnectDialogStatus populates the dialog status banner."""
+    body = _extract_func(index_html, "updateConnectDialogStatus")
+    assert "connectDialogStatus" in body
+    assert "connectDialogStatusLabel" in body
+    assert "connectDialogStatusMeta" in body
 
 
 def test_picker_cards_have_open_button(index_html: str) -> None:


### PR DESCRIPTION
## Summary
- **Disconnect moved to connect dialog** — When a source is connected, clicking the status badge opens the connect dialog which now shows a status banner at the top: green dot + source name + form count + Disconnect button. No more source card cluttering the Forms tab.
- **Clean Forms tab** — The empty state card (`setupEmptyState`) is hidden entirely when connected. Only the hero area and picker grid remain. Card reappears on disconnect.
- **Removed dead UI** — Cleaned up `sourceConnectedInfo`, `sourceDisconnectBtn`, `sourcePrompt`, and `.source-disconnect` CSS that are no longer needed.

Follow-up to #187, #188. Closes #185.

## Test plan
- [x] 489 tests pass (3 new tests for dialog status banner)
- [ ] Manual: connect GitHub → verify no source card on Forms tab, badge green
- [ ] Manual: click green badge → dialog shows status banner with source name + Disconnect
- [ ] Manual: click Disconnect → banner hides, dialog stays open, Forms tab restores empty state + demo button
- [ ] Manual: connect local folder → same verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)