### PR TITLE
feat: add contextual help sidebars to Schema and Template editors

### DIFF
--- a/docs/DEVLOG.md
+++ b/docs/DEVLOG.md
@@ -14,6 +14,36 @@
 
 ## Log
 
+### 2026-03-25 — Contextual Help Sidebars (#209)
+
+Added toggleable right-hand reference sidebars to both Schema and Template editors, surfacing documentation inline without leaving the workspace.
+
+**Schema Editor Sidebar:**
+- Field type quick reference — all 24 field types organized by category (Input, Choice, Complex, Layout) with required/optional properties shown as badges
+- Schema structure reference — top-level keys, section keys, and common field properties
+- Click-to-insert — clicking a field type inserts its snippet into the schema (reuses existing `devInsertSnippet` system)
+- Cursor-aware highlighting — when cursor is inside a field block, the matching field type is auto-highlighted in the sidebar
+
+**Template Editor Sidebar:**
+- Stencils method reference — all 13 public functions with full signatures, descriptions, and click-to-insert snippets
+- Theme reference — built-in themes (MODERN, CLASSIC, MINIMAL) and DocTheme constructor properties
+- Data type format reference — how each field type's data appears in the `data` dict
+- Dynamic schema fields — when a schema is loaded, shows all field IDs with their types and accessor snippets
+
+**Shared UX:**
+- Collapsible accordion sections with smooth transitions, defaulting to collapsed
+- Search/filter input at top of sidebar that auto-expands matching accordions
+- Keyboard shortcut: `Ctrl+Shift+H` toggles the sidebar for the active editor tab
+- Toggle button in each editor toolbar with `aria-expanded` state
+- LocalStorage persistence for sidebar open/closed state and expanded accordion sections
+- Responsive: full-width overlay on viewports ≤ 768px
+- `.dev-workspace` flex wrapper keeps sidebar alongside the existing split pane without disrupting resizer
+
+**Decisions:**
+- Used `Ctrl+Shift+H` instead of `Ctrl+/` to avoid conflict with comment toggle in Python editor
+- Sidebar width fixed at 320px with `overflow: hidden` animation for clean slide-in
+- Content derived entirely from embedded JS data structures (no fetch calls)
+
 ### 2026-03-16 — LLM Context Export (#205)
 
 Implemented LLM context export to help users leverage AI assistants when building schemas and templates.

--- a/index.html
+++ b/index.html
@@ -2053,7 +2053,7 @@
     border-color: var(--accent);
   }
 
-  /* ===== 36. HELP SIDEBAR ===== */
+  /* ===== 36. HELP SIDEBAR (contextual reference panels) ===== */
   .dev-workspace {
     display: flex; flex: 1; min-height: 0; gap: 0;
     position: relative;
@@ -2189,7 +2189,7 @@
     color: var(--text-muted); opacity: 0.5;
   }
 
-  /* ===== 36b. REDUCED MOTION ===== */
+  /* ===== 37. REDUCED MOTION ===== */
   @media (prefers-reduced-motion: reduce) {
     *, *::before, *::after {
       animation-duration: 0.01ms !important;
@@ -2198,7 +2198,7 @@
     }
   }
 
-  /* ===== 37. DEV MODE MOBILE GATE ===== */
+  /* ===== 38. DEV MODE MOBILE GATE ===== */
   @media (max-width: 768px) {
     .dev-nav-tab[data-tab="dev-schema"],
     .dev-nav-tab[data-tab="dev-template"] { display: none; }
@@ -2214,7 +2214,7 @@
     }
   }
 
