### PR TITLE
Convert top navigation to persistent sidebar layout

### DIFF
--- a/docs/DEVLOG.md
+++ b/docs/DEVLOG.md
@@ -14,6 +14,48 @@
 
 ## Log
 
+### 2026-03-24 — Issue Created: Contextual Help Sidebars (#209)
+
+Created issue #209 to add contextual help sidebars (right-hand drawers) to the Schema and Template editors. The Schema sidebar will surface field type references, schema structure rules, and cursor-aware highlighting. The Template sidebar will show stencils method signatures, theme reference, and data shape from the connected schema. Both include collapsible accordion sections, search/filter, insert-on-click snippets, keyboard shortcut toggle, and localStorage persistence. This reduces reliance on switching to the Docs tab for reference information during editing.
+
+---
+
+### 2026-03-25 — Sidebar Navigation (#208)
+
+Replaced the horizontal top navigation bar with a persistent left sidebar layout.
+
+**Layout restructure:**
+- New `.app-shell` flex container wraps `.app-sidebar` + `.app-main` horizontally
+- Header remains at the top spanning full width; sidebar sits below it
+- All four tabs (Forms, Schema, Template, Docs) render vertically in the sidebar
+- Active tab highlighted with `border-left: 2px solid var(--accent)` + `background: var(--accent-subtle)`
+
+**Collapsible sidebar:**
+- `toggleSidebar()` toggles `.collapsed` class (200px expanded → 52px icon-only)
+- Collapse state persisted via `localStorage('formforge-sidebar-collapsed')`
+- Chevron icon rotates 180 degrees when collapsed
+- Labels and status text hidden in collapsed mode via `.nav-label` / `.status-text` spans
+
+**Status badge relocation:**
+- Connection status badge moved from header into sidebar footer
+- New `syncSidebarStatus()` syncs sidebar badge whenever header badge changes
+- Header badge hidden on desktop (CSS `display: none`), shown on mobile via media query
+
+**Responsive behavior:**
+- `>1024px`: Full expanded sidebar with labels and collapse toggle
+- `768–1024px`: Auto-collapsed to icon-only, collapse toggle hidden
+- `<768px`: Sidebar hidden entirely; mobile bottom nav bar with all 4 tabs (icon + label)
+- All 4 tabs accessible on mobile (previously Schema/Template were hidden at 768px)
+
+**Tests updated:**
+- `test_dev_nav_has_four_tabs`: expects 8 tab instances (4 sidebar + 4 mobile bottom nav)
+- `test_css_section_31/37`: updated section names to "SIDEBAR NAVIGATION" / "SIDEBAR RESPONSIVE"
+- `test_mobile_gate_hides_sidebar`: verifies `.app-sidebar { display: none }` at 768px
+- `test_mobile_bottom_nav_exists`: verifies mobile bottom nav HTML presence
+- New `test_sidebar_structure` and `test_sidebar_collapse_persists` tests added
+
+---
+
 ### 2026-03-16 — LLM Context Export (#205)
 
 Implemented LLM context export to help users leverage AI assistants when building schemas and templates.

--- a/index.html
+++ b/index.html
@@ -41,13 +41,13 @@
    * 28. Drop Zones
    * 29. Docs Section
    * 30. Responsive / Media Queries
-   * 31. Dev Mode Core
+   * 31. Sidebar Navigation
    * 32. Dev Split Pane & Editor
    * 33. Context Menu
    * 34. Template Builder
    * 35. (removed)
    * 36. Reduced Motion
-   * 37. Dev Mode Mobile Gate
+   * 37. Sidebar Responsive
    */
 
   /* ===== 1. VARIABLES & RESETS ===== */
@@ -221,22 +221,28 @@
   .h1-home-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: var(--radius-xs); }
   .header-right { display: flex; align-items: center; gap: 12px; position: relative; }
   .status-badge {
-    display: inline-flex; align-items: center; gap: 8px;
-    padding: 6px 14px; border-radius: var(--radius-pill); font-size: var(--text-sm); font-weight: 500;
-    font-family: var(--font-mono);
-    background: var(--surface-2); border: 1px solid var(--border); color: var(--text-muted);
-    transition: all var(--transition-slow) ease;
+    display: none; /* moved to sidebar; kept as hidden fallback for mobile */
   }
-  .status-badge.ready { border-color: var(--success); color: var(--success); }
-  .status-badge.loading { border-color: var(--warning); color: var(--warning); }
-  .status-badge.error { border-color: var(--error); color: var(--error); }
   .status-dot { width: 7px; height: 7px; border-radius: var(--radius-circle); background: currentColor; }
-  .status-badge.loading .status-dot { animation: pulse 1.2s ease-in-out infinite; }
+  .sidebar-status-badge.loading .status-dot { animation: pulse 1.2s ease-in-out infinite; }
   @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.3; } }
-  .status-badge { cursor: pointer; }
-  .status-badge:hover { border-color: var(--text-muted); }
-  .status-badge.ready:hover { border-color: var(--success); }
   .status-chevron { font-size: var(--text-2xs); margin-left: 2px; opacity: 0.6; }
