### PR TITLE
refactor: tokenize hard-coded pixel values in sidebar CSS (#212)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,10 @@ All design values are centralized as CSS custom properties. When adding or modif
 | **Radii** | `--radius-xs` (4), `--radius-sm` (6), `--radius-md` (8), `--radius` / `--radius-lg` (10), `--radius-pill` (20) | `--radius-md` (8px) is the default for inputs and buttons. `--radius` (10px) for cards/sections. |
 | **Shadows** | `--shadow-sm`, `--shadow-md`, `--shadow-lg`, `--shadow-xl` | Used sparingly — only on hover-lifts, dropdowns, toasts, and overlays. |
 | **Transitions** | `--transition-fast` (0.15s), `--transition-base` (0.2s), `--transition-slow` (0.3s) | Default to `--transition-base`. Use `--transition-fast` for micro-interactions. |
+| **Spacing** | `--space-2xs` (2), `--space-xs` (4), `--space-sm` (6), `--space-md` (8), `--space-lg` (10), `--space-xl` (12) | Use for padding, gap, and margin in sidebar and other components. |
+| **Sidebar** | `--sidebar-width` (200), `--sidebar-collapsed-width` (52) | Expanded and icon-only widths for the left navigation sidebar. |
+| **Border widths** | `--border-width-accent` (2) | Active-indicator border thickness (sidebar left-border, mobile bottom-border). |
+| **Icon sizes** | `--icon-sm` (16) | Small icon dimensions (e.g., mobile nav SVGs). |
 
 ### Reusable Patterns
 - **`.mono-label`** — Utility class for the mono-label pattern (12px JetBrains Mono, muted). Apply via class or replicate the three properties.

--- a/docs/DEVLOG.md
+++ b/docs/DEVLOG.md
@@ -14,6 +14,19 @@
 
 ## Log
 
+### 2026-03-25 — Tokenize Sidebar CSS (#212)
+
+Replaced ~20 hard-coded pixel values in the sidebar CSS with CSS custom properties. Added new `:root` token categories:
+
+- **Spacing scale:** `--space-2xs` (2px) through `--space-xl` (12px) — used for padding, gap, and margin
+- **Sidebar:** `--sidebar-width` (200px), `--sidebar-collapsed-width` (52px)
+- **Border widths:** `--border-width-accent` (2px) — active-indicator thickness
+- **Icon sizes:** `--icon-sm` (16px) — mobile nav SVGs
+
+All sidebar styles (section 31 + section 38 responsive) now reference tokens. Updated design tokens table in `CLAUDE.md`.
+
+---
+
 ### 2026-03-25 — Contextual Help Sidebars (#209)
 
 Added toggleable right-hand reference sidebars to both Schema and Template editors, surfacing documentation inline without leaving the workspace.

--- a/index.html
+++ b/index.html
@@ -137,6 +137,24 @@
     --transition-fast: 0.15s;
     --transition-base: 0.2s;
     --transition-slow: 0.3s;
+
+    /* Spacing scale */
+    --space-2xs: 2px;
+    --space-xs: 4px;
+    --space-sm: 6px;
+    --space-md: 8px;
+    --space-lg: 10px;
+    --space-xl: 12px;
+
+    /* Sidebar */
+    --sidebar-width: 200px;
+    --sidebar-collapsed-width: 52px;
+
+    /* Border widths */
+    --border-width-accent: 2px;
+
+    /* Icon sizes */
+    --icon-sm: 16px;
   }
   * { margin: 0; padding: 0; box-sizing: border-box; }
 
@@ -1563,22 +1581,22 @@
 
   /* ===== 31. SIDEBAR NAVIGATION ===== */
   .app-sidebar {
-    width: 200px; flex-shrink: 0;
+    width: var(--sidebar-width); flex-shrink: 0;
     display: flex; flex-direction: column;
     background: var(--bg); border-right: 1px solid var(--border);
     transition: width var(--transition-base);
     overflow: hidden;
   }
