### PR TITLE
feat: support committing new files from editors to GitHub

### DIFF
--- a/docs/DEVLOG.md
+++ b/docs/DEVLOG.md
@@ -14,6 +14,34 @@
 
 ## Log
 
+### 2026-03-16 — Commit New Files from Editors (#202)
+
+Implemented support for committing new files created in the Schema and Template editors to a connected GitHub repository. Previously, the Commit button only appeared for files loaded from the repo, and Save downloaded locally.
+
+**New function — `devGhRegisterNewFile(type)`:**
+- Prompts for filename with sensible defaults (derived from schema title or template comment header)
+- Creates entries in `workspaceFiles` and `ghOriginalContents` with `sha: null` (signals new file)
+- Marks file as modified immediately so it appears in the commit panel
+- Validates: requires auth token, non-empty content, no duplicate filenames
+
+**Updated flows:**
+- `devSaveSchema()` / `devSaveTemplate()` — When GitHub connected, routes to register + commit panel instead of downloading. Also handles Ctrl+S on already-tracked files by showing the commit panel directly.
+- `updateSourceToolbar()` — Shows Commit button and "new file (unsaved)" label when GitHub is connected and the editor has content, even without a workspace file entry
+- `devGhTrackModification()` — Handles new files with `sha === null` (always marked modified if content is non-empty)
+- `devGhCommitAndPush()` — Single-file PUT omits `sha` for new files (GitHub creates the file). Multi-file path falls back to sequential PUTs when Git refs return 404 (empty repos with no commits)
+- `devGhShowCommitPanel()` — Auto-registers untracked editor content and labels new files with "(new)" in the file list
+- `devNewSchema()` / `devNewTemplate()` — Reset `currentWorkspaceFile` so toolbar shows new-file state
+
+**Post-commit:**
+- `devGhRefreshPicker()` re-fetches schemas and updates the Forms tab picker after new schemas are committed
+- `currentWorkspaceFile` is re-linked to the refreshed workspace entry so the user can continue editing
+
+**Also fixed:**
+- `friendlyError()` regex tightened from `/JSON/i` to `/JSON\.parse|Unexpected token|JSON at position/i` to avoid misclassifying "No .json files found" as a parse error
+- `connectRepo()` tolerates empty `schemas/` and `templates/` directories with helpful guidance messages
+
+---
+
 ### 2026-03-16 — UI/UX Audit Fixes (#192, #193, #194, #195, #196)
 
 Implemented all 4 priority tiers of the UI/UX audit across accessibility, design tokens, performance, and responsive design.

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -17,6 +17,13 @@ TODO: Schema context menu improvements — add option to add base scaffold (e.g.
 
 ## Completed Plans
 
+### Issue #202 — Commit New Files from Editors to GitHub ✅
+
+**Branch:** `feature/202-commit-new-files`
+**Issue:** #202
+
+Added `devGhRegisterNewFile()` to register editor content as new workspace files, updated save/commit/toolbar flows to support creating files in GitHub repos (including empty repos), with post-commit picker refresh.
+
 ### Issues #192–#196 — UI/UX Audit Fixes ✅
 
 **Branch:** `feature/192-ui-ux-audit`

--- a/index.html
+++ b/index.html
@@ -412,6 +412,13 @@
     grid-column: 1 / -1; text-align: center; padding: 40px;
     color: var(--text-muted); font-size: var(--text-base);
   }
+  .picker-card-create {
+    border-style: dashed; border-color: var(--border);
+    display: flex; flex-direction: column; align-items: center; justify-content: center; text-align: center;
+  }
+  .picker-card-create h4 { color: var(--text-muted); }
+  .picker-card-create:hover, .picker-card-create:focus-visible { border-color: var(--accent); }
+  .picker-card-create:hover h4, .picker-card-create:focus-visible h4 { color: var(--text); }
 
   .picker-card .btn-card-open {
     display: none; width: 100%; margin-top: 10px; justify-content: center; align-items: center; gap: 6px;
@@ -3784,8 +3791,24 @@ function renderPicker() {
   grid.innerHTML = '';
   selectedSchemaIdx = -1;
 
+  // Always show "Create a Form" card (at the end when forms exist, alone when empty)
+  const createCard = document.createElement('div');
+  createCard.className = 'picker-card picker-card-create';
+  createCard.setAttribute('tabindex', '0');
+  createCard.setAttribute('role', 'button');
+  createCard.setAttribute('aria-label', 'Create a new form');
+  createCard.innerHTML = `
+    <div class="card-icon"><svg width="28" height="28" style="color: var(--text-muted)"><use href="#icon-plus"/></svg></div>
+    <h4>Create a Form</h4>
+    <p>Open the Schema editor to build a new form</p>
+  `;
+  createCard.addEventListener('click', () => { devNewSchema(); showTab('dev-schema'); });
+  createCard.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); devNewSchema(); showTab('dev-schema'); }
+  });
+
   if (repoSchemas.length === 0) {
-    grid.innerHTML = '<div class="picker-empty">No schemas yet. Use the Schema tab to create one, then commit it to your repo.</div>';
+    grid.appendChild(createCard);
     return;
   }
 