+  /* Show header status badge on mobile where sidebar is hidden */
+  @media (max-width: 768px) {
+    .status-badge {
+      display: inline-flex; align-items: center; gap: 8px;
+      padding: 6px 14px; border-radius: var(--radius-pill); font-size: var(--text-sm); font-weight: 500;
+      font-family: var(--font-mono);
+      background: var(--surface-2); border: 1px solid var(--border); color: var(--text-muted);
+      transition: all var(--transition-slow) ease; cursor: pointer;
+    }
+    .status-badge:hover { border-color: var(--text-muted); }
+    .status-badge.ready { border-color: var(--success); color: var(--success); }
+    .status-badge.ready:hover { border-color: var(--success); }
+    .status-badge.loading { border-color: var(--warning); color: var(--warning); }
+    .status-badge.error { border-color: var(--error); color: var(--error); }
+    .status-badge.loading .status-dot { animation: pulse 1.2s ease-in-out infinite; }
+  }
 
   /* ===== 3b. CONNECT DIALOG ===== */
   .connect-dialog-overlay {
@@ -317,13 +323,18 @@
     height: 100vh; overflow: hidden;
     display: flex; flex-direction: column;
   }
-  body > .app-header,
-  body > .dev-nav { flex-shrink: 0; }
+  body > .app-header { flex-shrink: 0; }
+  .app-shell {
+    display: flex; flex: 1; min-height: 0;
+  }
   .view { display: none; }
   .view.active { display: block; flex: 1; overflow-y: auto; }
   .view.active[role="tabpanel"] {
     display: flex; flex-direction: column; flex: 1;
     width: 100%; min-height: 0; overflow: hidden;
+  }
+  .app-main {
+    flex: 1; min-width: 0; display: flex; flex-direction: column;
   }
   #view-dev-docs.view.active { overflow-y: auto; }
   #view-dev-docs .main-container { width: min(820px, 100% - 48px); }
@@ -1550,28 +1561,72 @@
   .docs-rendered-md blockquote { border-left: 3px solid var(--accent); padding-left: 14px; margin: 8px 0; color: var(--text-muted); font-style: italic; }
   .docs-rendered-md-link { color: var(--accent-hover); }
 
-  /* ===== 31. DEV MODE CORE ===== */
-  .dev-nav {
-    display: flex; align-items: center; justify-content: center; gap: 2px;
-    padding: 4px 24px; background: var(--bg);
-    border-bottom: 1px solid var(--border);
+  /* ===== 31. SIDEBAR NAVIGATION ===== */
+  .app-sidebar {
+    width: 200px; flex-shrink: 0;
+    display: flex; flex-direction: column;
+    background: var(--bg); border-right: 1px solid var(--border);
+    transition: width var(--transition-base);
+    overflow: hidden;
+  }
+  .app-sidebar.collapsed { width: 52px; }
+  .app-sidebar-nav {
+    display: flex; flex-direction: column; gap: 2px;
+    padding: 12px 8px; flex: 1;
   }
   .dev-nav-tab {
-    display: inline-flex; align-items: center; gap: 6px;
-    padding: 8px 14px; border-radius: var(--radius-md) var(--radius-md) 0 0;
-    background: transparent; border: 1px solid transparent;
-    border-bottom: none;
+    display: flex; align-items: center; gap: 10px;
+    padding: 10px 12px; border-radius: var(--radius-md);
+    background: transparent; border: none;
+    border-left: 2px solid transparent;
     color: var(--text-muted); font-family: var(--font-sans);
     font-size: var(--text-sm); cursor: pointer;
     transition: all var(--transition-base);
-    position: relative; bottom: -1px;
+    white-space: nowrap; overflow: hidden;
+    width: 100%; text-align: left;
   }
   .dev-nav-tab:hover { color: var(--text); background: var(--surface-2); }
-  .dev-nav-tab:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+  .dev-nav-tab:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: var(--radius-md); }
   .dev-nav-tab.active {
-    color: var(--text); background: var(--surface);
-    border-color: var(--border);
+    color: var(--text); background: var(--accent-subtle);
+    border-left-color: var(--accent);
   }