-  .app-sidebar.collapsed { width: 52px; }
+  .app-sidebar.collapsed { width: var(--sidebar-collapsed-width); }
   .app-sidebar-nav {
-    display: flex; flex-direction: column; gap: 2px;
-    padding: 12px 8px; flex: 1;
+    display: flex; flex-direction: column; gap: var(--space-2xs);
+    padding: var(--space-xl) var(--space-md); flex: 1;
   }
   .dev-nav-tab {
-    display: flex; align-items: center; gap: 10px;
-    padding: 10px 12px; border-radius: var(--radius-md);
+    display: flex; align-items: center; gap: var(--space-lg);
+    padding: var(--space-lg) var(--space-xl); border-radius: var(--radius-md);
     background: transparent; border: none;
-    border-left: 2px solid transparent;
+    border-left: var(--border-width-accent) solid transparent;
     color: var(--text-muted); font-family: var(--font-sans);
     font-size: var(--text-sm); cursor: pointer;
     transition: all var(--transition-base);
@@ -1595,12 +1613,12 @@
   .dev-nav-tab .nav-label { overflow: hidden; text-overflow: ellipsis; }
   .app-sidebar.collapsed .nav-label { display: none; }
   .app-sidebar-footer {
-    padding: 8px; border-top: 1px solid var(--border);
-    display: flex; flex-direction: column; gap: 6px;
+    padding: var(--space-md); border-top: 1px solid var(--border);
+    display: flex; flex-direction: column; gap: var(--space-sm);
   }
   .sidebar-toggle {
     display: flex; align-items: center; justify-content: center;
-    width: 100%; padding: 6px; background: transparent; border: none;
+    width: 100%; padding: var(--space-sm); background: transparent; border: none;
     color: var(--text-muted); cursor: pointer; border-radius: var(--radius-sm);
     transition: all var(--transition-fast);
   }
@@ -1609,8 +1627,8 @@
   .sidebar-toggle svg { transition: transform var(--transition-base); }
   .app-sidebar.collapsed .sidebar-toggle svg { transform: rotate(180deg); }
   .sidebar-status-badge {
-    display: flex; align-items: center; gap: 8px;
-    padding: 6px 10px; border-radius: var(--radius-pill); font-size: var(--text-xs); font-weight: 500;
+    display: flex; align-items: center; gap: var(--space-md);
+    padding: var(--space-sm) var(--space-lg); border-radius: var(--radius-pill); font-size: var(--text-xs); font-weight: 500;
     font-family: var(--font-mono);
     background: var(--surface-2); border: 1px solid var(--border); color: var(--text-muted);
     transition: all var(--transition-slow) ease;
@@ -1626,7 +1644,7 @@
   .sidebar-status-badge .status-text { overflow: hidden; text-overflow: ellipsis; }
   .app-sidebar.collapsed .sidebar-status-badge .status-text { display: none; }
   .app-sidebar.collapsed .sidebar-status-badge .status-chevron { display: none; }
-  .app-sidebar.collapsed .sidebar-status-badge { justify-content: center; padding: 6px; }
+  .app-sidebar.collapsed .sidebar-status-badge { justify-content: center; padding: var(--space-sm); }
 
   .dev-container {
     width: 100%; max-width: 1600px; margin: 0 auto;
@@ -2256,26 +2274,26 @@
   /* ===== 38. SIDEBAR RESPONSIVE ===== */
   .mobile-bottom-nav { display: none; }
   @media (max-width: 1024px) {
-    .app-sidebar { width: 52px; }
+    .app-sidebar { width: var(--sidebar-collapsed-width); }
     .app-sidebar .nav-label { display: none; }
     .app-sidebar .sidebar-status-badge .status-text { display: none; }
     .app-sidebar .sidebar-status-badge .status-chevron { display: none; }
-    .app-sidebar .sidebar-status-badge { justify-content: center; padding: 6px; }
+    .app-sidebar .sidebar-status-badge { justify-content: center; padding: var(--space-sm); }
     .sidebar-toggle { display: none; }
   }
   @media (max-width: 768px) {
     .app-shell { flex-direction: column; }
     .app-sidebar { display: none; }
     .mobile-bottom-nav {
-      display: flex; align-items: center; justify-content: center; gap: 2px;
-      padding: 6px 8px; background: var(--bg);
+      display: flex; align-items: center; justify-content: center; gap: var(--space-2xs);
+      padding: var(--space-sm) var(--space-md); background: var(--bg);
       border-top: 1px solid var(--border);
       flex-shrink: 0; order: 99;
     }
     .mobile-bottom-nav .dev-nav-tab {
-      flex: 1; flex-direction: column; gap: 2px;
-      padding: 6px 4px; border-left: none;
-      border-bottom: 2px solid transparent;
+      flex: 1; flex-direction: column; gap: var(--space-2xs);
+      padding: var(--space-sm) var(--space-xs); border-left: none;
+      border-bottom: var(--border-width-accent) solid transparent;
       text-align: center; justify-content: center;
       font-size: var(--text-2xs);
     }
@@ -2283,7 +2301,7 @@
       border-bottom-color: var(--accent); border-left-color: transparent;
       background: var(--accent-subtle);
     }
-    .mobile-bottom-nav .dev-nav-tab svg { width: 16px; height: 16px; }
+    .mobile-bottom-nav .dev-nav-tab svg { width: var(--icon-sm); height: var(--icon-sm); }
     .dev-split { flex-direction: column; }
     .dev-pane-resizer { display: none; }
     .help-sidebar.open {


### PR DESCRIPTION
## Summary
- Added new `:root` CSS custom properties: spacing scale (`--space-2xs` through `--space-xl`), sidebar dimensions (`--sidebar-width`, `--sidebar-collapsed-width`), border width (`--border-width-accent`), and icon size (`--icon-sm`)
- Replaced all ~20 hard-coded pixel values in sidebar CSS (section 31) and responsive overrides (section 38) with token references
- Updated design tokens table in `CLAUDE.md` with the new token categories

## Test plan
- [x] All 584 fast tests pass
- [ ] Visual regression check: sidebar looks identical at desktop, tablet (1024px), and mobile (768px) widths
- [ ] Collapse/expand toggle still works with correct widths
- [ ] Mobile bottom nav spacing unchanged

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)