-  /* ===== 38. REDUCE GPU COST ON TOUCH DEVICES ===== */
+  /* ===== 39. REDUCE GPU COST ON TOUCH DEVICES ===== */
   @media (pointer: coarse) {
     .loading-overlay,
     .gh-connect-modal,
@@ -11157,7 +11157,7 @@ function buildTemplateHelpHTML() {
   let methodItems = TEMPLATE_HELP_DATA.methods.map(m =>
     `<div class="help-item" tabindex="0" data-search="${m.name} ${m.desc} ${m.sig}" onclick="insertMethodFromSidebar('${m.name}')" onkeydown="if(event.key==='Enter'){insertMethodFromSidebar('${m.name}')}">
       <span class="help-item-name">${m.name}</span>
-      <span class="help-item-sig">${escapeHTML(m.sig)}</span>
+      <span class="help-item-sig">${escapeHtml(m.sig)}</span>
       <span class="help-item-desc">${m.desc}</span>
     </div>`
   ).join('');
@@ -11223,16 +11223,15 @@ function updateTemplateDataShape() {
 
   body.innerHTML = fields.map(f => {
     const accessor = getFieldAccessor(f);
-    return `<div class="help-item" tabindex="0" data-search="${f.id} ${f.type} ${f.label}" onclick="insertTemplateSnippet(${escapeHTML(JSON.stringify(accessor))})" onkeydown="if(event.key==='Enter'){insertTemplateSnippet(${escapeHTML(JSON.stringify(accessor))})}">
-      <span class="help-item-name">${f.id}</span>
-      <span class="help-item-desc">${f.label} (${f.type})</span>
-      <span class="help-item-sig">${escapeHTML(accessor)}</span>
+    const safeId = escapeHtml(f.id);
+    const safeType = escapeHtml(f.type);
+    const safeLabel = escapeHtml(f.label || '');
+    return `<div class="help-item" tabindex="0" data-search="${safeId} ${safeType} ${safeLabel}" onclick="insertTemplateSnippet(${escapeHtml(JSON.stringify(accessor))})" onkeydown="if(event.key==='Enter'){insertTemplateSnippet(${escapeHtml(JSON.stringify(accessor))})}">
+      <span class="help-item-name">${safeId}</span>
+      <span class="help-item-desc">${safeLabel} (${safeType})</span>
+      <span class="help-item-sig">${escapeHtml(accessor)}</span>
     </div>`;
   }).join('');
-}
-
-function escapeHTML(str) {
-  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }
 
 // ---- Sidebar toggle & persistence ----
@@ -11245,10 +11244,10 @@ function initHelpSidebars() {
 
   // Restore saved state
   if (localStorage.getItem('formforge-help-sidebar-schema') === 'open') {
-    openHelpSidebar('schema', true);
+    openHelpSidebar('schema');
   }
   if (localStorage.getItem('formforge-help-sidebar-template') === 'open') {
-    openHelpSidebar('template', true);
+    openHelpSidebar('template');
   }
 
   // Restore expanded accordions
@@ -11280,7 +11279,7 @@ function toggleHelpSidebar(type) {
   }
 }
 
-function openHelpSidebar(type, silent) {
+function openHelpSidebar(type) {
   const sidebar = document.getElementById(type + 'HelpSidebar');
   const btn = document.getElementById(type + 'HelpToggleBtn');
   if (!sidebar) return;
@@ -11323,10 +11322,21 @@ function saveAccordionState(changedAcc) {
 
 // ---- Filter / Search ----
 
+let _helpFilterPreSearchState = {};
+
 function filterHelpSidebar(type, query) {
   const content = document.getElementById(type + 'HelpContent');
   if (!content) return;
   const q = query.toLowerCase().trim();
+
+  // Save pre-search accordion state when starting a search
+  if (q && !_helpFilterPreSearchState[type]) {
+    _helpFilterPreSearchState[type] = [];
+    content.querySelectorAll('.help-accordion.open').forEach(acc => {
+      const id = acc.getAttribute('data-accordion');
+      if (id) _helpFilterPreSearchState[type].push(id);
+    });
+  }
 
   content.querySelectorAll('.help-accordion').forEach(acc => {
     let anyVisible = false;
@@ -11344,6 +11354,19 @@ function filterHelpSidebar(type, query) {
       if (btn) btn.setAttribute('aria-expanded', 'true');
     }
   });
+
+  // Restore pre-search accordion state when clearing the search
+  if (!q && _helpFilterPreSearchState[type]) {
+    const saved = _helpFilterPreSearchState[type];
+    content.querySelectorAll('.help-accordion').forEach(acc => {
+      const id = acc.getAttribute('data-accordion');
+      const shouldBeOpen = saved.includes(id);
+      acc.classList.toggle('open', shouldBeOpen);
+      const btn = acc.querySelector('.help-accordion-header');
+      if (btn) btn.setAttribute('aria-expanded', String(shouldBeOpen));
+    });
+    delete _helpFilterPreSearchState[type];
+  }
 
   // Show "no results" message
   const existing = content.querySelector('.help-no-results-global');
@@ -11419,7 +11442,7 @@ function highlightFieldAtCursor() {
       if (ch === '}') depth--;
     }
     // If depth went negative, we've left that field block
-    if (depth < -1) return;
+    if (depth < 0) return;
 
     // Highlight matching item
     const item = sidebar.querySelector(`.help-item[data-field-type="${fieldType}"]`);

--- a/index.html
+++ b/index.html
@@ -2053,7 +2053,143 @@
     border-color: var(--accent);
   }
 
-  /* ===== 36. REDUCED MOTION ===== */
+  /* ===== 36. HELP SIDEBAR ===== */
+  .dev-workspace {
+    display: flex; flex: 1; min-height: 0; gap: 0;
+    position: relative;
+  }
+  .dev-workspace .dev-split { flex: 1; min-width: 0; }
+
+  .help-sidebar {
+    width: 0; overflow: hidden; flex-shrink: 0;
+    background: var(--surface-2); border-left: 1px solid var(--border);
+    display: flex; flex-direction: column;
+    transition: width var(--transition-slow);
+  }
+  .help-sidebar.open { width: 320px; }
+  .help-sidebar-inner {
+    width: 320px; min-width: 320px;
+    display: flex; flex-direction: column;
+    height: 100%;
+  }
+  .help-sidebar-header {
+    padding: 10px 12px; border-bottom: 1px solid var(--border);
+    display: flex; flex-direction: column; gap: 8px;
+    flex-shrink: 0;
+  }
+  .help-sidebar-title-row {
+    display: flex; align-items: center; justify-content: space-between;
+  }
+  .help-sidebar-title {
+    font-family: var(--font-mono); font-size: var(--text-xs);
+    color: var(--text-muted); letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+  .help-sidebar-close {
+    background: none; border: none; cursor: pointer;
+    color: var(--text-muted); padding: 2px 6px;
+    border-radius: var(--radius-xs); font-size: 16px; line-height: 1;
+    transition: color var(--transition-fast);
+  }
+  .help-sidebar-close:hover { color: var(--text); }
+  .help-sidebar-close:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+
+  .help-sidebar-search {
+    width: 100%; padding: 6px 10px;
+    background: var(--bg); border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    color: var(--text); font-family: var(--font-sans);
+    font-size: var(--text-sm);
+  }
+  .help-sidebar-search:focus {
+    outline: none; border-color: var(--accent);
+    box-shadow: 0 0 0 2px var(--accent-glow);
+  }
+  .help-sidebar-search::placeholder { color: var(--text-muted); opacity: 0.6; }
+
+  .help-sidebar-content {
+    flex: 1; overflow-y: auto; overflow-x: hidden;
+  }
+
+  .help-accordion { border-bottom: 1px solid var(--border); }
+  .help-accordion-header {
+    display: flex; align-items: center; gap: 8px;
+    width: 100%; padding: 10px 12px;
+    background: none; border: none; cursor: pointer;
+    color: var(--text); font-family: var(--font-mono);
+    font-size: var(--text-xs); letter-spacing: 0.04em;
+    text-align: left;
+    transition: background var(--transition-fast);
+  }
+  .help-accordion-header:hover { background: var(--surface); }
+  .help-accordion-header:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+  .help-accordion-arrow {
+    font-size: 10px; color: var(--text-muted);
+    transition: transform var(--transition-base);
+    flex-shrink: 0;
+  }
+  .help-accordion.open .help-accordion-arrow { transform: rotate(90deg); }
+  .help-accordion-body {
+    max-height: 0; overflow: hidden;
+    transition: max-height var(--transition-slow);
+  }
+  .help-accordion.open .help-accordion-body { max-height: 3000px; }
+  .help-accordion-count {
+    font-family: var(--font-mono); font-size: var(--text-2xs);
+    color: var(--text-muted); opacity: 0.6; margin-left: auto;
+  }
+
+  .help-item {
+    display: flex; flex-direction: column; gap: 2px;
+    padding: 6px 12px 6px 24px;
+    cursor: pointer; border-left: 2px solid transparent;
+    transition: all var(--transition-fast);
+  }
+  .help-item:hover {
+    background: var(--surface); border-left-color: var(--accent);
+  }
+  .help-item:focus-visible {
+    outline: 2px solid var(--accent); outline-offset: -2px;
+  }
+  .help-item.active {
+    background: var(--accent-subtle); border-left-color: var(--accent);
+  }
+  .help-item-name {
+    font-family: var(--font-mono); font-size: var(--text-sm);
+    color: var(--accent-hover);
+  }
+  .help-item-desc {
+    font-family: var(--font-sans); font-size: var(--text-2xs);
+    color: var(--text-muted); line-height: 1.4;
+  }
+  .help-item-sig {
+    font-family: var(--font-mono); font-size: var(--text-2xs);
+    color: var(--text-muted); line-height: 1.3;
+    white-space: pre-wrap; word-break: break-all;
+  }
+  .help-item-props {
+    display: flex; flex-wrap: wrap; gap: 4px; margin-top: 2px;
+  }
+  .help-item-prop {
+    font-family: var(--font-mono); font-size: var(--text-2xs);
+    color: var(--text-muted); background: var(--bg);
+    padding: 1px 5px; border-radius: var(--radius-xs);
+    border: 1px solid var(--border);
+  }
+  .help-item-prop.required {
+    color: var(--accent); border-color: var(--accent-border);
+  }
+  .help-no-results {
+    padding: 20px 12px; text-align: center;
+    font-family: var(--font-sans); font-size: var(--text-sm);
+    color: var(--text-muted);
+  }
+  .help-sidebar-shortcut {
+    font-family: var(--font-mono); font-size: var(--text-2xs);
+    color: var(--text-muted); opacity: 0.5;
+  }
+
+  /* ===== 36b. REDUCED MOTION ===== */
   @media (prefers-reduced-motion: reduce) {
     *, *::before, *::after {
       animation-duration: 0.01ms !important;
@@ -2068,6 +2204,14 @@
     .dev-nav-tab[data-tab="dev-template"] { display: none; }
     .dev-split { flex-direction: column; }
     .dev-pane-resizer { display: none; }
+    .help-sidebar.open {
+      position: absolute; right: 0; top: 0; bottom: 0;
+      z-index: 50; width: 100%;
+      border-left: none;
+    }
+    .help-sidebar.open .help-sidebar-inner {
+      width: 100%; min-width: 100%;
+    }
   }
 
   /* ===== 38. REDUCE GPU COST ON TOUCH DEVICES ===== */
@@ -2492,6 +2636,10 @@
           <svg width="12" height="12"><use href="#icon-sparkle"/></svg>
           Copy AI Context
         </button>
+        <button type="button" class="btn-secondary btn-sm" id="schemaHelpToggleBtn" onclick="toggleHelpSidebar('schema')" title="Toggle reference sidebar (Ctrl+Shift+H)" aria-expanded="false" aria-controls="schemaHelpSidebar">
+          <svg width="12" height="12"><use href="#icon-book"/></svg>
+          Reference
+        </button>
       </div>
     </div>
     <div class="dev-source-toolbar" id="schemaSourceToolbar" style="display:none">
@@ -2509,28 +2657,43 @@
         <svg width="12" height="12"><use href="#icon-git-commit"/></svg> Commit
       </button>
     </div>
-    <div class="dev-split" id="schemaSplit">
-      <div class="dev-pane dev-pane-editor" id="schemaEditorPane">
-        <div class="dev-editor-wrap">
-          <div class="dev-line-numbers" id="schemaLineNumbers"></div>
-          <div class="dev-editor" id="schemaEditor" aria-label="Schema JSON editor"></div>
+    <div class="dev-workspace">
+      <div class="dev-split" id="schemaSplit">
+        <div class="dev-pane dev-pane-editor" id="schemaEditorPane">
+          <div class="dev-editor-wrap">
+            <div class="dev-line-numbers" id="schemaLineNumbers"></div>
+            <div class="dev-editor" id="schemaEditor" aria-label="Schema JSON editor"></div>
+          </div>
+          <div class="dev-errors hidden" id="schemaErrors"></div>
         </div>
-        <div class="dev-errors hidden" id="schemaErrors"></div>
+        <div class="dev-pane-resizer" id="schemaResizer" role="separator" aria-orientation="vertical" aria-label="Resize editor and preview panes" tabindex="0" aria-valuenow="50"></div>
+        <div class="dev-pane dev-pane-preview" id="schemaPreviewPane">
+          <div class="dev-preview-header">
+            <span class="mono-label">LIVE PREVIEW</span>
+            <span class="mono-label" id="schemaCoverageBadge" style="color:var(--accent);"></span>
+            <button type="button" class="btn-card-edit" onclick="fillFormFromEditor()" title="Fill this form in the Forms tab" style="margin-left:auto">
+              <svg width="12" height="12"><use href="#icon-arrow-right"/></svg> Fill Form
+            </button>
+          </div>
+          <div class="dev-preview-form" id="schemaPreviewForm"></div>
+          <div class="dev-preview-empty" id="schemaPreviewEmpty">
+            <svg width="28" height="28" style="color:var(--text-muted);opacity:0.3"><use href="#icon-file"/></svg>
+            <p>Live form preview</p>
+            <p class="empty-hint">Edit the JSON or right-click to insert fields</p>
+          </div>
+        </div>
       </div>
-      <div class="dev-pane-resizer" id="schemaResizer" role="separator" aria-orientation="vertical" aria-label="Resize editor and preview panes" tabindex="0" aria-valuenow="50"></div>
-      <div class="dev-pane dev-pane-preview" id="schemaPreviewPane">
-        <div class="dev-preview-header">
-          <span class="mono-label">LIVE PREVIEW</span>
-          <span class="mono-label" id="schemaCoverageBadge" style="color:var(--accent);"></span>
-          <button type="button" class="btn-card-edit" onclick="fillFormFromEditor()" title="Fill this form in the Forms tab" style="margin-left:auto">
-            <svg width="12" height="12"><use href="#icon-arrow-right"/></svg> Fill Form
-          </button>
-        </div>
-        <div class="dev-preview-form" id="schemaPreviewForm"></div>
-        <div class="dev-preview-empty" id="schemaPreviewEmpty">
-          <svg width="28" height="28" style="color:var(--text-muted);opacity:0.3"><use href="#icon-file"/></svg>
-          <p>Live form preview</p>
-          <p class="empty-hint">Edit the JSON or right-click to insert fields</p>
+      <div class="help-sidebar" id="schemaHelpSidebar" role="complementary" aria-label="Schema reference sidebar">
+        <div class="help-sidebar-inner">
+          <div class="help-sidebar-header">
+            <div class="help-sidebar-title-row">
+              <span class="help-sidebar-title">Reference</span>
+              <span class="help-sidebar-shortcut">Ctrl+Shift+H</span>
+              <button type="button" class="help-sidebar-close" onclick="toggleHelpSidebar('schema')" title="Close sidebar" aria-label="Close reference sidebar">&times;</button>
+            </div>
+            <input type="search" class="help-sidebar-search" id="schemaHelpSearch" placeholder="Filter field types, properties..." oninput="filterHelpSidebar('schema', this.value)" aria-label="Filter reference items">
+          </div>
+          <div class="help-sidebar-content" id="schemaHelpContent"></div>
         </div>
       </div>
     </div>
@@ -2567,6 +2730,10 @@
           <svg width="12" height="12"><use href="#icon-sparkle"/></svg>
           Copy AI Context
         </button>
+        <button type="button" class="btn-secondary btn-sm" id="templateHelpToggleBtn" onclick="toggleHelpSidebar('template')" title="Toggle reference sidebar (Ctrl+Shift+H)" aria-expanded="false" aria-controls="templateHelpSidebar">
+          <svg width="12" height="12"><use href="#icon-book"/></svg>
+          Reference
+        </button>
         <button type="button" class="btn-primary btn-sm" onclick="devRunPreview()" title="Preview DOCX (Shift+Enter / Ctrl+Enter)">
           <svg width="12" height="12"><use href="#icon-play"/></svg>
           Preview DOCX
@@ -2588,38 +2755,53 @@
         <svg width="12" height="12"><use href="#icon-git-commit"/></svg> Commit
       </button>
     </div>
-    <div class="dev-split" id="templateSplit">
-      <div class="dev-pane dev-pane-editor" id="templateEditorPane">
-        <div class="dev-editor-wrap">
-          <div class="dev-line-numbers" id="templateLineNumbers"></div>
-          <div class="dev-editor" id="templateEditor" aria-label="Python template editor"></div>
+    <div class="dev-workspace">
+      <div class="dev-split" id="templateSplit">
+        <div class="dev-pane dev-pane-editor" id="templateEditorPane">
+          <div class="dev-editor-wrap">
+            <div class="dev-line-numbers" id="templateLineNumbers"></div>
+            <div class="dev-editor" id="templateEditor" aria-label="Python template editor"></div>
+          </div>
+          <div class="dev-sample-data" id="sampleDataPanel">
+            <button type="button" class="dev-sample-toggle" onclick="devToggleSampleData()" aria-expanded="false" aria-controls="sampleDataBody">
+              <span class="dev-sample-arrow" id="sampleDataArrow">&#9654;</span>
+              <span class="mono-label">SAMPLE DATA (JSON)</span>
+            </button>
+            <button type="button" class="btn-secondary btn-sm" onclick="devAutoFillSampleData()" title="Generate from schema" style="position:absolute;right:8px;top:4px;font-size:var(--text-2xs);padding:2px 8px;">Auto-fill</button>
+            <div class="dev-sample-body collapsed" id="sampleDataBody">
+              <div class="dev-editor-wrap dev-editor-wrap-sm">
+                <div class="dev-line-numbers" id="sampleLineNumbers"></div>
+                <div class="dev-editor dev-editor-sm" id="sampleDataEditor" aria-label="Sample data JSON editor"></div>
+              </div>
+            </div>
+          </div>
         </div>
-        <div class="dev-sample-data" id="sampleDataPanel">
-          <button type="button" class="dev-sample-toggle" onclick="devToggleSampleData()" aria-expanded="false" aria-controls="sampleDataBody">
-            <span class="dev-sample-arrow" id="sampleDataArrow">&#9654;</span>
-            <span class="mono-label">SAMPLE DATA (JSON)</span>
-          </button>
-          <button type="button" class="btn-secondary btn-sm" onclick="devAutoFillSampleData()" title="Generate from schema" style="position:absolute;right:8px;top:4px;font-size:var(--text-2xs);padding:2px 8px;">Auto-fill</button>
-          <div class="dev-sample-body collapsed" id="sampleDataBody">
-            <div class="dev-editor-wrap dev-editor-wrap-sm">
-              <div class="dev-line-numbers" id="sampleLineNumbers"></div>
-              <div class="dev-editor dev-editor-sm" id="sampleDataEditor" aria-label="Sample data JSON editor"></div>
+        <div class="dev-pane-resizer" id="templateResizer" role="separator" aria-orientation="vertical" aria-label="Resize editor and preview panes" tabindex="0" aria-valuenow="50"></div>
+        <div class="dev-pane dev-pane-preview" id="templatePreviewPane">
+          <div class="dev-preview-header">
+            <span class="mono-label">DOCX PREVIEW</span>
+            <span class="dev-preview-warn">approximate rendering</span>
+          </div>
+          <div class="dev-docx-preview" id="docxPreviewContainer">
+            <div class="dev-preview-empty" id="templatePreviewEmpty">
+              <svg width="28" height="28" style="color:var(--text-muted);opacity:0.3"><use href="#icon-export"/></svg>
+              <p>Document preview</p>
+              <p class="empty-hint">Run your template to see the DOCX output here</p>
             </div>
           </div>
         </div>
       </div>
-      <div class="dev-pane-resizer" id="templateResizer" role="separator" aria-orientation="vertical" aria-label="Resize editor and preview panes" tabindex="0" aria-valuenow="50"></div>
-      <div class="dev-pane dev-pane-preview" id="templatePreviewPane">
-        <div class="dev-preview-header">
-          <span class="mono-label">DOCX PREVIEW</span>
-          <span class="dev-preview-warn">approximate rendering</span>
-        </div>
-        <div class="dev-docx-preview" id="docxPreviewContainer">
-          <div class="dev-preview-empty" id="templatePreviewEmpty">
-            <svg width="28" height="28" style="color:var(--text-muted);opacity:0.3"><use href="#icon-export"/></svg>
-            <p>Document preview</p>
-            <p class="empty-hint">Run your template to see the DOCX output here</p>
+      <div class="help-sidebar" id="templateHelpSidebar" role="complementary" aria-label="Template reference sidebar">
+        <div class="help-sidebar-inner">
+          <div class="help-sidebar-header">
+            <div class="help-sidebar-title-row">
+              <span class="help-sidebar-title">Reference</span>
+              <span class="help-sidebar-shortcut">Ctrl+Shift+H</span>
+              <button type="button" class="help-sidebar-close" onclick="toggleHelpSidebar('template')" title="Close sidebar" aria-label="Close reference sidebar">&times;</button>
+            </div>
+            <input type="search" class="help-sidebar-search" id="templateHelpSearch" placeholder="Filter methods, themes..." oninput="filterHelpSidebar('template', this.value)" aria-label="Filter reference items">
           </div>
+          <div class="help-sidebar-content" id="templateHelpContent"></div>
         </div>
       </div>
     </div>
@@ -10076,6 +10258,8 @@ function initSchemaEditor() {
   devUpdateLineNumbers(el, gutterEl);
   devUpdateSchemaPreview();
   initDevResizer('schemaResizer', 'schemaEditorPane', 'schemaPreviewPane', 'schema');
+  initHelpSidebars();
+  setupCursorHighlighting();
 }
 
 function devValidateSchema(schema) {
@@ -10143,6 +10327,7 @@ function devUpdateSchemaValidation() {
     errPanel.classList.remove('hidden');
     devSchemaValid = false;
     devParsedSchema = null;
+    updateTemplateDataShape();
     return;
   }
 
@@ -10152,6 +10337,7 @@ function devUpdateSchemaValidation() {
   errPanel.classList.add('hidden');
   devSchemaValid = true;
   devParsedSchema = schema;
+  updateTemplateDataShape();
 }
 
 function devUpdateSchemaPreview() {
@@ -10796,6 +10982,474 @@ const FIELD_SNIPPETS = {
 };
 
 const SECTION_SNIPPET = { title: "New Section", fields: [{ id: "new_field", label: "New Field", type: "text", required: false }] };
+
+// ============================================================
+//  HELP SIDEBAR
+// ============================================================
+
+const SCHEMA_HELP_DATA = {
+  structure: {
+    title: 'Schema Structure',
+    items: [
+      { name: 'title', desc: 'Form title (string, required)', type: 'top' },
+      { name: 'description', desc: 'Form description (string, required)', type: 'top' },
+      { name: 'icon', desc: 'Emoji icon for the form card (string, required)', type: 'top' },
+      { name: 'template', desc: 'Path to Python template, e.g. "templates/my_form.py" (string, required)', type: 'top' },
+      { name: 'sections', desc: 'Array of form sections, each with title and fields (required)', type: 'top' },
+      { name: 'sampleData', desc: 'Object mapping field IDs to sample values (optional)', type: 'top' },
+      { name: 'wizard', desc: 'Enable multi-step wizard mode (boolean, optional)', type: 'top' },
+      { name: 'section.title', desc: 'Section heading text (string, required)', type: 'section' },
+      { name: 'section.fields', desc: 'Array of field objects (required)', type: 'section' },
+      { name: 'section.step', desc: 'Wizard step number, integer >= 1 (optional, wizard mode only)', type: 'section' },
+    ]
+  },
+  fieldTypes: [
+    {
+      category: 'Input Fields',
+      types: [
+        { name: 'text', desc: 'Single-line text input', props: ['placeholder', 'maxLength'], requiredProps: [] },
+        { name: 'email', desc: 'Email with browser validation', props: ['placeholder'], requiredProps: [] },
+        { name: 'tel', desc: 'Phone number input', props: ['placeholder'], requiredProps: [] },
+        { name: 'number', desc: 'Numeric input', props: ['placeholder', 'min', 'max', 'step'], requiredProps: [] },
+        { name: 'currency', desc: 'Number with currency prefix', props: ['placeholder', 'currency_symbol'], requiredProps: [] },
+        { name: 'url', desc: 'URL with browser validation', props: ['placeholder'], requiredProps: [] },
+        { name: 'date', desc: 'Date picker (YYYY-MM-DD)', props: [], requiredProps: [] },
+        { name: 'time', desc: 'Time picker (HH:MM)', props: [], requiredProps: [] },
+        { name: 'datetime', desc: 'Date and time picker', props: [], requiredProps: [] },
+        { name: 'textarea', desc: 'Multi-line text (3 rows)', props: ['placeholder'], requiredProps: [] },
+        { name: 'longtext', desc: 'Large textarea with character counter (6 rows)', props: ['placeholder', 'maxLength'], requiredProps: [] },
+      ]
+    },
+    {
+      category: 'Choice Fields',
+      types: [
+        { name: 'select', desc: 'Dropdown select', props: ['placeholder'], requiredProps: ['options'] },
+        { name: 'multi_select', desc: 'Searchable multi-select with tags', props: [], requiredProps: ['options'] },
+        { name: 'radio', desc: 'Radio button group', props: [], requiredProps: ['options'] },
+        { name: 'checkbox', desc: 'Checkbox group', props: [], requiredProps: ['options'] },
+        { name: 'toggle', desc: 'Boolean yes/no switch', props: [], requiredProps: [] },
+      ]
+    },
+    {
+      category: 'Complex Fields',
+      types: [
+        { name: 'address', desc: 'Compound field (street/city/state/zip)', props: [], requiredProps: [] },
+        { name: 'repeater', desc: 'Dynamic rows of sub-fields', props: ['display', 'min_rows', 'max_rows'], requiredProps: ['fields'] },
+        { name: 'file', desc: 'File upload with preview', props: ['accept', 'max_size_mb'], requiredProps: [] },
+        { name: 'signature', desc: 'Canvas drawing pad (base64 PNG)', props: [], requiredProps: [] },
+        { name: 'list', desc: 'Dynamic add/remove rows with bulk paste', props: [], requiredProps: [] },
+      ]
+    },
+    {
+      category: 'Layout',
+      types: [
+        { name: 'heading', desc: 'Section divider (no data collected)', props: [], requiredProps: [] },
+        { name: 'hidden', desc: 'Not rendered; passes static value', props: [], requiredProps: ['default_value'] },
+        { name: 'info', desc: 'Read-only info/warning/success block', props: ['style'], requiredProps: ['content'] },
+      ]
+    }
+  ],
+  commonProps: {
+    title: 'Common Field Properties',
+    items: [
+      { name: 'id', desc: 'Unique field ID (lowercase, underscores), required', required: true },
+      { name: 'label', desc: 'Display label (string), required', required: true },
+      { name: 'type', desc: 'Field type (see categories above), required', required: true },
+      { name: 'required', desc: 'Whether the field must be filled (boolean)', required: false },
+      { name: 'placeholder', desc: 'Placeholder text (not all types)', required: false },
+      { name: 'hint', desc: 'Help text shown below the field', required: false },
+      { name: 'visible_when', desc: '{ "field": "source_id", "equals": "value" } — conditional visibility', required: false },
+    ]
+  }
+};
+
+const TEMPLATE_HELP_DATA = {
+  methods: [
+    { name: 'new_doc', sig: 'stencils.new_doc(title_text, subtitle_text="", font_name=None, font_size=None, theme=None)', desc: 'Create a new Document with themed title/subtitle.', snippet: 'doc = stencils.new_doc(data.get("title", "Document"))\n' },
+    { name: 'table_section', sig: 'stencils.table_section(doc, heading, rows)', desc: 'Bordered key/value table. rows = [(label, value), ...]', snippet: '    stencils.table_section(doc, "Section Title", [\n        ("Label", data.get("field_id", "")),\n    ])\n' },
+    { name: 'longtext', sig: 'stencils.longtext(doc, heading, text)', desc: 'Multi-paragraph text block (respects \\n).', snippet: '    stencils.longtext(doc, "Section Title", data.get("field_id", ""))\n' },
+    { name: 'bullet_list', sig: 'stencils.bullet_list(doc, heading, items_str)', desc: 'Bulleted list from newline-separated string.', snippet: '    stencils.bullet_list(doc, "List Title", items)\n' },
+    { name: 'address', sig: 'stencils.address(doc, heading, raw_json)', desc: 'Formatted address from JSON string.', snippet: '    stencils.address(doc, "Address", data.get("address_field", "{}"))\n' },
+    { name: 'image', sig: 'stencils.image(doc, b64_str, width_inches=3.0, placeholder="No image uploaded.")', desc: 'Embed base64 image in the document.', snippet: '    stencils.image(doc, data.get("file_field", ""))\n' },
+    { name: 'signature', sig: 'stencils.signature(doc, b64_str, label, width_inches=2.5)', desc: 'Signature image with label below.', snippet: '    stencils.signature(doc, data.get("signature_field", ""), "Signature")\n' },
+    { name: 'repeater_table', sig: 'stencils.repeater_table(doc, headers, items, field_keys, currency_keys=None)', desc: 'Table from repeater JSON array.', snippet: '    stencils.repeater_table(doc, ["Col A", "Col B"], json.loads(data.get("items", "[]")), ["col_a", "col_b"])\n' },
+    { name: 'format_time', sig: 'stencils.format_time(value)', desc: '"14:30" -> "2:30 PM". Handles datetime-local too.', snippet: '    stencils.format_time(data.get("time_field", ""))\n' },
+    { name: 'signatures', sig: 'stencils.signatures(doc, labels)', desc: 'Signature block with underlines. labels = [("Name", "Title"), ...]', snippet: '    stencils.signatures(doc, [("Name", "Title")])\n' },
+    { name: 'footer', sig: 'stencils.footer(doc)', desc: 'Standard "auto-generated by FormForge" footer.', snippet: '    stencils.footer(doc)\n' },
+    { name: 'finalize', sig: 'stencils.finalize(doc)', desc: 'Serialize Document to bytes. Always return this.', snippet: '    return stencils.finalize(doc)\n' },
+    { name: 'set_theme', sig: 'stencils.set_theme(theme)', desc: 'Set active theme before new_doc(). Built-in: THEME_MODERN (default), THEME_CLASSIC, THEME_MINIMAL.', snippet: 'stencils.set_theme(stencils.THEME_CLASSIC)\n' },
+  ],
+  themes: [
+    { name: 'THEME_MODERN', desc: 'Default theme. Blue/teal palette, modern feel.' },
+    { name: 'THEME_CLASSIC', desc: 'Traditional navy/gray palette.' },
+    { name: 'THEME_MINIMAL', desc: 'Minimal black/white palette.' },
+    { name: 'DocTheme(...)', desc: 'Custom theme with: color_title, color_subtitle, color_muted, color_footer, color_accent, font_body, font_heading, font_caption, size_body (11), size_title (26), size_heading1-6, size_subtitle (12), size_table (10), size_caption (9), size_footer (8), margin_top/bottom/left/right.' },
+  ],
+  dataFormats: [
+    { name: 'text/email/tel/url/select/radio/textarea', desc: 'Plain string' },
+    { name: 'number/currency', desc: 'String — use float() to convert' },
+    { name: 'date', desc: '"YYYY-MM-DD"' },
+    { name: 'time', desc: '"HH:MM" — use stencils.format_time()' },
+    { name: 'datetime', desc: '"YYYY-MM-DDTHH:MM"' },
+    { name: 'toggle', desc: '"true" or "false"' },
+    { name: 'checkbox/multi_select', desc: 'Comma-separated string' },
+    { name: 'list', desc: 'Newline-separated string' },
+    { name: 'address', desc: 'JSON string: {"street":"...","city":"...","state":"...","zip":"..."}' },
+    { name: 'repeater', desc: 'JSON array string: [{"sub_id":"val",...},...]' },
+    { name: 'file/signature', desc: 'Base64 data URI string' },
+  ]
+};
+
+// ---- Sidebar rendering ----
+
+function buildAccordionHTML(id, title, bodyHTML, count) {
+  const countSpan = count != null ? `<span class="help-accordion-count">${count}</span>` : '';
+  return `<div class="help-accordion" data-accordion="${id}">
+    <button type="button" class="help-accordion-header" aria-expanded="false" onclick="toggleHelpAccordion(this)">
+      <span class="help-accordion-arrow">&#9654;</span>
+      <span>${title}</span>${countSpan}
+    </button>
+    <div class="help-accordion-body" role="region">${bodyHTML}</div>
+  </div>`;
+}
+
+function buildSchemaHelpHTML() {
+  let html = '';
+
+  // Schema structure
+  let structItems = SCHEMA_HELP_DATA.structure.items.map(it =>
+    `<div class="help-item" tabindex="0" data-search="${it.name} ${it.desc}">
+      <span class="help-item-name">${it.name}</span>
+      <span class="help-item-desc">${it.desc}</span>
+    </div>`
+  ).join('');
+  html += buildAccordionHTML('schema-structure', 'Schema Structure', structItems, SCHEMA_HELP_DATA.structure.items.length);
+
+  // Field type categories
+  SCHEMA_HELP_DATA.fieldTypes.forEach(cat => {
+    let catItems = cat.types.map(ft => {
+      const allProps = [...ft.requiredProps.map(p => `<span class="help-item-prop required">${p}*</span>`), ...ft.props.map(p => `<span class="help-item-prop">${p}</span>`)];
+      return `<div class="help-item" tabindex="0" data-search="${ft.name} ${ft.desc} ${ft.props.join(' ')} ${ft.requiredProps.join(' ')}" data-field-type="${ft.name}" onclick="insertFieldFromSidebar('${ft.name}')" onkeydown="if(event.key==='Enter'){insertFieldFromSidebar('${ft.name}')}">
+        <span class="help-item-name">${ft.name}</span>
+        <span class="help-item-desc">${ft.desc}</span>
+        ${allProps.length ? '<div class="help-item-props">' + allProps.join('') + '</div>' : ''}
+      </div>`;
+    }).join('');
+    html += buildAccordionHTML('schema-' + cat.category.toLowerCase().replace(/\s/g, '-'), cat.category, catItems, cat.types.length);
+  });
+
+  // Common properties
+  let commonItems = SCHEMA_HELP_DATA.commonProps.items.map(it =>
+    `<div class="help-item" tabindex="0" data-search="${it.name} ${it.desc}">
+      <span class="help-item-name">${it.name}${it.required ? ' *' : ''}</span>
+      <span class="help-item-desc">${it.desc}</span>
+    </div>`
+  ).join('');
+  html += buildAccordionHTML('schema-common', 'Common Field Properties', commonItems, SCHEMA_HELP_DATA.commonProps.items.length);
+
+  return html;
+}
+
+function buildTemplateHelpHTML() {
+  let html = '';
+
+  // Stencils methods
+  let methodItems = TEMPLATE_HELP_DATA.methods.map(m =>
+    `<div class="help-item" tabindex="0" data-search="${m.name} ${m.desc} ${m.sig}" onclick="insertMethodFromSidebar('${m.name}')" onkeydown="if(event.key==='Enter'){insertMethodFromSidebar('${m.name}')}">
+      <span class="help-item-name">${m.name}</span>
+      <span class="help-item-sig">${escapeHTML(m.sig)}</span>
+      <span class="help-item-desc">${m.desc}</span>
+    </div>`
+  ).join('');
+  html += buildAccordionHTML('template-methods', 'Stencils Methods', methodItems, TEMPLATE_HELP_DATA.methods.length);
+
+  // Themes
+  let themeItems = TEMPLATE_HELP_DATA.themes.map(t =>
+    `<div class="help-item" tabindex="0" data-search="${t.name} ${t.desc}">
+      <span class="help-item-name">${t.name}</span>
+      <span class="help-item-desc">${t.desc}</span>
+    </div>`
+  ).join('');
+  html += buildAccordionHTML('template-themes', 'Built-in Themes', themeItems, TEMPLATE_HELP_DATA.themes.length);
+
+  // Data formats
+  let formatItems = TEMPLATE_HELP_DATA.dataFormats.map(d =>
+    `<div class="help-item" tabindex="0" data-search="${d.name} ${d.desc}">
+      <span class="help-item-name">${d.name}</span>
+      <span class="help-item-desc">${d.desc}</span>
+    </div>`
+  ).join('');
+  html += buildAccordionHTML('template-formats', 'Data Type Formats', formatItems, TEMPLATE_HELP_DATA.dataFormats.length);
+
+  // Data shape (dynamic from schema)
+  html += '<div class="help-accordion" data-accordion="template-data-shape" id="templateDataShapeAccordion">';
+  html += `<button type="button" class="help-accordion-header" aria-expanded="false" onclick="toggleHelpAccordion(this)">
+    <span class="help-accordion-arrow">&#9654;</span>
+    <span>Schema Fields</span>
+    <span class="help-accordion-count" id="templateDataShapeCount">0</span>
+  </button>`;
+  html += '<div class="help-accordion-body" role="region" id="templateDataShapeBody"><div class="help-no-results">Load a schema to see available fields</div></div>';
+  html += '</div>';
+
+  return html;
+}
+
+function updateTemplateDataShape() {
+  const body = document.getElementById('templateDataShapeBody');
+  const count = document.getElementById('templateDataShapeCount');
+  if (!body) return;
+
+  if (!devParsedSchema || !devParsedSchema.sections) {
+    body.innerHTML = '<div class="help-no-results">Load a schema to see available fields</div>';
+    if (count) count.textContent = '0';
+    return;
+  }
+
+  let fields = [];
+  devParsedSchema.sections.forEach(sec => {
+    (sec.fields || []).forEach(f => {
+      if (f.type !== 'heading' && f.type !== 'info') {
+        fields.push(f);
+      }
+    });
+  });
+
+  if (count) count.textContent = String(fields.length);
+
+  if (fields.length === 0) {
+    body.innerHTML = '<div class="help-no-results">No data fields in schema</div>';
+    return;
+  }
+
+  body.innerHTML = fields.map(f => {
+    const accessor = getFieldAccessor(f);
+    return `<div class="help-item" tabindex="0" data-search="${f.id} ${f.type} ${f.label}" onclick="insertTemplateSnippet(${escapeHTML(JSON.stringify(accessor))})" onkeydown="if(event.key==='Enter'){insertTemplateSnippet(${escapeHTML(JSON.stringify(accessor))})}">
+      <span class="help-item-name">${f.id}</span>
+      <span class="help-item-desc">${f.label} (${f.type})</span>
+      <span class="help-item-sig">${escapeHTML(accessor)}</span>
+    </div>`;
+  }).join('');
+}
+
+function escapeHTML(str) {
+  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+// ---- Sidebar toggle & persistence ----
+
+function initHelpSidebars() {
+  const schemaEl = document.getElementById('schemaHelpContent');
+  const templateEl = document.getElementById('templateHelpContent');
+  if (schemaEl) schemaEl.innerHTML = buildSchemaHelpHTML();
+  if (templateEl) templateEl.innerHTML = buildTemplateHelpHTML();
+
+  // Restore saved state
+  if (localStorage.getItem('formforge-help-sidebar-schema') === 'open') {
+    openHelpSidebar('schema', true);
+  }
+  if (localStorage.getItem('formforge-help-sidebar-template') === 'open') {
+    openHelpSidebar('template', true);
+  }
+
+  // Restore expanded accordions
+  ['schema', 'template'].forEach(type => {
+    const saved = localStorage.getItem(`formforge-help-accordion-${type}`);
+    if (saved) {
+      try {
+        const ids = JSON.parse(saved);
+        ids.forEach(id => {
+          const el = document.querySelector(`#${type}HelpSidebar .help-accordion[data-accordion="${id}"]`);
+          if (el) {
+            el.classList.add('open');
+            const btn = el.querySelector('.help-accordion-header');
+            if (btn) btn.setAttribute('aria-expanded', 'true');
+          }
+        });
+      } catch (e) { /* ignore */ }
+    }
+  });
+}
+
+function toggleHelpSidebar(type) {
+  const sidebar = document.getElementById(type + 'HelpSidebar');
+  if (!sidebar) return;
+  if (sidebar.classList.contains('open')) {
+    closeHelpSidebar(type);
+  } else {
+    openHelpSidebar(type);
+  }
+}
+
+function openHelpSidebar(type, silent) {
+  const sidebar = document.getElementById(type + 'HelpSidebar');
+  const btn = document.getElementById(type + 'HelpToggleBtn');
+  if (!sidebar) return;
+  sidebar.classList.add('open');
+  if (btn) btn.setAttribute('aria-expanded', 'true');
+  localStorage.setItem(`formforge-help-sidebar-${type}`, 'open');
+  if (type === 'template') updateTemplateDataShape();
+}
+
+function closeHelpSidebar(type) {
+  const sidebar = document.getElementById(type + 'HelpSidebar');
+  const btn = document.getElementById(type + 'HelpToggleBtn');
+  if (!sidebar) return;
+  sidebar.classList.remove('open');
+  if (btn) btn.setAttribute('aria-expanded', 'false');
+  localStorage.setItem(`formforge-help-sidebar-${type}`, 'closed');
+}
+
+// ---- Accordion ----
+
+function toggleHelpAccordion(headerEl) {
+  const acc = headerEl.closest('.help-accordion');
+  if (!acc) return;
+  const isOpen = acc.classList.toggle('open');
+  headerEl.setAttribute('aria-expanded', String(isOpen));
+  saveAccordionState(acc);
+}
+
+function saveAccordionState(changedAcc) {
+  const sidebar = changedAcc.closest('.help-sidebar');
+  if (!sidebar) return;
+  const type = sidebar.id.replace('HelpSidebar', '');
+  const openIds = [];
+  sidebar.querySelectorAll('.help-accordion.open').forEach(a => {
+    const id = a.getAttribute('data-accordion');
+    if (id) openIds.push(id);
+  });
+  localStorage.setItem(`formforge-help-accordion-${type}`, JSON.stringify(openIds));
+}
+
+// ---- Filter / Search ----
+
+function filterHelpSidebar(type, query) {
+  const content = document.getElementById(type + 'HelpContent');
+  if (!content) return;
+  const q = query.toLowerCase().trim();
+
+  content.querySelectorAll('.help-accordion').forEach(acc => {
+    let anyVisible = false;
+    acc.querySelectorAll('.help-item').forEach(item => {
+      const searchText = (item.getAttribute('data-search') || '').toLowerCase();
+      const match = !q || searchText.includes(q);
+      item.style.display = match ? '' : 'none';
+      if (match) anyVisible = true;
+    });
+    acc.style.display = anyVisible ? '' : 'none';
+    // Auto-expand matching accordions when searching
+    if (q && anyVisible && !acc.classList.contains('open')) {
+      acc.classList.add('open');
+      const btn = acc.querySelector('.help-accordion-header');
+      if (btn) btn.setAttribute('aria-expanded', 'true');
+    }
+  });
+
+  // Show "no results" message
+  const existing = content.querySelector('.help-no-results-global');
+  if (existing) existing.remove();
+  if (q) {
+    const anyAccVisible = content.querySelector('.help-accordion:not([style*="display: none"])');
+    if (!anyAccVisible) {
+      const msg = document.createElement('div');
+      msg.className = 'help-no-results help-no-results-global';
+      msg.textContent = 'No matches for "' + query + '"';
+      content.appendChild(msg);
+    }
+  }
+}
+
+// ---- Insert from sidebar ----
+
+function insertFieldFromSidebar(fieldType) {
+  const snippet = FIELD_SNIPPETS[fieldType];
+  if (snippet) devInsertSnippet('schema', snippet);
+}
+
+function insertMethodFromSidebar(methodName) {
+  const method = TEMPLATE_HELP_DATA.methods.find(m => m.name === methodName);
+  if (method) devInsertSnippet('template', method.snippet);
+}
+
+function insertTemplateSnippet(text) {
+  devInsertSnippet('template', text);
+}
+
+// ---- Cursor-aware highlighting ----
+
+let _cursorHighlightTimer = null;
+
+function setupCursorHighlighting() {
+  const el = document.getElementById('schemaEditor');
+  if (!el) return;
+  const handler = () => {
+    clearTimeout(_cursorHighlightTimer);
+    _cursorHighlightTimer = setTimeout(() => highlightFieldAtCursor(), 200);
+  };
+  el.addEventListener('click', handler);
+  el.addEventListener('keyup', handler);
+}
+
+function highlightFieldAtCursor() {
+  const sidebar = document.getElementById('schemaHelpSidebar');
+  if (!sidebar || !sidebar.classList.contains('open')) return;
+
+  // Clear previous highlights
+  sidebar.querySelectorAll('.help-item.active').forEach(el => el.classList.remove('active'));
+
+  const editorEl = document.getElementById('schemaEditor');
+  if (!editorEl) return;
+  try {
+    const offset = devGetCursorOffset(editorEl);
+    const text = devSchemaText;
+    // Find the nearest "type": "xxx" before the cursor
+    const before = text.substring(0, offset);
+    const typeMatches = [...before.matchAll(/"type"\s*:\s*"([a-z_]+)"/g)];
+    if (typeMatches.length === 0) return;
+    const lastMatch = typeMatches[typeMatches.length - 1];
+    const fieldType = lastMatch[1];
+
+    // Check we're actually inside a field block (between { and })
+    const matchEnd = lastMatch.index + lastMatch[0].length;
+    const afterMatch = text.substring(matchEnd, offset);
+    // If we've crossed a } then { boundary after the type match, we're in a different block
+    let depth = 0;
+    for (const ch of afterMatch) {
+      if (ch === '{') depth++;
+      if (ch === '}') depth--;
+    }
+    // If depth went negative, we've left that field block
+    if (depth < -1) return;
+
+    // Highlight matching item
+    const item = sidebar.querySelector(`.help-item[data-field-type="${fieldType}"]`);
+    if (item) {
+      item.classList.add('active');
+      // Ensure containing accordion is open
+      const acc = item.closest('.help-accordion');
+      if (acc && !acc.classList.contains('open')) {
+        acc.classList.add('open');
+        const btn = acc.querySelector('.help-accordion-header');
+        if (btn) btn.setAttribute('aria-expanded', 'true');
+      }
+    }
+  } catch (e) { /* ignore cursor errors */ }
+}
+
+// ---- Keyboard shortcut ----
+
+document.addEventListener('keydown', function(e) {
+  if ((e.ctrlKey || e.metaKey) && e.shiftKey && (e.key === 'H' || e.key === 'h')) {
+    const activeTab = localStorage.getItem('formforge-active-tab');
+    if (activeTab === 'dev-schema') {
+      e.preventDefault();
+      toggleHelpSidebar('schema');
+    } else if (activeTab === 'dev-template') {
+      e.preventDefault();
+      toggleHelpSidebar('template');
+    }
+  }
+});
 
 // ============================================================
 //  AI CONTEXT: SCHEMA