+  .dev-nav-tab svg { flex-shrink: 0; }
+  .dev-nav-tab .nav-label { overflow: hidden; text-overflow: ellipsis; }
+  .app-sidebar.collapsed .nav-label { display: none; }
+  .app-sidebar-footer {
+    padding: 8px; border-top: 1px solid var(--border);
+    display: flex; flex-direction: column; gap: 6px;
+  }
+  .sidebar-toggle {
+    display: flex; align-items: center; justify-content: center;
+    width: 100%; padding: 6px; background: transparent; border: none;
+    color: var(--text-muted); cursor: pointer; border-radius: var(--radius-sm);
+    transition: all var(--transition-fast);
+  }
+  .sidebar-toggle:hover { color: var(--text); background: var(--surface-2); }
+  .sidebar-toggle:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+  .sidebar-toggle svg { transition: transform var(--transition-base); }
+  .app-sidebar.collapsed .sidebar-toggle svg { transform: rotate(180deg); }
+  .sidebar-status-badge {
+    display: flex; align-items: center; gap: 8px;
+    padding: 6px 10px; border-radius: var(--radius-pill); font-size: var(--text-xs); font-weight: 500;
+    font-family: var(--font-mono);
+    background: var(--surface-2); border: 1px solid var(--border); color: var(--text-muted);
+    transition: all var(--transition-slow) ease;
+    cursor: pointer; white-space: nowrap; overflow: hidden;
+    width: 100%;
+  }
+  .sidebar-status-badge:hover { border-color: var(--text-muted); }
+  .sidebar-status-badge.ready { border-color: var(--success); color: var(--success); }
+  .sidebar-status-badge.ready:hover { border-color: var(--success); }
+  .sidebar-status-badge.loading { border-color: var(--warning); color: var(--warning); }
+  .sidebar-status-badge.error { border-color: var(--error); color: var(--error); }
+  .sidebar-status-badge .status-dot { flex-shrink: 0; }
+  .sidebar-status-badge .status-text { overflow: hidden; text-overflow: ellipsis; }
+  .app-sidebar.collapsed .sidebar-status-badge .status-text { display: none; }
+  .app-sidebar.collapsed .sidebar-status-badge .status-chevron { display: none; }
+  .app-sidebar.collapsed .sidebar-status-badge { justify-content: center; padding: 6px; }
 
   .dev-container {
     width: 100%; max-width: 1600px; margin: 0 auto;
@@ -2062,12 +2117,41 @@
     }
   }
 
-  /* ===== 37. DEV MODE MOBILE GATE ===== */
+  /* ===== 37. SIDEBAR RESPONSIVE ===== */
+  @media (max-width: 1024px) {
+    .app-sidebar { width: 52px; }
+    .app-sidebar .nav-label { display: none; }
+    .app-sidebar .sidebar-status-badge .status-text { display: none; }
+    .app-sidebar .sidebar-status-badge .status-chevron { display: none; }
+    .app-sidebar .sidebar-status-badge { justify-content: center; padding: 6px; }
+    .sidebar-toggle { display: none; }
+  }
   @media (max-width: 768px) {
-    .dev-nav-tab[data-tab="dev-schema"],
-    .dev-nav-tab[data-tab="dev-template"] { display: none; }
+    .app-shell { flex-direction: column; }
+    .app-sidebar { display: none; }
+    .mobile-bottom-nav {
+      display: flex; align-items: center; justify-content: center; gap: 2px;
+      padding: 6px 8px; background: var(--bg);
+      border-top: 1px solid var(--border);
+      flex-shrink: 0; order: 99;
+    }
+    .mobile-bottom-nav .dev-nav-tab {
+      flex: 1; flex-direction: column; gap: 2px;
+      padding: 6px 4px; border-left: none;
+      border-bottom: 2px solid transparent;
+      text-align: center; justify-content: center;
+      font-size: var(--text-2xs);
+    }
+    .mobile-bottom-nav .dev-nav-tab.active {
+      border-bottom-color: var(--accent); border-left-color: transparent;
+      background: var(--accent-subtle);
+    }
+    .mobile-bottom-nav .dev-nav-tab svg { width: 16px; height: 16px; }
     .dev-split { flex-direction: column; }
     .dev-pane-resizer { display: none; }
+  }
+  @media (min-width: 769px) {
+    .mobile-bottom-nav { display: none; }
   }
 
   /* ===== 38. REDUCE GPU COST ON TOUCH DEVICES ===== */
@@ -2206,6 +2290,10 @@
   <!-- Link: used for Connect a Source -->
   <symbol id="icon-link" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
     <path d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"/>
+  </symbol>
+  <!-- Chevron left: used for sidebar collapse toggle -->
+  <symbol id="icon-chevron-left" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+    <path d="M15 18l-6-6 6-6"/>
   </symbol>
 </svg>
 
@@ -2348,25 +2436,43 @@
   </div>
 </div>
 