@@ -3815,6 +3838,9 @@ function renderPicker() {
     `;
     grid.appendChild(card);
   });
+
+  // Append "Create a Form" card after all existing forms
+  grid.appendChild(createCard);
 
   // Abort previous listeners to prevent accumulation on repeated renderPicker() calls
   if (pickerAbortController) pickerAbortController.abort();

--- a/index.html
+++ b/index.html
@@ -3377,7 +3377,7 @@ function escapeHtml(str) {
 // Map raw error messages to user-friendly language
 function friendlyError(err) {
   const msg = (err && err.message) ? err.message : String(err);
-  if (/404|not found/i.test(msg)) return 'Repository not found. Check the owner/repo format.';
+  if (/\b404\b/.test(msg)) return 'Repository not found. Check the owner/repo format.';
   if (/401|403|unauthorized|forbidden|credentials/i.test(msg)) return 'Access denied. Your token may be invalid or expired.';
   if (/rate limit/i.test(msg)) return 'GitHub rate limit reached. Add a personal access token or try again in a few minutes.';
   if (/network|fetch|CORS|ERR_/i.test(msg)) return 'Network error. Check your connection and try again.';

--- a/index.html
+++ b/index.html
@@ -3382,7 +3382,7 @@ function friendlyError(err) {
   if (/rate limit/i.test(msg)) return 'GitHub rate limit reached. Add a personal access token or try again in a few minutes.';
   if (/network|fetch|CORS|ERR_/i.test(msg)) return 'Network error. Check your connection and try again.';
   if (/timeout/i.test(msg)) return 'Request timed out. Try again.';
-  if (/JSON/i.test(msg)) return 'Invalid JSON — check file syntax.';
+  if (/\bJSON\.parse\b|Unexpected token|JSON at position/i.test(msg)) return 'Invalid JSON — check file syntax.';
   return msg;
 }
 
@@ -3653,51 +3653,59 @@ async function connectRepo() {
 
     // Fetch schemas/ directory
     log(`Fetching schemas from ${ghOwner}/${ghRepo}@${ghBranch}...`, 'info');
-    const schemaFiles = await ghFetch('schemas');
-
-    if (!Array.isArray(schemaFiles)) throw new Error('schemas/ directory not found or not a directory');
+    let schemaFiles = [];
+    try {
+      const schemaDirResult = await ghFetch('schemas');
+      if (Array.isArray(schemaDirResult)) schemaFiles = schemaDirResult;
+    } catch (e) {
+      log('schemas/ directory not found — you can create schemas in the Schema tab', 'info');
+    }
 
     const jsonFiles = schemaFiles.filter(f => f.name.endsWith('.json') && !f.name.startsWith('_'));
-    if (jsonFiles.length === 0) throw new Error('No .json files found in schemas/');
 
     // Fetch all schemas in parallel for metadata
-    log(`Fetching ${jsonFiles.length} schema(s) in parallel...`, 'info');
-    const schemaResults = await Promise.all(
-      jsonFiles.map(file =>
-        ghFetchRaw(file.path)
-          .then(raw => {
-            const schema = JSON.parse(raw);
-            const baseName = file.name.replace('.json', '');
-            log(`Found schema: ${schema.title || baseName}`, 'success');
-            return {
-              name: schema.title || baseName,
-              description: schema.description || '',
-              icon: schema.icon || '📄',
-              schemaPath: file.path,
-              templatePath: schema.template || `templates/${baseName}.py`,
-              schema: schema
-            };
-          })
-          .catch(e => {
-            log(`Skipped ${file.name}: ${e.message}`, 'error');
-            return null;
-          })
-      )
-    );
-    repoSchemas = schemaResults.filter(s => s !== null);
-
-    if (repoSchemas.length === 0) throw new Error('No valid schemas could be parsed');
+    if (jsonFiles.length > 0) {
+      log(`Fetching ${jsonFiles.length} schema(s) in parallel...`, 'info');
+      const schemaResults = await Promise.all(
+        jsonFiles.map(file =>
+          ghFetchRaw(file.path)
+            .then(raw => {
+              const schema = JSON.parse(raw);
+              const baseName = file.name.replace('.json', '');
+              log(`Found schema: ${schema.title || baseName}`, 'success');
+              return {
+                name: schema.title || baseName,
+                description: schema.description || '',
+                icon: schema.icon || '📄',
+                schemaPath: file.path,
+                templatePath: schema.template || `templates/${baseName}.py`,
+                schema: schema
+              };
+            })
+            .catch(e => {
+              log(`Skipped ${file.name}: ${e.message}`, 'error');
+              return null;
+            })
+        )
+      );
+      repoSchemas = schemaResults.filter(s => s !== null);
+    } else {
+      repoSchemas = [];
+      log('No schemas found — use the Schema tab to create one', 'info');
+    }
 
     // Check templates/ exists
     try {
       await ghFetch('templates');
       log('templates/ directory confirmed', 'success');
     } catch (e) {
-      log('Warning: templates/ directory not found — export may fail', 'error');
+      log('templates/ directory not found — you can create templates in the Template tab', 'info');
     }
 
     statusEl.className = 'repo-status success';
-    statusEl.textContent = `Connected — ${repoSchemas.length} schema${repoSchemas.length !== 1 ? 's' : ''} found`;
+    statusEl.textContent = repoSchemas.length > 0
+      ? `Connected — ${repoSchemas.length} schema${repoSchemas.length !== 1 ? 's' : ''} found`
+      : 'Connected — no schemas yet. Use Schema & Template tabs to create content.';
 
     // Update badge
     const badge = document.getElementById('statusBadge');
@@ -3777,7 +3785,7 @@ function renderPicker() {
   selectedSchemaIdx = -1;
 
   if (repoSchemas.length === 0) {
-    grid.innerHTML = '<div class="picker-empty">No schemas found in this repository.</div>';
+    grid.innerHTML = '<div class="picker-empty">No schemas yet. Use the Schema tab to create one, then commit it to your repo.</div>';
     return;
   }
 
@@ -9433,15 +9441,20 @@ function updateSourceToolbar() {
     const isGh = contentSourceType === 'github';
     const isLocal = contentSourceType === 'local';
 
+    // Check if editor has content (for showing commit on unregistered new files)
+    const editorContent = fileType === 'schema' ? devSchemaText : devTemplateText;
+    const hasEditorContent = editorContent && editorContent.trim();
+
     // Show toolbar if a file is loaded OR if GitHub is connected (branch controls)
     if (f || isGh) {
       toolbar.style.display = 'flex';
-      document.getElementById(prefix + 'SourceFile').textContent = f ? (f.ghPath || f.name) : '';
+      document.getElementById(prefix + 'SourceFile').textContent = f ? (f.ghPath || f.name) : (hasEditorContent ? 'new file (unsaved)' : '');
       document.getElementById(prefix + 'SourceBranch').textContent = isGh ? `@ ${ghBranch}` : '';
       document.getElementById(prefix + 'BranchSelect').style.display = isGh ? '' : 'none';
       document.getElementById(prefix + 'NewBranchBtn').style.display = isGh ? 'inline-flex' : 'none';
       document.getElementById(prefix + 'RefreshBtn').style.display = isGh ? 'inline-flex' : 'none';
-      document.getElementById(prefix + 'CommitBtn').style.display = (f && isGh) ? 'inline-flex' : 'none';
+      // Show commit button for tracked files OR for new unsaved content when GitHub connected
+      document.getElementById(prefix + 'CommitBtn').style.display = (isGh && (f || hasEditorContent)) ? 'inline-flex' : 'none';
       document.getElementById(prefix + 'SaveLocalBtn').style.display = (f && isLocal) ? 'inline-flex' : 'none';
     } else if (isLocal && f) {
       toolbar.style.display = 'flex';
@@ -10356,6 +10369,8 @@ function devEnablePreviewDragDrop() {
 function devNewSchema() {
   devSchemaText = JSON.stringify(DEV_STARTER_SCHEMA, null, 2);
   if (schemaJar) schemaJar.updateCode(devSchemaText);
+  currentWorkspaceFile = null;
+  updateSourceToolbar();
   devUpdateSchemaPreview();
   showToast('New schema created');
 }
@@ -10392,6 +10407,18 @@ function devSaveSchema() {
   }
   if (workspaceHandle) {
     devCreateWorkspaceFile('schema');
+    return;
+  }
+  // GitHub connected with tracked file — show commit panel
+  if (contentSourceType === 'github' && currentWorkspaceFile && currentWorkspaceFile.type === 'schema') {
+    devGhShowCommitPanel();
+    return;
+  }
+  // GitHub connected but no workspace file — register as new file and show commit panel
+  if (contentSourceType === 'github' && (!currentWorkspaceFile || currentWorkspaceFile.type !== 'schema')) {
+    if (devGhRegisterNewFile('schema')) {
+      devGhShowCommitPanel();
+    }
     return;
   }
   const blob = new Blob([devSchemaText], { type: 'application/json' });
@@ -11062,6 +11089,8 @@ bytes(_result) if isinstance(_result, (bytes, bytearray)) else _result
 function devNewTemplate() {
   devTemplateText = DEV_STARTER_TEMPLATE;
   if (templateJar) templateJar.updateCode(devTemplateText);
+  currentWorkspaceFile = null;
+  updateSourceToolbar();
   showToast('New template created');
 }
 
@@ -11085,6 +11114,18 @@ function devSaveTemplate() {
   }
   if (workspaceHandle) {
     devCreateWorkspaceFile('template');
+    return;
+  }
+  // GitHub connected with tracked file — show commit panel
+  if (contentSourceType === 'github' && currentWorkspaceFile && currentWorkspaceFile.type === 'template') {
+    devGhShowCommitPanel();
+    return;
+  }
+  // GitHub connected but no workspace file — register as new file and show commit panel
+  if (contentSourceType === 'github' && (!currentWorkspaceFile || currentWorkspaceFile.type !== 'template')) {
+    if (devGhRegisterNewFile('template')) {
+      devGhShowCommitPanel();
+    }
     return;
   }
   const blob = new Blob([devTemplateText], { type: 'text/x-python' });
@@ -11604,6 +11645,66 @@ async function devGhFetchFiles() {
 }
 
 
+function devGhRegisterNewFile(type) {
+  // Register editor content as a new file in the workspace for committing to GitHub
+  if (!ghToken) {
+    showToast('A GitHub token is required to commit files. Add one in the connect dialog.', 'error');
+    return false;
+  }
+
+  const content = type === 'schema' ? devSchemaText : devTemplateText;
+  if (!content || !content.trim()) {
+    showToast('Editor is empty — nothing to commit', 'error');
+    return false;
+  }
+
+  // Derive a sensible default filename
+  let defaultName;
+  if (type === 'schema') {
+    defaultName = 'schema.json';
+    try {
+      const obj = JSON.parse(content);
+      if (obj.title) defaultName = obj.title.toLowerCase().replace(/[^a-z0-9]+/g, '_') + '.json';
+    } catch (e) { /* use default */ }
+  } else {
+    defaultName = 'template.py';
+    const match = content.match(/^#\s*(\S+\.py)/m);
+    if (match) defaultName = match[1];
+  }
+
+  const userFilename = prompt(`Filename for new ${type}:`, defaultName);
+  if (!userFilename) return false; // cancelled
+
+  let finalName = userFilename.trim();
+  if (type === 'schema' && !finalName.endsWith('.json')) finalName += '.json';
+  if (type === 'template' && !finalName.endsWith('.py')) finalName += '.py';
+
+  const dir = type === 'schema' ? 'schemas' : 'templates';
+  const ghPath = `${dir}/${finalName}`;
+
+  // Check if file already exists in workspace
+  const files = type === 'schema' ? workspaceFiles.schemas : workspaceFiles.templates;
+  if (files.some(f => f.ghPath === ghPath)) {
+    showToast(`${ghPath} already exists — edit it instead`, 'error');
+    return false;
+  }
+
+  // Register in workspace
+  const entry = { name: finalName, text: '', handle: null, ghPath, ghSha: null };
+  files.push(entry);
+  const index = files.length - 1;
+  currentWorkspaceFile = { type, index };
+
+  // Register in ghOriginalContents with empty original and null sha (signals new file)
+  ghOriginalContents[ghPath] = { content: '', sha: null };
+
+  // Mark as modified immediately (content differs from empty original)
+  ghModifiedFiles.add(ghPath);
+
+  updateSourceToolbar();
+  return true;
+}
+
 function devGhTrackModification(type, index) {
   // Called when a file is edited in the builder — compare current content with original
   let path, currentContent;
@@ -11622,7 +11723,14 @@ function devGhTrackModification(type, index) {
   const original = ghOriginalContents[path];
   if (!original) return;
 
-  if (currentContent !== original.content) {
+  // For new files (sha === null), always mark as modified if there's content
+  if (original.sha === null) {
+    if (currentContent && currentContent.trim()) {
+      ghModifiedFiles.add(path);
+    } else {
+      ghModifiedFiles.delete(path);
+    }
+  } else if (currentContent !== original.content) {
     ghModifiedFiles.add(path);
   } else {
     ghModifiedFiles.delete(path);
@@ -11715,9 +11823,23 @@ async function devGhCreateBranch() {
 }
 
 function devGhShowCommitPanel() {
+  // If no files are modified yet, check if the editor has unregistered new content
   if (ghModifiedFiles.size === 0) {
-    showToast('No files modified', 'info');
-    return;
+    let registered = false;
+    // Check if current tab has unregistered content that needs to be registered first
+    const activeView = document.querySelector('.view.active');
+    const viewId = activeView ? activeView.id : '';
+    if (viewId === 'view-dev-schema' && devSchemaText && devSchemaText.trim() &&
+        (!currentWorkspaceFile || currentWorkspaceFile.type !== 'schema')) {
+      registered = devGhRegisterNewFile('schema');
+    } else if (viewId === 'view-dev-template' && devTemplateText && devTemplateText.trim() &&
+        (!currentWorkspaceFile || currentWorkspaceFile.type !== 'template')) {
+      registered = devGhRegisterNewFile('template');
+    }
+    if (!registered && ghModifiedFiles.size === 0) {
+      showToast('No files modified', 'info');
+      return;
+    }
   }
 
   const fileList = document.getElementById('ghCommitFileList');
@@ -11725,7 +11847,8 @@ function devGhShowCommitPanel() {
   ghModifiedFiles.forEach(path => {
     const entry = document.createElement('div');
     entry.className = 'gh-commit-file-entry';
-    entry.textContent = path;
+    const isNew = ghOriginalContents[path] && ghOriginalContents[path].sha === null;
+    entry.textContent = path + (isNew ? ' (new)' : '');
     fileList.appendChild(entry);
   });
 
@@ -11784,95 +11907,159 @@ async function devGhCommitAndPush() {
       if (content === null) throw new Error('Could not read file content for ' + path);
       const original = ghOriginalContents[path];
 
+      const putBody = {
+        message,
+        content: btoa(unescape(encodeURIComponent(content))),
+        branch: ghBranch
+      };
+      // Include sha only for existing files — omitting it creates a new file
+      if (original && original.sha) putBody.sha = original.sha;
+
       const resp = await devGhApiFetch(
         `https://api.github.com/repos/${ghOwner}/${ghRepo}/contents/${path}`,
         {
           method: 'PUT',
           headers: { ...ghHeaders(), 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            message,
-            content: btoa(unescape(encodeURIComponent(content))),
-            sha: original.sha,
-            branch: ghBranch
-          })
+          body: JSON.stringify(putBody)
         }
       );
       const result = await resp.json();
       const commitSha = result.commit.sha.slice(0, 7);
       showToast(`Committed ${commitSha} to ${ghBranch}`);
     } else {
-      // Multi-file: use Git Trees + Commits API for atomic commit
-      // 1. Get current commit SHA for the branch
-      const refResp = await devGhApiFetch(
-        `https://api.github.com/repos/${ghOwner}/${ghRepo}/git/refs/heads/${ghBranch}`
-      );
-      const refData = await refResp.json();
-      const baseCommitSha = refData.object.sha;
+      // Multi-file: try Git Trees + Commits API for atomic commit
+      // On empty repos (no commits yet), ref fetch returns 404 — fall back to sequential PUTs
+      let useTreesApi = true;
+      let baseCommitSha, baseTreeSha;
 
-      // 2. Get the base tree
-      const commitResp = await devGhApiFetch(
-        `https://api.github.com/repos/${ghOwner}/${ghRepo}/git/commits/${baseCommitSha}`
-      );
-      const commitData = await commitResp.json();
-      const baseTreeSha = commitData.tree.sha;
+      try {
+        // 1. Get current commit SHA for the branch
+        const refResp = await devGhApiFetch(
+          `https://api.github.com/repos/${ghOwner}/${ghRepo}/git/refs/heads/${ghBranch}`
+        );
+        const refData = await refResp.json();
+        baseCommitSha = refData.object.sha;
 
-      // 3. Create blobs for each modified file
-      const treeItems = [];
-      for (const path of modifiedPaths) {
-        const content = devGhGetCurrentContent(path);
-        if (content === null) throw new Error('Could not read file content for ' + path);
+        // 2. Get the base tree
+        const commitResp = await devGhApiFetch(
+          `https://api.github.com/repos/${ghOwner}/${ghRepo}/git/commits/${baseCommitSha}`
+        );
+        const commitData = await commitResp.json();
+        baseTreeSha = commitData.tree.sha;
+      } catch (refErr) {
+        if (refErr.message.includes('404')) {
+          useTreesApi = false; // Empty repo — no commits yet
+        } else {
+          throw refErr;
+        }
+      }
 
-        const blobResp = await devGhApiFetch(
-          `https://api.github.com/repos/${ghOwner}/${ghRepo}/git/blobs`,
+      if (useTreesApi) {
+        // 3. Create blobs for each modified file
+        const treeItems = [];
+        for (const path of modifiedPaths) {
+          const content = devGhGetCurrentContent(path);
+          if (content === null) throw new Error('Could not read file content for ' + path);
+
+          const blobResp = await devGhApiFetch(
+            `https://api.github.com/repos/${ghOwner}/${ghRepo}/git/blobs`,
+            {
+              method: 'POST',
+              headers: { ...ghHeaders(), 'Content-Type': 'application/json' },
+              body: JSON.stringify({ content, encoding: 'utf-8' })
+            }
+          );
+          const blobData = await blobResp.json();
+          treeItems.push({ path, mode: '100644', type: 'blob', sha: blobData.sha });
+        }
+
+        // 4. Create a new tree
+        const treeResp = await devGhApiFetch(
+          `https://api.github.com/repos/${ghOwner}/${ghRepo}/git/trees`,
           {
             method: 'POST',
             headers: { ...ghHeaders(), 'Content-Type': 'application/json' },
-            body: JSON.stringify({ content, encoding: 'utf-8' })
+            body: JSON.stringify({ base_tree: baseTreeSha, tree: treeItems })
           }
         );
-        const blobData = await blobResp.json();
-        treeItems.push({ path, mode: '100644', type: 'blob', sha: blobData.sha });
+        const treeData = await treeResp.json();
+
+        // 5. Create a new commit
+        const newCommitResp = await devGhApiFetch(
+          `https://api.github.com/repos/${ghOwner}/${ghRepo}/git/commits`,
+          {
+            method: 'POST',
+            headers: { ...ghHeaders(), 'Content-Type': 'application/json' },
+            body: JSON.stringify({ message, tree: treeData.sha, parents: [baseCommitSha] })
+          }
+        );
+        const newCommitData = await newCommitResp.json();
+
+        // 6. Update the branch ref
+        await devGhApiFetch(
+          `https://api.github.com/repos/${ghOwner}/${ghRepo}/git/refs/heads/${ghBranch}`,
+          {
+            method: 'PATCH',
+            headers: { ...ghHeaders(), 'Content-Type': 'application/json' },
+            body: JSON.stringify({ sha: newCommitData.sha })
+          }
+        );
+
+        const commitSha = newCommitData.sha.slice(0, 7);
+        showToast(`Committed ${commitSha} to ${ghBranch} (${modifiedPaths.length} files)`);
+      } else {
+        // Empty repo fallback: commit files sequentially via Contents API
+        let lastCommitSha = '';
+        for (const path of modifiedPaths) {
+          const content = devGhGetCurrentContent(path);
+          if (content === null) throw new Error('Could not read file content for ' + path);
+          const original = ghOriginalContents[path];
+          const putBody = {
+            message: modifiedPaths.indexOf(path) === 0 ? message : `${message} (${path})`,
+            content: btoa(unescape(encodeURIComponent(content))),
+            branch: ghBranch
+          };
+          if (original && original.sha) putBody.sha = original.sha;
+          const resp = await devGhApiFetch(
+            `https://api.github.com/repos/${ghOwner}/${ghRepo}/contents/${path}`,
+            {
+              method: 'PUT',
+              headers: { ...ghHeaders(), 'Content-Type': 'application/json' },
+              body: JSON.stringify(putBody)
+            }
+          );
+          const result = await resp.json();
+          lastCommitSha = result.commit.sha.slice(0, 7);
+        }
+        showToast(`Committed ${lastCommitSha} to ${ghBranch} (${modifiedPaths.length} files)`);
       }
-
-      // 4. Create a new tree
-      const treeResp = await devGhApiFetch(
-        `https://api.github.com/repos/${ghOwner}/${ghRepo}/git/trees`,
-        {
-          method: 'POST',
-          headers: { ...ghHeaders(), 'Content-Type': 'application/json' },
-          body: JSON.stringify({ base_tree: baseTreeSha, tree: treeItems })
-        }
-      );
-      const treeData = await treeResp.json();
-
-      // 5. Create a new commit
-      const newCommitResp = await devGhApiFetch(
-        `https://api.github.com/repos/${ghOwner}/${ghRepo}/git/commits`,
-        {
-          method: 'POST',
-          headers: { ...ghHeaders(), 'Content-Type': 'application/json' },
-          body: JSON.stringify({ message, tree: treeData.sha, parents: [baseCommitSha] })
-        }
-      );
-      const newCommitData = await newCommitResp.json();
-
-      // 6. Update the branch ref
-      await devGhApiFetch(
-        `https://api.github.com/repos/${ghOwner}/${ghRepo}/git/refs/heads/${ghBranch}`,
-        {
-          method: 'PATCH',
-          headers: { ...ghHeaders(), 'Content-Type': 'application/json' },
-          body: JSON.stringify({ sha: newCommitData.sha })
-        }
-      );
-
-      const commitSha = newCommitData.sha.slice(0, 7);
-      showToast(`Committed ${commitSha} to ${ghBranch} (${modifiedPaths.length} files)`);
     }
 
-    // Refresh files to get new SHAs
+    // Refresh files to get new SHAs and re-link current workspace file
     devGhHideCommitPanel();
+    const hadNewSchemas = modifiedPaths.some(p => p.startsWith('schemas/'));
+    // Remember the file path being edited so we can re-link after refresh
+    const editingPath = currentWorkspaceFile
+      ? (currentWorkspaceFile.type === 'schema'
+          ? workspaceFiles.schemas[currentWorkspaceFile.index]?.ghPath
+          : workspaceFiles.templates[currentWorkspaceFile.index]?.ghPath)
+      : null;
     await devGhFetchFiles();
+    // Re-link currentWorkspaceFile to the refreshed entry
+    if (editingPath) {
+      const schemaIdx = workspaceFiles.schemas.findIndex(f => f.ghPath === editingPath);
+      if (schemaIdx >= 0) {
+        currentWorkspaceFile = { type: 'schema', index: schemaIdx };
+      } else {
+        const tmplIdx = workspaceFiles.templates.findIndex(f => f.ghPath === editingPath);
+        if (tmplIdx >= 0) currentWorkspaceFile = { type: 'template', index: tmplIdx };
+      }
+    }
+    // Refresh picker if new schemas were committed
+    if (hadNewSchemas) {
+      await devGhRefreshPicker();
+    }
+    updateSourceToolbar();
   } catch (e) {
     if (e.message.includes('409')) {
       showToast('Conflict: file changed on remote. Refresh and try again.', 'error');
@@ -11892,6 +12079,38 @@ async function devGhRefreshFiles() {
     showToast('Files refreshed from GitHub');
   } catch (e) {
     showToast('Failed to refresh: ' + e.message, 'error');
+  }
+}
+
+async function devGhRefreshPicker() {
+  // Re-fetch schemas from the repo and update the picker after new files are committed
+  try {
+    const schemaFiles = await ghFetch('schemas');
+    if (!Array.isArray(schemaFiles)) return;
+    const jsonFiles = schemaFiles.filter(f => f.name.endsWith('.json') && !f.name.startsWith('_'));
+    if (jsonFiles.length === 0) { repoSchemas = []; renderPicker(); return; }
+    const results = await Promise.all(
+      jsonFiles.map(file =>
+        ghFetchRaw(file.path)
+          .then(raw => {
+            const schema = JSON.parse(raw);
+            const baseName = file.name.replace('.json', '');
+            return {
+              name: schema.title || baseName,
+              description: schema.description || '',
+              icon: schema.icon || '\u{1F4C4}',
+              schemaPath: file.path,
+              templatePath: schema.template || `templates/${baseName}.py`,
+              schema
+            };
+          })
+          .catch(() => null)
+      )
+    );
+    repoSchemas = results.filter(s => s !== null);
+    renderPicker();
+  } catch (e) {
+    // Non-critical — picker just won't update
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -413,11 +413,13 @@
     color: var(--text-muted); font-size: var(--text-base);
   }
   .picker-card-create {
-    border-style: dashed; border-color: var(--border);
+    border: 1px dashed var(--border);
     display: flex; flex-direction: column; align-items: center; justify-content: center; text-align: center;
   }
   .picker-card-create h4 { color: var(--text-muted); }
-  .picker-card-create:hover, .picker-card-create:focus-visible { border-color: var(--accent); }
+  .picker-card-create:hover, .picker-card-create:focus-visible {
+    border-color: var(--accent); transform: none; box-shadow: none;
+  }
   .picker-card-create:hover h4, .picker-card-create:focus-visible h4 { color: var(--text); }
 
   .picker-card .btn-card-open {
@@ -11705,6 +11707,12 @@ function devGhRegisterNewFile(type) {
   if (type === 'schema' && !finalName.endsWith('.json')) finalName += '.json';
   if (type === 'template' && !finalName.endsWith('.py')) finalName += '.py';
 
+  // Validate filename — no path separators, no leading dots/underscores
+  if (/[\/\\]/.test(finalName) || finalName.startsWith('_') || finalName.startsWith('.')) {
+    showToast('Invalid filename — avoid path separators and leading _ or . characters', 'error');
+    return false;
+  }
+
   const dir = type === 'schema' ? 'schemas' : 'templates';
   const ghPath = `${dir}/${finalName}`;
 
@@ -11748,6 +11756,10 @@ function devGhTrackModification(type, index) {
 
   const original = ghOriginalContents[path];
   if (!original) return;
+
+  // Keep workspace entry text in sync with editor content
+  const f = type === 'schema' ? workspaceFiles.schemas[index] : workspaceFiles.templates[index];
+  if (f) f.text = currentContent;
 
   // For new files (sha === null), always mark as modified if there's content
   if (original.sha === null) {
@@ -11855,11 +11867,9 @@ function devGhShowCommitPanel() {
     // Check if current tab has unregistered content that needs to be registered first
     const activeView = document.querySelector('.view.active');
     const viewId = activeView ? activeView.id : '';
-    if (viewId === 'view-dev-schema' && devSchemaText && devSchemaText.trim() &&
-        (!currentWorkspaceFile || currentWorkspaceFile.type !== 'schema')) {
+    if (viewId === 'view-dev-schema' && devSchemaText && devSchemaText.trim() && !currentWorkspaceFile) {
       registered = devGhRegisterNewFile('schema');
-    } else if (viewId === 'view-dev-template' && devTemplateText && devTemplateText.trim() &&
-        (!currentWorkspaceFile || currentWorkspaceFile.type !== 'template')) {
+    } else if (viewId === 'view-dev-template' && devTemplateText && devTemplateText.trim() && !currentWorkspaceFile) {
       registered = devGhRegisterNewFile('template');
     }
     if (!registered && ghModifiedFiles.size === 0) {
@@ -12056,6 +12066,9 @@ async function devGhCommitAndPush() {
           );
           const result = await resp.json();
           lastCommitSha = result.commit.sha.slice(0, 7);
+          // Update SHA so retry after partial failure doesn't 422
+          if (ghOriginalContents[path]) ghOriginalContents[path].sha = result.content.sha;
+          ghModifiedFiles.delete(path);
         }
         showToast(`Committed ${lastCommitSha} to ${ghBranch} (${modifiedPaths.length} files)`);
       }
@@ -12070,20 +12083,24 @@ async function devGhCommitAndPush() {
           ? workspaceFiles.schemas[currentWorkspaceFile.index]?.ghPath
           : workspaceFiles.templates[currentWorkspaceFile.index]?.ghPath)
       : null;
-    await devGhFetchFiles();
-    // Re-link currentWorkspaceFile to the refreshed entry
-    if (editingPath) {
-      const schemaIdx = workspaceFiles.schemas.findIndex(f => f.ghPath === editingPath);
-      if (schemaIdx >= 0) {
-        currentWorkspaceFile = { type: 'schema', index: schemaIdx };
-      } else {
-        const tmplIdx = workspaceFiles.templates.findIndex(f => f.ghPath === editingPath);
-        if (tmplIdx >= 0) currentWorkspaceFile = { type: 'template', index: tmplIdx };
+    try {
+      await devGhFetchFiles();
+      // Re-link currentWorkspaceFile to the refreshed entry
+      if (editingPath) {
+        const schemaIdx = workspaceFiles.schemas.findIndex(f => f.ghPath === editingPath);
+        if (schemaIdx >= 0) {
+          currentWorkspaceFile = { type: 'schema', index: schemaIdx };
+        } else {
+          const tmplIdx = workspaceFiles.templates.findIndex(f => f.ghPath === editingPath);
+          if (tmplIdx >= 0) currentWorkspaceFile = { type: 'template', index: tmplIdx };
+        }
       }
-    }
-    // Refresh picker if new schemas were committed
-    if (hadNewSchemas) {
-      await devGhRefreshPicker();
+      // Refresh picker if new schemas were committed
+      if (hadNewSchemas) {
+        await devGhRefreshPicker();
+      }
+    } catch (refreshErr) {
+      showToast('Committed successfully, but failed to refresh workspace. Reload the page to sync.', 'info');
     }
     updateSourceToolbar();
   } catch (e) {
@@ -12136,7 +12153,7 @@ async function devGhRefreshPicker() {
     repoSchemas = results.filter(s => s !== null);
     renderPicker();
   } catch (e) {
-    // Non-critical — picker just won't update
+    log('Could not refresh picker: ' + e.message, 'error');
   }
 }
 

--- a/tests/test_dev_mode.py
+++ b/tests/test_dev_mode.py
@@ -438,7 +438,9 @@ def test_polling_stops_after_repeated_errors(index_html: str) -> None:
 
 def _extract_func(html: str, name: str) -> str:
     """Extract JS function body from index.html."""
-    match = re.search(rf"function {name}\b[^{{]*\{{([\s\S]*?)^function ", html, re.M)
+    match = re.search(
+        rf"function {name}\b[^{{]*\{{([\s\S]*?)^(?:async )?function ", html, re.M
+    )
     assert match, f"Function {name} not found"
     return match.group(1)
 
@@ -1319,50 +1321,50 @@ class TestGitHubWorkspaceJavaScript:
     def test_connect_repo_tolerates_empty_schemas(self, index_html: str) -> None:
         """connectRepo does not throw when schemas/ has no JSON files."""
         body = _extract_func(index_html, "connectRepo")
-        assert (
-            "No schemas found" not in body
-            or "throw" not in body.split("No schemas found")[0][-50:]
-        )
-        # Should log a helpful message instead of throwing
-        assert (
-            "Schema tab" in body
-            or "no schemas yet" in body.lower()
-            or "create" in body.lower()
-        )
+        # Should not throw on empty schemas
+        for line in body.split("\n"):
+            if "throw" in line:
+                assert "schemas" not in line.lower() and ".json" not in line.lower(), (
+                    f"connectRepo should not throw on empty schemas: {line.strip()}"
+                )
+        # Should show a helpful status message
+        assert "no schemas yet" in body.lower() or "create" in body.lower()
 
     def test_friendly_error_precise_json_match(self, index_html: str) -> None:
         """friendlyError only matches actual JSON parse errors, not '.json' in filenames."""
         body = _extract_func(index_html, "friendlyError")
         # Should NOT have a broad /JSON/i pattern
         assert "test(msg)" in body
-        # Should match specific parse error patterns
-        assert (
-            "Unexpected token" in body
-            or "JSON.parse" in body
-            or "JSON at position" in body
-        )
+        # Should match specific parse error patterns (escaped in regex literal)
+        assert "Unexpected token" in body
+        assert "JSON at position" in body
+
+    def test_friendly_error_404_pattern(self, index_html: str) -> None:
+        """friendlyError matches HTTP 404 status code, not casual 'not found' text."""
+        body = _extract_func(index_html, "friendlyError")
+        assert r"\b404\b" in body, "should use word-boundary match for 404"
 
     def test_multi_file_commit_empty_repo_fallback(self, index_html: str) -> None:
         """Multi-file commit falls back to sequential PUTs on empty repos (404 on refs)."""
         body = _extract_func(index_html, "devGhCommitAndPush")
         assert "useTreesApi" in body, "should have Trees API flag"
-        assert "'404'" in body or '"404"' in body, "should check for 404"
-        assert (
-            "Contents API" in body
-            or "sequential" in body.lower()
-            or "fallback" in body.lower()
-        )
+        assert "includes('404')" in body, "should detect 404 via includes()"
 
-    def test_save_schema_routes_tracked_file_to_commit(self, index_html: str) -> None:
-        """devSaveSchema shows commit panel for tracked GitHub files (Ctrl+S)."""
-        body = _extract_func(index_html, "devSaveSchema")
-        # Should have a branch for tracked files that calls commit panel
-        assert "devGhShowCommitPanel" in body
+    def test_register_new_file_validates_filename(self, index_html: str) -> None:
+        """devGhRegisterNewFile rejects filenames with path separators or leading dots."""
+        body = _extract_func(index_html, "devGhRegisterNewFile")
+        assert "Invalid filename" in body
+        assert "startsWith('_')" in body or "startsWith('.')" in body
 
-    def test_save_template_routes_tracked_file_to_commit(self, index_html: str) -> None:
-        """devSaveTemplate shows commit panel for tracked GitHub files (Ctrl+S)."""
-        body = _extract_func(index_html, "devSaveTemplate")
-        assert "devGhShowCommitPanel" in body
+    def test_sequential_fallback_updates_sha(self, index_html: str) -> None:
+        """Sequential fallback updates SHA after each PUT for safe retry."""
+        body = _extract_func(index_html, "devGhCommitAndPush")
+        assert "result.content.sha" in body, "should update SHA from PUT response"
+
+    def test_commit_handles_refresh_failure(self, index_html: str) -> None:
+        """Post-commit handles devGhFetchFiles failure gracefully."""
+        body = _extract_func(index_html, "devGhCommitAndPush")
+        assert "refreshErr" in body or "refresh workspace" in body.lower()
 
 
 # ============================================================

--- a/tests/test_dev_mode.py
+++ b/tests/test_dev_mode.py
@@ -1708,6 +1708,20 @@ def test_profile_empty_state_hint(index_html: str) -> None:
     assert "Save a profile to autofill common fields" in index_html
 
 
+def test_picker_create_card_in_render(index_html: str) -> None:
+    """renderPicker always adds a 'Create a Form' card."""
+    body = _extract_func(index_html, "renderPicker")
+    assert "picker-card-create" in body
+    assert "Create a Form" in body
+    assert "devNewSchema" in body
+
+
+def test_picker_create_card_css(index_html: str) -> None:
+    """Create card has dashed border styling."""
+    assert ".picker-card-create" in index_html
+    assert "dashed" in index_html
+
+
 def test_picker_after_empty_state(index_html: str) -> None:
     """Picker section should appear after the empty state in setup view."""
     setup_start = index_html.index('id="view-setup"')

--- a/tests/test_dev_mode.py
+++ b/tests/test_dev_mode.py
@@ -1227,6 +1227,143 @@ class TestGitHubWorkspaceJavaScript:
         # Check for regex validation of branch name
         assert "test(name)" in body or "test(" in body
 
+    def test_register_new_file_function_exists(self, index_html: str) -> None:
+        """devGhRegisterNewFile function is defined for committing new files."""
+        body = _extract_func(index_html, "devGhRegisterNewFile")
+        assert "ghToken" in body, "should check for auth token"
+        assert "ghOriginalContents" in body, "should register in originals"
+        assert "ghModifiedFiles" in body, "should mark file as modified"
+        assert "workspaceFiles" in body, "should add to workspace files"
+        assert "currentWorkspaceFile" in body, "should set as current file"
+        assert "prompt(" in body, "should prompt for filename"
+
+    def test_register_new_file_derives_schema_filename(self, index_html: str) -> None:
+        """devGhRegisterNewFile derives filename from schema title."""
+        body = _extract_func(index_html, "devGhRegisterNewFile")
+        assert "obj.title" in body, "should use schema title for default name"
+        assert ".json" in body, "should enforce .json extension for schemas"
+        assert ".py" in body, "should enforce .py extension for templates"
+
+    def test_register_new_file_sets_sha_null(self, index_html: str) -> None:
+        """New files are registered with sha: null to signal creation."""
+        body = _extract_func(index_html, "devGhRegisterNewFile")
+        assert "sha: null" in body, "should set sha to null for new files"
+
+    def test_register_new_file_prevents_duplicates(self, index_html: str) -> None:
+        """devGhRegisterNewFile rejects files that already exist in workspace."""
+        body = _extract_func(index_html, "devGhRegisterNewFile")
+        assert "already exists" in body, "should prevent duplicate file registration"
+
+    def test_commit_omits_sha_for_new_files(self, index_html: str) -> None:
+        """devGhCommitAndPush omits sha from PUT body for new files."""
+        body = _extract_func(index_html, "devGhCommitAndPush")
+        assert "original.sha" in body or "original && original.sha" in body
+        # The PUT body should conditionally include sha
+        assert "putBody" in body, "should build PUT body conditionally"
+
+    def test_track_modification_handles_new_files(self, index_html: str) -> None:
+        """devGhTrackModification handles new files with sha === null."""
+        body = _extract_func(index_html, "devGhTrackModification")
+        assert "sha === null" in body, "should check for null sha (new file)"
+
+    def test_commit_panel_labels_new_files(self, index_html: str) -> None:
+        """Commit panel shows (new) indicator for untracked files."""
+        body = _extract_func(index_html, "devGhShowCommitPanel")
+        assert "(new)" in body, "should label new files in commit panel"
+
+    def test_save_schema_github_path(self, index_html: str) -> None:
+        """devSaveSchema routes to register flow when GitHub connected."""
+        body = _extract_func(index_html, "devSaveSchema")
+        assert "devGhRegisterNewFile" in body, "should call register for GitHub"
+        assert "devGhShowCommitPanel" in body, "should show commit panel"
+
+    def test_save_template_github_path(self, index_html: str) -> None:
+        """devSaveTemplate routes to register flow when GitHub connected."""
+        body = _extract_func(index_html, "devSaveTemplate")
+        assert "devGhRegisterNewFile" in body, "should call register for GitHub"
+        assert "devGhShowCommitPanel" in body, "should show commit panel"
+
+    def test_source_toolbar_shows_commit_for_new_content(self, index_html: str) -> None:
+        """updateSourceToolbar shows commit button for new unregistered content."""
+        body = _extract_func(index_html, "updateSourceToolbar")
+        assert "hasEditorContent" in body, "should check for editor content"
+        assert "new file" in body, "should show 'new file' indicator"
+
+    def test_new_schema_clears_workspace_file(self, index_html: str) -> None:
+        """devNewSchema resets currentWorkspaceFile."""
+        body = _extract_func(index_html, "devNewSchema")
+        assert "currentWorkspaceFile = null" in body
+
+    def test_new_template_clears_workspace_file(self, index_html: str) -> None:
+        """devNewTemplate resets currentWorkspaceFile."""
+        body = _extract_func(index_html, "devNewTemplate")
+        assert "currentWorkspaceFile = null" in body
+
+    def test_commit_refreshes_picker_for_new_schemas(self, index_html: str) -> None:
+        """After committing new schemas, the picker is refreshed."""
+        body = _extract_func(index_html, "devGhCommitAndPush")
+        assert "devGhRefreshPicker" in body, "should refresh picker after schema commit"
+
+    def test_refresh_picker_function_exists(self, index_html: str) -> None:
+        """devGhRefreshPicker re-fetches schemas and updates the picker."""
+        body = _extract_func(index_html, "devGhRefreshPicker")
+        assert "renderPicker" in body, "should call renderPicker"
+        assert "repoSchemas" in body, "should update repoSchemas"
+
+    def test_commit_relinks_workspace_file(self, index_html: str) -> None:
+        """After commit, currentWorkspaceFile is re-linked to refreshed entry."""
+        body = _extract_func(index_html, "devGhCommitAndPush")
+        assert "editingPath" in body, "should remember editing path"
+        assert "findIndex" in body, "should find file in refreshed workspace"
+
+    def test_connect_repo_tolerates_empty_schemas(self, index_html: str) -> None:
+        """connectRepo does not throw when schemas/ has no JSON files."""
+        body = _extract_func(index_html, "connectRepo")
+        assert (
+            "No schemas found" not in body
+            or "throw" not in body.split("No schemas found")[0][-50:]
+        )
+        # Should log a helpful message instead of throwing
+        assert (
+            "Schema tab" in body
+            or "no schemas yet" in body.lower()
+            or "create" in body.lower()
+        )
+
+    def test_friendly_error_precise_json_match(self, index_html: str) -> None:
+        """friendlyError only matches actual JSON parse errors, not '.json' in filenames."""
+        body = _extract_func(index_html, "friendlyError")
+        # Should NOT have a broad /JSON/i pattern
+        assert "test(msg)" in body
+        # Should match specific parse error patterns
+        assert (
+            "Unexpected token" in body
+            or "JSON.parse" in body
+            or "JSON at position" in body
+        )
+
+    def test_multi_file_commit_empty_repo_fallback(self, index_html: str) -> None:
+        """Multi-file commit falls back to sequential PUTs on empty repos (404 on refs)."""
+        body = _extract_func(index_html, "devGhCommitAndPush")
+        assert "useTreesApi" in body, "should have Trees API flag"
+        assert "'404'" in body or '"404"' in body, "should check for 404"
+        assert (
+            "Contents API" in body
+            or "sequential" in body.lower()
+            or "fallback" in body.lower()
+        )
+
+    def test_save_schema_routes_tracked_file_to_commit(self, index_html: str) -> None:
+        """devSaveSchema shows commit panel for tracked GitHub files (Ctrl+S)."""
+        body = _extract_func(index_html, "devSaveSchema")
+        # Should have a branch for tracked files that calls commit panel
+        assert "devGhShowCommitPanel" in body
+
+    def test_save_template_routes_tracked_file_to_commit(self, index_html: str) -> None:
+        """devSaveTemplate shows commit panel for tracked GitHub files (Ctrl+S)."""
+        body = _extract_func(index_html, "devSaveTemplate")
+        assert "devGhShowCommitPanel" in body
+
 
 # ============================================================
 #  ISSUE #130 — Line Numbers in Editors


### PR DESCRIPTION
## Summary

Closes #202

- **New function `devGhRegisterNewFile(type)`** — prompts for filename (defaults from schema title or template comment), creates workspace entries with `sha: null`, marks as modified
- **Save routes to commit** — `devSaveSchema()`/`devSaveTemplate()` show the commit panel when GitHub is connected (both new files and tracked files)
- **Toolbar shows Commit for new content** — `updateSourceToolbar()` displays Commit button and "new file (unsaved)" label when editor has content without a workspace entry
- **New file creation via Contents API** — `devGhCommitAndPush()` omits `sha` for new files; falls back to sequential PUTs on empty repos where Git refs return 404
- **Post-commit refresh** — `devGhRefreshPicker()` updates the Forms tab picker; `currentWorkspaceFile` is re-linked to the refreshed workspace entry
- **Empty repo tolerance** — `connectRepo()` no longer throws on empty `schemas/`/`templates/` directories
- **Precise error matching** — `friendlyError()` regex tightened to avoid false "Invalid JSON" on ".json" in error text

## Test plan

- [x] 20 new tests in `test_dev_mode.py` covering all new functions and behavior (513 total, all passing)
- [x] Lint clean (`ruff check` + `ruff format`)
- [ ] Manual: connect to empty GitHub repo, create schema in editor, click Save → prompted for filename → commit panel opens → commit succeeds
- [ ] Manual: create template, commit it alongside schema (multi-file)
- [ ] Manual: after commit, schema appears in Forms tab picker
- [ ] Manual: Ctrl+S on tracked GitHub file shows commit panel (not download)

🤖 Generated with [Claude Code](https://claude.com/claude-code)