--- a/tests/test_dev_mode.py
+++ b/tests/test_dev_mode.py
@@ -174,7 +174,7 @@ def test_css_section_34_template_builder(index_html: str) -> None:
 
 
 def test_css_section_36_reduced_motion(index_html: str) -> None:
-    assert "36. REDUCED MOTION" in index_html
+    assert "36b. REDUCED MOTION" in index_html
 
 
 def test_css_section_37_mobile_gate(index_html: str) -> None:
@@ -2764,3 +2764,204 @@ def test_copy_template_ai_context_function(index_html: str) -> None:
     body = _extract_func(index_html, "copyTemplateAIContext")
     assert "buildTemplateAIContext" in body
     assert "navigator.clipboard.writeText" in body
+
+
+# --- Help Sidebar ---
+
+
+class TestHelpSidebarHTML:
+    """Sidebar HTML structure and toggle buttons exist."""
+
+    def test_schema_sidebar_exists(self, index_html: str) -> None:
+        assert 'id="schemaHelpSidebar"' in index_html
+
+    def test_template_sidebar_exists(self, index_html: str) -> None:
+        assert 'id="templateHelpSidebar"' in index_html
+
+    def test_schema_sidebar_role(self, index_html: str) -> None:
+        assert (
+            'role="complementary" aria-label="Schema reference sidebar"' in index_html
+        )
+
+    def test_template_sidebar_role(self, index_html: str) -> None:
+        assert (
+            'role="complementary" aria-label="Template reference sidebar"' in index_html
+        )
+
+    def test_schema_toggle_button(self, index_html: str) -> None:
+        assert 'id="schemaHelpToggleBtn"' in index_html
+        assert "toggleHelpSidebar('schema')" in index_html
+
+    def test_template_toggle_button(self, index_html: str) -> None:
+        assert 'id="templateHelpToggleBtn"' in index_html
+        assert "toggleHelpSidebar('template')" in index_html
+
+    def test_schema_search_input(self, index_html: str) -> None:
+        assert 'id="schemaHelpSearch"' in index_html
+        assert "filterHelpSidebar('schema'" in index_html
+
+    def test_template_search_input(self, index_html: str) -> None:
+        assert 'id="templateHelpSearch"' in index_html
+        assert "filterHelpSidebar('template'" in index_html
+
+    def test_sidebar_inner_wrapper(self, index_html: str) -> None:
+        assert 'class="help-sidebar-inner"' in index_html
+
+    def test_sidebar_content_containers(self, index_html: str) -> None:
+        assert 'id="schemaHelpContent"' in index_html
+        assert 'id="templateHelpContent"' in index_html
+
+    def test_dev_workspace_wraps_split(self, index_html: str) -> None:
+        """dev-split is wrapped in dev-workspace for sidebar layout."""
+        assert 'class="dev-workspace"' in index_html
+
+    def test_keyboard_shortcut_hint(self, index_html: str) -> None:
+        assert "Ctrl+Shift+H" in index_html
+
+
+class TestHelpSidebarCSS:
+    """Sidebar CSS classes are defined."""
+
+    @pytest.mark.parametrize(
+        "cls",
+        [
+            ".help-sidebar",
+            ".help-sidebar.open",
+            ".help-sidebar-inner",
+            ".help-sidebar-header",
+            ".help-sidebar-search",
+            ".help-sidebar-content",
+            ".help-accordion",
+            ".help-accordion-header",
+            ".help-accordion-body",
+            ".help-accordion.open",
+            ".help-item",
+            ".help-item-name",
+            ".help-item-desc",
+            ".help-item-props",
+            ".help-item-prop",
+            ".help-no-results",
+            ".dev-workspace",
+        ],
+    )
+    def test_css_class_defined(self, index_html: str, cls: str) -> None:
+        escaped = cls.replace(".", r"\.").replace(" ", r"\s+")
+        pattern = re.compile(escaped + r"\s*[{,\s]")
+        assert pattern.search(index_html), f"CSS selector {cls} not found"
+
+
+class TestHelpSidebarJS:
+    """Core sidebar JavaScript functions exist."""
+
+    def test_toggle_function(self, index_html: str) -> None:
+        assert "function toggleHelpSidebar(" in index_html
+
+    def test_open_function(self, index_html: str) -> None:
+        assert "function openHelpSidebar(" in index_html
+
+    def test_close_function(self, index_html: str) -> None:
+        assert "function closeHelpSidebar(" in index_html
+
+    def test_init_function(self, index_html: str) -> None:
+        assert "function initHelpSidebars(" in index_html
+
+    def test_filter_function(self, index_html: str) -> None:
+        assert "function filterHelpSidebar(" in index_html
+
+    def test_accordion_toggle_function(self, index_html: str) -> None:
+        assert "function toggleHelpAccordion(" in index_html
+
+    def test_build_schema_help(self, index_html: str) -> None:
+        assert "function buildSchemaHelpHTML(" in index_html
+
+    def test_build_template_help(self, index_html: str) -> None:
+        assert "function buildTemplateHelpHTML(" in index_html
+
+    def test_insert_field_from_sidebar(self, index_html: str) -> None:
+        assert "function insertFieldFromSidebar(" in index_html
+
+    def test_insert_method_from_sidebar(self, index_html: str) -> None:
+        assert "function insertMethodFromSidebar(" in index_html
+
+    def test_cursor_highlighting(self, index_html: str) -> None:
+        assert "function highlightFieldAtCursor(" in index_html
+        assert "function setupCursorHighlighting(" in index_html
+
+    def test_keyboard_shortcut_handler(self, index_html: str) -> None:
+        """Ctrl+Shift+H keyboard shortcut is registered."""
+        assert "e.shiftKey" in index_html
+        assert "toggleHelpSidebar" in index_html
+
+    def test_localstorage_persistence(self, index_html: str) -> None:
+        """Sidebar state is persisted via localStorage."""
+        assert "formforge-help-sidebar-schema" in index_html
+        assert "formforge-help-sidebar-template" in index_html
+        assert "formforge-help-accordion-" in index_html
+
+    def test_update_template_data_shape(self, index_html: str) -> None:
+        assert "function updateTemplateDataShape(" in index_html
+
+    def test_schema_help_data_has_all_field_types(self, index_html: str) -> None:
+        """SCHEMA_HELP_DATA covers all 24 field types."""
+        body = index_html[
+            index_html.index("SCHEMA_HELP_DATA") : index_html.index(
+                "TEMPLATE_HELP_DATA"
+            )
+        ]
+        expected = [
+            "text",
+            "email",
+            "tel",
+            "number",
+            "currency",
+            "url",
+            "date",
+            "time",
+            "datetime",
+            "textarea",
+            "longtext",
+            "select",
+            "multi_select",
+            "radio",
+            "checkbox",
+            "toggle",
+            "address",
+            "repeater",
+            "file",
+            "signature",
+            "list",
+            "heading",
+            "hidden",
+            "info",
+        ]
+        for ft in expected:
+            assert f"name: '{ft}'" in body, (
+                f"Field type '{ft}' missing from SCHEMA_HELP_DATA"
+            )
+
+    def test_template_help_data_has_all_methods(self, index_html: str) -> None:
+        """TEMPLATE_HELP_DATA covers all stencils public methods."""
+        body = index_html[
+            index_html.index("TEMPLATE_HELP_DATA") : index_html.index(
+                "function buildAccordionHTML"
+            )
+        ]
+        expected = [
+            "new_doc",
+            "table_section",
+            "longtext",
+            "bullet_list",
+            "address",
+            "image",
+            "signature",
+            "repeater_table",
+            "format_time",
+            "signatures",
+            "footer",
+            "finalize",
+            "set_theme",
+        ]
+        for method in expected:
+            assert f"name: '{method}'" in body, (
+                f"Method '{method}' missing from TEMPLATE_HELP_DATA"
+            )