-<!-- Primary Navigation -->
-<nav class="dev-nav" id="mainNav" role="tablist" aria-label="Main navigation">
-  <button type="button" class="dev-nav-tab active" id="tab-forms" data-tab="forms" role="tab" aria-selected="true" aria-controls="view-setup" onclick="showTab('forms')">
-    <svg width="14" height="14" aria-hidden="true"><use href="#icon-file-text"/></svg>
-    Forms
-  </button>
-  <button type="button" class="dev-nav-tab" id="tab-dev-schema" data-tab="dev-schema" role="tab" aria-selected="false" aria-controls="view-dev-schema" onclick="showTab('dev-schema')">
-    <svg width="14" height="14" aria-hidden="true"><use href="#icon-file-upload"/></svg>
-    Schema
-  </button>
-  <button type="button" class="dev-nav-tab" id="tab-dev-template" data-tab="dev-template" role="tab" aria-selected="false" aria-controls="view-dev-template" onclick="showTab('dev-template')">
-    <svg width="14" height="14" aria-hidden="true"><use href="#icon-code"/></svg>
-    Template
-  </button>
-  <button type="button" class="dev-nav-tab" id="tab-dev-docs" data-tab="dev-docs" role="tab" aria-selected="false" aria-controls="view-dev-docs" onclick="showTab('dev-docs')">
-    <svg width="14" height="14" aria-hidden="true"><use href="#icon-book"/></svg>
-    Docs
-  </button>
-</nav>
+<!-- App Shell: sidebar + main content -->
+<div class="app-shell">
+
+<!-- Sidebar Navigation -->
+<aside class="app-sidebar" id="appSidebar" role="navigation" aria-label="Main navigation">
+  <nav class="app-sidebar-nav" id="mainNav" role="tablist" aria-label="Main navigation">
+    <button type="button" class="dev-nav-tab active" id="tab-forms" data-tab="forms" role="tab" aria-selected="true" aria-controls="view-setup" onclick="showTab('forms')">
+      <svg width="16" height="16" aria-hidden="true"><use href="#icon-file-text"/></svg>
+      <span class="nav-label">Forms</span>
+    </button>
+    <button type="button" class="dev-nav-tab" id="tab-dev-schema" data-tab="dev-schema" role="tab" aria-selected="false" aria-controls="view-dev-schema" onclick="showTab('dev-schema')">
+      <svg width="16" height="16" aria-hidden="true"><use href="#icon-file-upload"/></svg>
+      <span class="nav-label">Schema</span>
+    </button>
+    <button type="button" class="dev-nav-tab" id="tab-dev-template" data-tab="dev-template" role="tab" aria-selected="false" aria-controls="view-dev-template" onclick="showTab('dev-template')">
+      <svg width="16" height="16" aria-hidden="true"><use href="#icon-code"/></svg>
+      <span class="nav-label">Template</span>
+    </button>
+    <button type="button" class="dev-nav-tab" id="tab-dev-docs" data-tab="dev-docs" role="tab" aria-selected="false" aria-controls="view-dev-docs" onclick="showTab('dev-docs')">
+      <svg width="16" height="16" aria-hidden="true"><use href="#icon-book"/></svg>
+      <span class="nav-label">Docs</span>
+    </button>
+  </nav>
+  <div class="app-sidebar-footer">
+    <button type="button" class="sidebar-toggle" id="sidebarToggle" onclick="toggleSidebar()" aria-label="Collapse sidebar" title="Collapse sidebar">
+      <svg width="16" height="16" aria-hidden="true"><use href="#icon-chevron-left"/></svg>
+    </button>
+    <button type="button" class="sidebar-status-badge" id="sidebarStatusBadge" onclick="showConnectDialog()" title="Connection settings" aria-label="Connection settings">
+      <div class="status-dot" aria-hidden="true"></div>
+      <span class="status-text" id="sidebarStatusText">not connected</span>
+      <span class="status-chevron" aria-hidden="true">&#9662;</span>
+    </button>
+  </div>
+</aside>
+
+<!-- Main Content Area -->
+<div class="app-main">
 
 <!-- ==================== SETUP VIEW ==================== -->
 <main class="view active" id="view-setup" role="tabpanel" aria-labelledby="tab-forms">
@@ -2707,6 +2813,30 @@
     </div>
   </div>
 </main>
+
+</div><!-- /.app-main -->
+
+<!-- Mobile Bottom Navigation (visible only at <=768px) -->
+<nav class="mobile-bottom-nav" id="mobileBottomNav" role="tablist" aria-label="Main navigation">
+  <button type="button" class="dev-nav-tab active" data-tab="forms" role="tab" aria-selected="true" aria-controls="view-setup" onclick="showTab('forms')">
+    <svg width="16" height="16" aria-hidden="true"><use href="#icon-file-text"/></svg>
+    <span class="nav-label">Forms</span>
+  </button>
+  <button type="button" class="dev-nav-tab" data-tab="dev-schema" role="tab" aria-selected="false" aria-controls="view-dev-schema" onclick="showTab('dev-schema')">
+    <svg width="16" height="16" aria-hidden="true"><use href="#icon-file-upload"/></svg>
+    <span class="nav-label">Schema</span>
+  </button>
+  <button type="button" class="dev-nav-tab" data-tab="dev-template" role="tab" aria-selected="false" aria-controls="view-dev-template" onclick="showTab('dev-template')">
+    <svg width="16" height="16" aria-hidden="true"><use href="#icon-code"/></svg>
+    <span class="nav-label">Template</span>
+  </button>
+  <button type="button" class="dev-nav-tab" data-tab="dev-docs" role="tab" aria-selected="false" aria-controls="view-dev-docs" onclick="showTab('dev-docs')">
+    <svg width="16" height="16" aria-hidden="true"><use href="#icon-book"/></svg>
+    <span class="nav-label">Docs</span>
+  </button>
+</nav>
+
+</div><!-- /.app-shell -->
 
 <!-- GitHub Connect Repo Modal -->
 <div class="gh-connect-modal" id="ghConnectModal" role="dialog" aria-labelledby="ghConnectTitle" aria-modal="true">
@@ -3804,6 +3934,7 @@ async function connectRepo() {
     const badge = document.getElementById('statusBadge');
     badge.className = 'status-badge ready';
     document.getElementById('statusText').textContent = `${ghOwner}/${ghRepo}`;
+    syncSidebarStatus('ready', `${ghOwner}/${ghRepo}`);
 
     contentSourceType = 'github';
 
@@ -9416,6 +9547,30 @@ function loadScript(src) {
   });
 }
 
+// ============================================================
+//  SIDEBAR
+// ============================================================
+
+function toggleSidebar() {
+  const sidebar = document.getElementById('appSidebar');
+  const collapsed = sidebar.classList.toggle('collapsed');
+  localStorage.setItem('formforge-sidebar-collapsed', collapsed ? '1' : '');
+  const btn = document.getElementById('sidebarToggle');
+  if (btn) {
+    btn.setAttribute('aria-label', collapsed ? 'Expand sidebar' : 'Collapse sidebar');
+    btn.setAttribute('title', collapsed ? 'Expand sidebar' : 'Collapse sidebar');
+  }
+}
+
+function syncSidebarStatus(className, text) {
+  const badge = document.getElementById('sidebarStatusBadge');
+  const textEl = document.getElementById('sidebarStatusText');
+  if (badge) {
+    badge.className = 'sidebar-status-badge' + (className ? ' ' + className : '');
+  }
+  if (textEl && text != null) textEl.textContent = text;
+}
+
 const VALID_TABS = new Set(['forms', 'dev-schema', 'dev-template', 'dev-docs']);
 
 async function showTab(tabName) {
@@ -11779,6 +11934,7 @@ function finalizeLocalConnection(handle) {
   contentSourceType = 'local';
   document.getElementById('statusBadge').className = 'status-badge ready';
   document.getElementById('statusText').textContent = `local: ${handle.name}`;
+  syncSidebarStatus('ready', `local: ${handle.name}`);
   renderPicker();
   if (repoSchemas.length === 0) {
     showToast('No schemas found — use "Create a Form" to get started', 'info');
@@ -11854,6 +12010,7 @@ async function restoreLocalFolder(folderName) {
       grid.appendChild(card);
       document.getElementById('statusBadge').className = 'status-badge';
       document.getElementById('statusText').textContent = `local: ${displayName} (reconnect needed)`;
+      syncSidebarStatus('', `local: ${displayName} (reconnect needed)`);
     }
   } catch (e) {
     log('Could not restore local folder: ' + e.message, 'error');
@@ -12737,6 +12894,7 @@ function disconnectSource() {
   // Reset status badge and picker
   document.getElementById('statusBadge').className = 'status-badge';
   document.getElementById('statusText').textContent = 'not connected';
+  syncSidebarStatus('', 'not connected');
   document.getElementById('pickerSection').style.display = 'none';
   document.getElementById('setupEmptyState').style.display = '';
 
@@ -12973,6 +13131,16 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Preload Pyodide in the background so the first export is faster
   preloadPyodide();
+
+  // Restore sidebar collapsed state
+  if (localStorage.getItem('formforge-sidebar-collapsed') === '1') {
+    const sidebar = document.getElementById('appSidebar');
+    if (sidebar) {
+      sidebar.classList.add('collapsed');
+      const btn = document.getElementById('sidebarToggle');
+      if (btn) { btn.setAttribute('aria-label', 'Expand sidebar'); btn.setAttribute('title', 'Expand sidebar'); }
+    }
+  }
 
   // Restore last active tab
   const lastTab = localStorage.getItem('formforge-active-tab');

--- a/index.html
+++ b/index.html
@@ -2473,7 +2473,7 @@
 <div class="app-main">
 
 <!-- ==================== SETUP VIEW ==================== -->
-<main class="view active" id="view-setup" role="tabpanel" aria-labelledby="tab-forms">
+<main class="view active" id="view-setup" role="tabpanel" aria-labelledby="tab-forms mob-tab-forms" tabindex="-1">
   <div class="main-container">
     <div class="setup-hero">
       <h2>Forms that build documents</h2>
@@ -2566,7 +2566,7 @@
 </main>
 
 <!-- ==================== DEV: SCHEMA BUILDER VIEW ==================== -->
-<main class="view" id="view-dev-schema" role="tabpanel" aria-labelledby="tab-dev-schema">
+<main class="view" id="view-dev-schema" role="tabpanel" aria-labelledby="tab-dev-schema mob-tab-dev-schema">
   <div class="dev-container">
     <div class="dev-toolbar">
       <div class="dev-toolbar-left">
@@ -2642,7 +2642,7 @@
 </main>
 
 <!-- ==================== DEV: TEMPLATE BUILDER VIEW ==================== -->
-<main class="view" id="view-dev-template" role="tabpanel" aria-labelledby="tab-dev-template">
+<main class="view" id="view-dev-template" role="tabpanel" aria-labelledby="tab-dev-template mob-tab-dev-template">
   <div class="dev-container">
     <div class="dev-toolbar">
       <div class="dev-toolbar-left">
@@ -2750,7 +2750,7 @@
 </div>
 
 <!-- ==================== DEV: DOCS VIEW ==================== -->
-<main class="view" id="view-dev-docs" role="tabpanel" aria-labelledby="tab-dev-docs">
+<main class="view" id="view-dev-docs" role="tabpanel" aria-labelledby="tab-dev-docs mob-tab-dev-docs">
   <div class="main-container">
     <div class="docs-section" id="docsSection">
 
@@ -2816,19 +2816,19 @@
 
 <!-- Mobile Bottom Navigation (visible only at <=768px) -->
 <nav class="mobile-bottom-nav" id="mobileBottomNav" role="tablist" aria-label="Navigation">
-  <button type="button" class="dev-nav-tab active" data-tab="forms" role="tab" aria-selected="true" aria-controls="view-setup" onclick="showTab('forms')">
+  <button type="button" class="dev-nav-tab active" id="mob-tab-forms" data-tab="forms" role="tab" aria-selected="true" aria-controls="view-setup" onclick="showTab('forms')">
     <svg width="16" height="16" aria-hidden="true"><use href="#icon-file-text"/></svg>
     <span class="nav-label">Forms</span>
   </button>
-  <button type="button" class="dev-nav-tab" data-tab="dev-schema" role="tab" aria-selected="false" aria-controls="view-dev-schema" onclick="showTab('dev-schema')">
+  <button type="button" class="dev-nav-tab" id="mob-tab-dev-schema" data-tab="dev-schema" role="tab" aria-selected="false" aria-controls="view-dev-schema" onclick="showTab('dev-schema')">
     <svg width="16" height="16" aria-hidden="true"><use href="#icon-file-upload"/></svg>
     <span class="nav-label">Schema</span>
   </button>
-  <button type="button" class="dev-nav-tab" data-tab="dev-template" role="tab" aria-selected="false" aria-controls="view-dev-template" onclick="showTab('dev-template')">
+  <button type="button" class="dev-nav-tab" id="mob-tab-dev-template" data-tab="dev-template" role="tab" aria-selected="false" aria-controls="view-dev-template" onclick="showTab('dev-template')">
     <svg width="16" height="16" aria-hidden="true"><use href="#icon-code"/></svg>
     <span class="nav-label">Template</span>
   </button>
-  <button type="button" class="dev-nav-tab" data-tab="dev-docs" role="tab" aria-selected="false" aria-controls="view-dev-docs" onclick="showTab('dev-docs')">
+  <button type="button" class="dev-nav-tab" id="mob-tab-dev-docs" data-tab="dev-docs" role="tab" aria-selected="false" aria-controls="view-dev-docs" onclick="showTab('dev-docs')">
     <svg width="16" height="16" aria-hidden="true"><use href="#icon-book"/></svg>
     <span class="nav-label">Docs</span>
   </button>
@@ -12941,8 +12941,9 @@ function hideConnectDialog() {
 
 function connectDialogKeyHandler(e) {
   if (e.key === 'Escape') { hideConnectDialog(); e.stopPropagation(); return; }
-  // Arrow key navigation between connect dialog tabs
-  if ((e.key === 'ArrowLeft' || e.key === 'ArrowRight') && document.activeElement?.getAttribute('role') === 'tab') {
+  // Arrow key navigation between connect dialog tabs (scoped to dialog)
+  if ((e.key === 'ArrowLeft' || e.key === 'ArrowRight') && document.activeElement?.getAttribute('role') === 'tab'
+      && document.querySelector('.connect-dialog')?.contains(document.activeElement)) {
     e.preventDefault();
     const tabs = [document.getElementById('connectTabBtnGithub'), document.getElementById('connectTabBtnLocal')];
     const idx = tabs.indexOf(document.activeElement);
@@ -13140,6 +13141,27 @@ document.addEventListener('DOMContentLoaded', () => {
       if (btn) { btn.setAttribute('aria-label', 'Expand sidebar'); btn.setAttribute('title', 'Expand sidebar'); }
     }
   }
+
+  // Arrow-key navigation for main nav tablists (ARIA APG tablist pattern)
+  const NAV_TAB_ORDER = ['forms', 'dev-schema', 'dev-template', 'dev-docs'];
+  function handleNavTabKeydown(e) {
+    const btn = e.target.closest('.dev-nav-tab');
+    if (!btn || !btn.dataset.tab) return;
+    // Sidebar: vertical — ArrowUp/ArrowDown; Mobile: horizontal — ArrowLeft/ArrowRight
+    const isVertical = !!btn.closest('.app-sidebar-nav');
+    const prev = isVertical ? 'ArrowUp' : 'ArrowLeft';
+    const next = isVertical ? 'ArrowDown' : 'ArrowRight';
+    if (e.key !== prev && e.key !== next) return;
+    e.preventDefault();
+    const idx = NAV_TAB_ORDER.indexOf(btn.dataset.tab);
+    if (idx < 0) return;
+    const nextIdx = e.key === next ? (idx + 1) % NAV_TAB_ORDER.length : (idx - 1 + NAV_TAB_ORDER.length) % NAV_TAB_ORDER.length;
+    const container = btn.closest('[role="tablist"]');
+    const nextBtn = container?.querySelector(`.dev-nav-tab[data-tab="${NAV_TAB_ORDER[nextIdx]}"]`);
+    if (nextBtn) { nextBtn.focus(); nextBtn.click(); }
+  }
+  document.getElementById('mainNav')?.addEventListener('keydown', handleNavTabKeydown);
+  document.getElementById('mobileBottomNav')?.addEventListener('keydown', handleNavTabKeydown);
 
   // Restore last active tab
   const lastTab = localStorage.getItem('formforge-active-tab');

--- a/index.html
+++ b/index.html
@@ -2118,6 +2118,7 @@
   }
 
   /* ===== 37. SIDEBAR RESPONSIVE ===== */
+  .mobile-bottom-nav { display: none; }
   @media (max-width: 1024px) {
     .app-sidebar { width: 52px; }
     .app-sidebar .nav-label { display: none; }
@@ -2149,9 +2150,6 @@
     .mobile-bottom-nav .dev-nav-tab svg { width: 16px; height: 16px; }
     .dev-split { flex-direction: column; }
     .dev-pane-resizer { display: none; }
-  }
-  @media (min-width: 769px) {
-    .mobile-bottom-nav { display: none; }
   }
 
   /* ===== 38. REDUCE GPU COST ON TOUCH DEVICES ===== */
@@ -2440,7 +2438,7 @@
 <div class="app-shell">
 
 <!-- Sidebar Navigation -->
-<aside class="app-sidebar" id="appSidebar" role="navigation" aria-label="Main navigation">
+<aside class="app-sidebar" id="appSidebar">
   <nav class="app-sidebar-nav" id="mainNav" role="tablist" aria-label="Main navigation">
     <button type="button" class="dev-nav-tab active" id="tab-forms" data-tab="forms" role="tab" aria-selected="true" aria-controls="view-setup" onclick="showTab('forms')">
       <svg width="16" height="16" aria-hidden="true"><use href="#icon-file-text"/></svg>
@@ -2817,7 +2815,7 @@
 </div><!-- /.app-main -->
 
 <!-- Mobile Bottom Navigation (visible only at <=768px) -->
-<nav class="mobile-bottom-nav" id="mobileBottomNav" role="tablist" aria-label="Main navigation">
+<nav class="mobile-bottom-nav" id="mobileBottomNav" role="tablist" aria-label="Navigation">
   <button type="button" class="dev-nav-tab active" data-tab="forms" role="tab" aria-selected="true" aria-controls="view-setup" onclick="showTab('forms')">
     <svg width="16" height="16" aria-hidden="true"><use href="#icon-file-text"/></svg>
     <span class="nav-label">Forms</span>
@@ -9553,8 +9551,10 @@ function loadScript(src) {
 
 function toggleSidebar() {
   const sidebar = document.getElementById('appSidebar');
+  if (!sidebar) return;
   const collapsed = sidebar.classList.toggle('collapsed');
-  localStorage.setItem('formforge-sidebar-collapsed', collapsed ? '1' : '');
+  if (collapsed) localStorage.setItem('formforge-sidebar-collapsed', '1');
+  else localStorage.removeItem('formforge-sidebar-collapsed');
   const btn = document.getElementById('sidebarToggle');
   if (btn) {
     btn.setAttribute('aria-label', collapsed ? 'Expand sidebar' : 'Collapse sidebar');
@@ -9591,11 +9591,10 @@ async function showTab(tabName) {
     t.classList.remove('active');
     t.setAttribute('aria-selected', 'false');
   });
-  const tab = document.querySelector(`.dev-nav-tab[data-tab="${tabName}"]`);
-  if (tab) {
-    tab.classList.add('active');
-    tab.setAttribute('aria-selected', 'true');
-  }
+  document.querySelectorAll(`.dev-nav-tab[data-tab="${tabName}"]`).forEach(t => {
+    t.classList.add('active');
+    t.setAttribute('aria-selected', 'true');
+  });
   localStorage.setItem('formforge-active-tab', tabName);
 
   // Map tab to view

--- a/tests/test_dev_mode.py
+++ b/tests/test_dev_mode.py
@@ -70,7 +70,24 @@ def test_dev_nav_exists(index_html: str) -> None:
 
 
 def test_dev_nav_has_four_tabs(index_html: str) -> None:
-    assert index_html.count('class="dev-nav-tab') == 4
+    # Sidebar has 4 tabs + mobile bottom nav has 4 tabs = 8 total
+    assert index_html.count('class="dev-nav-tab') == 8
+
+
+def test_sidebar_structure(index_html: str) -> None:
+    """Sidebar has expected structure: aside, nav, footer, toggle, status badge."""
+    assert 'id="appSidebar"' in index_html
+    assert 'class="app-sidebar"' in index_html
+    assert 'class="app-sidebar-nav"' in index_html
+    assert 'class="app-sidebar-footer"' in index_html
+    assert 'id="sidebarToggle"' in index_html
+    assert 'id="sidebarStatusBadge"' in index_html
+
+
+def test_sidebar_collapse_persists(index_html: str) -> None:
+    """toggleSidebar saves collapsed state to localStorage."""
+    assert "formforge-sidebar-collapsed" in index_html
+    assert "function toggleSidebar" in index_html
 
 
 def test_view_dev_schema_exists(index_html: str) -> None:
@@ -157,8 +174,8 @@ def test_no_default_repo_value(index_html: str) -> None:
 # --- CSS Sections ---
 
 
-def test_css_section_31_dev_mode_core(index_html: str) -> None:
-    assert "31. DEV MODE CORE" in index_html
+def test_css_section_31_sidebar_navigation(index_html: str) -> None:
+    assert "31. SIDEBAR NAVIGATION" in index_html
 
 
 def test_css_section_32_split_pane(index_html: str) -> None:
@@ -177,16 +194,14 @@ def test_css_section_36_reduced_motion(index_html: str) -> None:
     assert "36. REDUCED MOTION" in index_html
 
 
-def test_css_section_37_mobile_gate(index_html: str) -> None:
-    assert "37. DEV MODE MOBILE GATE" in index_html
+def test_css_section_37_sidebar_responsive(index_html: str) -> None:
+    assert "37. SIDEBAR RESPONSIVE" in index_html
 
 
-def test_mobile_gate_hides_dev_nav(index_html: str) -> None:
-    """Editor tabs (Schema/Template) must be hidden on narrow viewports."""
-    pattern = r'@media\s*\(max-width:\s*768px\)\s*\{[\s\S]*?\.dev-nav-tab\[data-tab="dev-schema"\]'
-    assert re.search(pattern, index_html), (
-        "Schema/Template tabs must be hidden at <=768px"
-    )
+def test_mobile_gate_hides_sidebar(index_html: str) -> None:
+    """Sidebar must be hidden on narrow viewports, replaced by mobile bottom nav."""
+    pattern = r"@media\s*\(max-width:\s*768px\)\s*\{[\s\S]*?\.app-sidebar\s*\{[\s\S]*?display:\s*none"
+    assert re.search(pattern, index_html), "Sidebar must be hidden at <=768px"
 
 
 # --- JavaScript Functions ---
@@ -893,13 +908,10 @@ def test_workspace_poll_auto_reloads_editor(index_html: str) -> None:
 # ============================================================
 
 
-def test_mobile_gate_hides_dev_nav_display_none(index_html: str) -> None:
-    """Schema/Template tabs are hidden at max-width 768px via CSS."""
-    # Individual editor tabs are hidden rather than the entire nav bar
-    pattern = r'@media\s*\(max-width:\s*768px\)\s*\{[\s\S]*?\.dev-nav-tab\[data-tab="dev-schema"\][\s\S]*?display:\s*none'
-    assert re.search(pattern, index_html), (
-        "Schema/Template tabs must be hidden at <=768px"
-    )
+def test_mobile_bottom_nav_exists(index_html: str) -> None:
+    """Mobile bottom nav provides all 4 tabs on narrow viewports."""
+    assert 'class="mobile-bottom-nav"' in index_html
+    assert 'id="mobileBottomNav"' in index_html
 
 
 # ============================================================

--- a/tests/test_dev_mode.py
+++ b/tests/test_dev_mode.py
@@ -2007,7 +2007,8 @@ def test_forms_view_has_tabpanel_role(index_html: str) -> None:
     match = re.search(r'id="view-setup"[^>]*>', index_html)
     assert match
     assert 'role="tabpanel"' in match.group(0)
-    assert 'aria-labelledby="tab-forms"' in match.group(0)
+    assert "tab-forms" in match.group(0)
+    assert "aria-labelledby=" in match.group(0)
 
 
 def test_demo_sets_content_source_type(index_html: str) -> None:


### PR DESCRIPTION
## Summary

- Replaced horizontal top navigation bar (`<nav class="dev-nav">`) with a persistent left sidebar (`<aside class="app-sidebar">`) housing all four tabs vertically
- Added collapsible icon-only mode (200px → 52px) with localStorage persistence via `toggleSidebar()`
- Relocated connection status badge from header to sidebar footer with `syncSidebarStatus()` syncing both locations
- Added mobile bottom navigation bar (`<nav class="mobile-bottom-nav">`) showing all four tabs at ≤768px — Schema and Template are now accessible on mobile (previously hidden)
- Responsive breakpoints: expanded sidebar (>1024px), auto-collapsed icon-only (768–1024px), hidden sidebar + bottom nav (<768px)

Closes #208

## Test plan

- [x] All 539 fast tests pass (`PYTHONPATH=. python -m pytest tests/ -v`)
- [x] Lint clean (`ruff check templates/ tests/`)
- [ ] Visual verification: expanded sidebar at 1280px with labels + collapse toggle
- [ ] Visual verification: collapsed sidebar shows icon-only mode
- [ ] Visual verification: mobile bottom nav at 375px with all 4 tabs
- [ ] Tab switching preserves editor state (content, scroll, unsaved changes)
- [ ] Collapse preference persists across page reloads (localStorage)
- [ ] Status badge syncs in sidebar when connecting/disconnecting sources
- [ ] Lazy-loading of editor CDN deps on first Schema/Template click still works
- [ ] `showView()` unsaved-changes guard still fires when leaving dirty form

🤖 Generated with [Claude Code](https://claude.com/claude-code)