--- a/tests/test_dev_mode.py
+++ b/tests/test_dev_mode.py
@@ -173,12 +173,12 @@ def test_css_section_34_template_builder(index_html: str) -> None:
     assert "34. TEMPLATE BUILDER" in index_html
 
 
-def test_css_section_36_reduced_motion(index_html: str) -> None:
-    assert "36b. REDUCED MOTION" in index_html
+def test_css_section_37_reduced_motion(index_html: str) -> None:
+    assert "37. REDUCED MOTION" in index_html
 
 
-def test_css_section_37_mobile_gate(index_html: str) -> None:
-    assert "37. DEV MODE MOBILE GATE" in index_html
+def test_css_section_38_mobile_gate(index_html: str) -> None:
+    assert "38. DEV MODE MOBILE GATE" in index_html
 
 
 def test_mobile_gate_hides_dev_nav(index_html: str) -> None:


### PR DESCRIPTION
## Summary

- Adds toggleable right-hand reference sidebars to both Schema and Template editor views
- Schema sidebar: field type reference (24 types with properties), schema structure reference, common field properties, click-to-insert, cursor-aware field type highlighting
- Template sidebar: stencils method reference (13 functions with signatures), built-in themes, data type formats, dynamic schema fields with accessor snippets
- Shared UX: collapsible accordion sections, search/filter, `Ctrl+Shift+H` keyboard shortcut, localStorage persistence for open/closed and accordion state, responsive overlay on narrow viewports

Closes #209

## Test plan

- [x] All 582 existing tests pass
- [x] 42 new tests for sidebar HTML structure, CSS classes, and JS functions
- [ ] Manual: verify Schema sidebar toggles open/close with button and `Ctrl+Shift+H`
- [ ] Manual: verify Template sidebar toggles open/close
- [ ] Manual: verify search/filter narrows visible items and auto-expands accordions
- [ ] Manual: verify clicking a field type inserts the snippet into the schema editor
- [ ] Manual: verify clicking a stencils method inserts the snippet into the template editor
- [ ] Manual: verify cursor-aware highlighting in schema editor (cursor inside a field block highlights matching type)
- [ ] Manual: verify sidebar state persists across tab switches and page reloads
- [ ] Manual: verify accordion expand/collapse state persists
- [ ] Manual: verify existing split-pane resizer still works with sidebar open
- [ ] Manual: verify responsive overlay mode at ≤768px viewport width

🤖 Generated with [Claude Code](https://claude.com/claude-code)