### PR TITLE
feat: load demo schema/template into editors with reset (#214)

### DIFF
--- a/docs/DEVLOG.md
+++ b/docs/DEVLOG.md
@@ -14,6 +14,19 @@
 
 ## Log
 
+### 2026-03-25 — Load Demo Content into Editors (#214)
+
+When users click "Try Demo" and then switch to Schema or Template tabs, the editors now show the actual demo schema and template (previously showed blank starters). Key changes:
+
+- `launchDemo()` pre-loads `DEMO_SCHEMA`, `DEMO_TEMPLATE`, and sample data into editor variables
+- `initSchemaEditor()` / `initTemplateEditor()` fall back to demo content when `contentSourceType === 'demo'`
+- Source toolbar shows "demo · Employee Onboarding" label in demo mode
+- "Reset Demo" buttons appear in each editor toolbar when content has been modified, restoring originals
+- Reset buttons auto-hide when not in demo mode or when content matches original
+- Added 10 tests covering editor loading, reset functions, button visibility, and toolbar demo label
+
+---
+
 ### 2026-03-25 — Tokenize Sidebar CSS (#212)
 
 Replaced ~20 hard-coded pixel values in the sidebar CSS with CSS custom properties. Added new `:root` token categories:

--- a/index.html
+++ b/index.html
@@ -3613,7 +3613,7 @@ function getDocRawContent(panelId) {
     exampleSchema: () => {
       if (typeof DEMO_SCHEMA === 'undefined' || typeof DEMO_TEMPLATE === 'undefined') return '';
       const parts = [];
-      parts.push('# Example Schema\n\n```json\n' + JSON.stringify(DEMO_SCHEMA, null, 2) + '\n```');
+      parts.push('# Example Schema\n\n```json\n' + DEMO_SCHEMA_JSON + '\n```');
       parts.push('\n\n# Example Template\n\n```python\n' + DEMO_TEMPLATE.trim() + '\n```');
       return parts.join('');
     }
@@ -3816,7 +3816,7 @@ function friendlyError(err) {
 }
 
 function buildFallbackExamples() {
-  const schema = JSON.stringify(DEMO_SCHEMA, null, 2);
+  const schema = DEMO_SCHEMA_JSON;
   return `<p>These are the embedded demo files. Save them as <code>.json</code> and <code>.py</code> to use as starting points.</p>
     <h4>onboarding.json</h4>
     <pre class="docs-code">${escapeHtml(schema)}</pre>
@@ -4012,7 +4012,7 @@ async function launchDemo() {
     document.getElementById('exportBtn').disabled = false;
 
     // Pre-load demo content into editors so Schema/Template tabs show it
-    devSchemaText = JSON.stringify(DEMO_SCHEMA, null, 2);
+    devSchemaText = DEMO_SCHEMA_JSON;
     devTemplateText = DEMO_TEMPLATE;
     devSampleDataText = JSON.stringify(DEMO_SCHEMA.sampleData || {}, null, 2);
     currentSchemaFile = null;
@@ -8099,6 +8099,8 @@ const DEMO_SCHEMA = {
   ]
 };
 
+const DEMO_SCHEMA_JSON = JSON.stringify(DEMO_SCHEMA, null, 2);
+
 const DEMO_TEMPLATE = `
 import stencils
 
@@ -9985,7 +9987,7 @@ function updateSourceToolbar() {
     if (f || isGh || isLocal || isDemo) {
       toolbar.style.display = 'flex';
       document.getElementById(prefix + 'SourceFile').textContent = isDemo
-        ? 'demo · Employee Onboarding'
+        ? `demo \u00b7 ${DEMO_SCHEMA.title}`
         : (f ? (f.ghPath || f.name) : (hasEditorContent ? 'new file (unsaved)' : ''));
       document.getElementById(prefix + 'SourceBranch').textContent = isGh ? `@ ${ghBranch}` : '';
       document.getElementById(prefix + 'BranchSelect').style.display = isGh ? '' : 'none';
@@ -10417,7 +10419,7 @@ function initSchemaEditor() {
 
   if (!devSchemaText) {
     devSchemaText = contentSourceType === 'demo'
-      ? JSON.stringify(DEMO_SCHEMA, null, 2)
+      ? DEMO_SCHEMA_JSON
       : JSON.stringify(DEV_STARTER_SCHEMA, null, 2);
   }
   el.textContent = devSchemaText;
@@ -10912,22 +10914,20 @@ function devNewSchema() {
 }
 
 function devResetDemoSchema() {
-  devSchemaText = JSON.stringify(DEMO_SCHEMA, null, 2);
-  if (schemaJar) schemaJar.updateCode(devSchemaText);
-  devSaveEditorState();
-  devUpdateSchemaPreview();
-  devUpdateDemoResetButtons();
+  devSchemaText = DEMO_SCHEMA_JSON;
+  // updateCode triggers onUpdate which handles save/preview/reset-buttons,
+  // but explicit calls are needed as fallback when jar isn't initialized
+  if (schemaJar) { schemaJar.updateCode(devSchemaText); }
+  else { devSaveEditorState(); devUpdateSchemaPreview(); devUpdateDemoResetButtons(); }
   showToast('Schema reset to demo original');
 }
 
 function devResetDemoTemplate() {
   devTemplateText = DEMO_TEMPLATE;
-  if (templateJar) templateJar.updateCode(devTemplateText);
   devSampleDataText = JSON.stringify(DEMO_SCHEMA.sampleData || {}, null, 2);
+  if (templateJar) { templateJar.updateCode(devTemplateText); }
+  else { devSaveEditorState(); devUpdateTemplateValidation(); devUpdateDemoResetButtons(); }
   if (sampleJar) sampleJar.updateCode(devSampleDataText);
-  devSaveEditorState();
-  devUpdateTemplateValidation();
-  devUpdateDemoResetButtons();
   showToast('Template reset to demo original');
 }
 
@@ -10942,11 +10942,8 @@ function devUpdateDemoResetButtons() {
     return;
   }
 
-  const origSchema = JSON.stringify(DEMO_SCHEMA, null, 2);
-  schemaBtn.style.display = devSchemaText !== origSchema ? 'inline-flex' : 'none';
-
-  const origTemplate = DEMO_TEMPLATE;
-  templateBtn.style.display = devTemplateText !== origTemplate ? 'inline-flex' : 'none';
+  schemaBtn.style.display = devSchemaText !== DEMO_SCHEMA_JSON ? 'inline-flex' : 'none';
+  templateBtn.style.display = devTemplateText !== DEMO_TEMPLATE ? 'inline-flex' : 'none';
 }
 
 function devLoadSchemaFile(event) {
@@ -11789,12 +11786,14 @@ function buildSchemaAIContext() {
   lines.push('## Complete Example Schema');
   lines.push('');
   lines.push('```json');
-  lines.push(JSON.stringify(DEMO_SCHEMA, null, 2));
+  lines.push(DEMO_SCHEMA_JSON);
   lines.push('```');
   lines.push('');
 
-  // Current WIP
-  if (devSchemaText && devSchemaText.trim() && devSchemaText.trim() !== JSON.stringify(DEV_STARTER_SCHEMA, null, 2)) {
+  // Current WIP (exclude starter and demo content)
+  if (devSchemaText && devSchemaText.trim()
+      && devSchemaText.trim() !== JSON.stringify(DEV_STARTER_SCHEMA, null, 2)
+      && devSchemaText.trim() !== DEMO_SCHEMA_JSON) {
     lines.push('## Current Work in Progress');
     lines.push('');
     lines.push('The user is currently editing this schema:');
@@ -12153,8 +12152,10 @@ function buildTemplateAIContext() {
     lines.push('');
   }
 
-  // Current WIP
-  if (devTemplateText && devTemplateText.trim() && devTemplateText.trim() !== DEV_STARTER_TEMPLATE.trim()) {
+  // Current WIP (exclude starter and demo content)
+  if (devTemplateText && devTemplateText.trim()
+      && devTemplateText.trim() !== DEV_STARTER_TEMPLATE.trim()
+      && devTemplateText.trim() !== DEMO_TEMPLATE.trim()) {
     lines.push('## Current Work in Progress');
     lines.push('');
     lines.push('The user is currently editing this template:');
@@ -13648,6 +13649,19 @@ function disconnectSource() {
   workspaceHandle = null;
   if (devWorkspacePoller) { clearInterval(devWorkspacePoller); devWorkspacePoller = null; }
   baseModuleLoaded = false;
+
+  // Clear demo editor content so it doesn't persist into the next session
+  if (wasType === 'demo') {
+    devSchemaText = '';
+    devTemplateText = '';
+    devSampleDataText = '{}';
+    if (schemaJar) schemaJar.updateCode('');
+    if (templateJar) templateJar.updateCode('');
+    if (sampleJar) sampleJar.updateCode('{}');
+    localStorage.removeItem('formforge-dev-schema');
+    localStorage.removeItem('formforge-dev-template');
+    localStorage.removeItem('formforge-dev-sampledata');
+  }
 
   // Clear stored connection info
   localStorage.removeItem('formforge-dev-github-repo');

--- a/index.html
+++ b/index.html
@@ -2762,6 +2762,10 @@
           <svg width="12" height="12"><use href="#icon-book"/></svg>
           Reference
         </button>
+        <button type="button" class="btn-secondary btn-sm demo-reset-btn" id="schemaDemoResetBtn" onclick="devResetDemoSchema()" title="Reset to original demo schema" style="display:none">
+          <svg width="12" height="12"><use href="#icon-refresh"/></svg>
+          Reset Demo
+        </button>
       </div>
     </div>
     <div class="dev-source-toolbar" id="schemaSourceToolbar" style="display:none">
@@ -2859,6 +2863,10 @@
         <button type="button" class="btn-primary btn-sm" onclick="devRunPreview()" title="Preview DOCX (Shift+Enter / Ctrl+Enter)">
           <svg width="12" height="12"><use href="#icon-play"/></svg>
           Preview DOCX
+        </button>
+        <button type="button" class="btn-secondary btn-sm demo-reset-btn" id="templateDemoResetBtn" onclick="devResetDemoTemplate()" title="Reset to original demo template" style="display:none">
+          <svg width="12" height="12"><use href="#icon-refresh"/></svg>
+          Reset Demo
         </button>
       </div>
     </div>
@@ -4002,6 +4010,18 @@ async function launchDemo() {
     log('Demo template loaded into Pyodide', 'success');
 
     document.getElementById('exportBtn').disabled = false;
+
+    // Pre-load demo content into editors so Schema/Template tabs show it
+    devSchemaText = JSON.stringify(DEMO_SCHEMA, null, 2);
+    devTemplateText = DEMO_TEMPLATE;
+    devSampleDataText = JSON.stringify(DEMO_SCHEMA.sampleData || {}, null, 2);
+    currentSchemaFile = null;
+    currentTemplateFile = null;
+    if (schemaJar) schemaJar.updateCode(devSchemaText);
+    if (templateJar) templateJar.updateCode(devTemplateText);
+    if (sampleJar) sampleJar.updateCode(devSampleDataText);
+    devSaveEditorState();
+
     showView('form');
     postLaunchHook();
   } catch (err) {
@@ -9959,10 +9979,14 @@ function updateSourceToolbar() {
     const editorContent = fileType === 'schema' ? devSchemaText : devTemplateText;
     const hasEditorContent = editorContent && editorContent.trim();
 
-    // Show toolbar when a source is connected (GitHub or local folder) or a file is loaded
-    if (f || isGh || isLocal) {
+    const isDemo = contentSourceType === 'demo';
+
+    // Show toolbar when a source is connected (GitHub, local folder, or demo)
+    if (f || isGh || isLocal || isDemo) {
       toolbar.style.display = 'flex';
-      document.getElementById(prefix + 'SourceFile').textContent = f ? (f.ghPath || f.name) : (hasEditorContent ? 'new file (unsaved)' : '');
+      document.getElementById(prefix + 'SourceFile').textContent = isDemo
+        ? 'demo · Employee Onboarding'
+        : (f ? (f.ghPath || f.name) : (hasEditorContent ? 'new file (unsaved)' : ''));
       document.getElementById(prefix + 'SourceBranch').textContent = isGh ? `@ ${ghBranch}` : '';
       document.getElementById(prefix + 'BranchSelect').style.display = isGh ? '' : 'none';
       document.getElementById(prefix + 'NewBranchBtn').style.display = isGh ? 'inline-flex' : 'none';
@@ -9976,6 +10000,7 @@ function updateSourceToolbar() {
 
   configureToolbar(schemaToolbar, 'schema', 'schema');
   configureToolbar(tmplToolbar, 'template', 'template');
+  devUpdateDemoResetButtons();
 }
 
 // ============================================================
@@ -10391,7 +10416,9 @@ function initSchemaEditor() {
   if (!el || typeof CodeJar === 'undefined') return;
 
   if (!devSchemaText) {
-    devSchemaText = JSON.stringify(DEV_STARTER_SCHEMA, null, 2);
+    devSchemaText = contentSourceType === 'demo'
+      ? JSON.stringify(DEMO_SCHEMA, null, 2)
+      : JSON.stringify(DEV_STARTER_SCHEMA, null, 2);
   }
   el.textContent = devSchemaText;
 
@@ -10412,6 +10439,7 @@ function initSchemaEditor() {
     clearTimeout(devPreviewDebounce);
     devPreviewDebounce = setTimeout(devUpdateSchemaPreview, 300);
     devSaveEditorState();
+    devUpdateDemoResetButtons();
     if (contentSourceType === 'github' && currentSchemaFile) {
       devGhTrackModification('schema', currentSchemaFile.index);
     }
@@ -10881,6 +10909,44 @@ function devNewSchema() {
   updateSourceToolbar();
   devUpdateSchemaPreview();
   showToast('New schema created');
+}
+
+function devResetDemoSchema() {
+  devSchemaText = JSON.stringify(DEMO_SCHEMA, null, 2);
+  if (schemaJar) schemaJar.updateCode(devSchemaText);
+  devSaveEditorState();
+  devUpdateSchemaPreview();
+  devUpdateDemoResetButtons();
+  showToast('Schema reset to demo original');
+}
+
+function devResetDemoTemplate() {
+  devTemplateText = DEMO_TEMPLATE;
+  if (templateJar) templateJar.updateCode(devTemplateText);
+  devSampleDataText = JSON.stringify(DEMO_SCHEMA.sampleData || {}, null, 2);
+  if (sampleJar) sampleJar.updateCode(devSampleDataText);
+  devSaveEditorState();
+  devUpdateTemplateValidation();
+  devUpdateDemoResetButtons();
+  showToast('Template reset to demo original');
+}
+
+function devUpdateDemoResetButtons() {
+  const schemaBtn = document.getElementById('schemaDemoResetBtn');
+  const templateBtn = document.getElementById('templateDemoResetBtn');
+  if (!schemaBtn || !templateBtn) return;
+
+  if (contentSourceType !== 'demo') {
+    schemaBtn.style.display = 'none';
+    templateBtn.style.display = 'none';
+    return;
+  }
+
+  const origSchema = JSON.stringify(DEMO_SCHEMA, null, 2);
+  schemaBtn.style.display = devSchemaText !== origSchema ? 'inline-flex' : 'none';
+
+  const origTemplate = DEMO_TEMPLATE;
+  templateBtn.style.display = devTemplateText !== origTemplate ? 'inline-flex' : 'none';
 }
 
 function devLoadSchemaFile(event) {
@@ -12135,7 +12201,9 @@ function initTemplateEditor() {
   if (!el || typeof CodeJar === 'undefined') return;
 
   if (!devTemplateText) {
-    devTemplateText = DEV_STARTER_TEMPLATE;
+    devTemplateText = contentSourceType === 'demo'
+      ? DEMO_TEMPLATE
+      : DEV_STARTER_TEMPLATE;
   }
   el.textContent = devTemplateText;
 
@@ -12154,6 +12222,7 @@ function initTemplateEditor() {
     devSaveEditorState();
     clearTimeout(devTemplateValidDebounce);
     devTemplateValidDebounce = setTimeout(devUpdateTemplateValidation, 300);
+    devUpdateDemoResetButtons();
     if (contentSourceType === 'github' && currentTemplateFile) {
       devGhTrackModification('template', currentTemplateFile.index);
     }

--- a/tests/test_dev_mode.py
+++ b/tests/test_dev_mode.py
@@ -2711,6 +2711,29 @@ def test_demo_button_restored_on_disconnect(index_html: str) -> None:
     assert "demoBtnAction" in body
 
 
+def test_disconnect_clears_demo_editor_state(index_html: str) -> None:
+    """disconnectSource clears editor content when leaving demo mode."""
+    body = _extract_func(index_html, "disconnectSource")
+    assert "wasType === 'demo'" in body
+    assert "devSchemaText" in body
+    assert "devTemplateText" in body
+    assert "devSampleDataText" in body
+    assert "formforge-dev-schema" in body
+
+
+def test_demo_schema_json_constant_exists(index_html: str) -> None:
+    """DEMO_SCHEMA_JSON is pre-computed to avoid repeated serialization."""
+    assert (
+        "const DEMO_SCHEMA_JSON = JSON.stringify(DEMO_SCHEMA, null, 2);" in index_html
+    )
+
+
+def test_source_toolbar_demo_label_uses_title(index_html: str) -> None:
+    """Demo source label uses DEMO_SCHEMA.title instead of a hardcoded string."""
+    body = _extract_func(index_html, "updateSourceToolbar")
+    assert "DEMO_SCHEMA.title" in body
+
+
 def test_empty_state_hidden_when_connected(index_html: str) -> None:
     """renderPicker hides the empty state card."""
     body = _extract_func(index_html, "renderPicker")
@@ -2824,6 +2847,8 @@ def test_build_schema_ai_context_function(index_html: str) -> None:
     assert "devSchemaText" in body
     assert "contentSourceType" in body
     assert "workspaceFiles" in body
+    # WIP section excludes demo content
+    assert "DEMO_SCHEMA_JSON" in body
 
 
 def test_build_template_ai_context_function(index_html: str) -> None:
@@ -2837,6 +2862,8 @@ def test_build_template_ai_context_function(index_html: str) -> None:
     assert "devParsedSchema" in body
     assert "devSampleDataText" in body
     assert "contentSourceType" in body
+    # WIP section excludes demo content
+    assert "DEMO_TEMPLATE.trim()" in body
 
 
 def test_copy_schema_ai_context_function(index_html: str) -> None:

--- a/tests/test_dev_mode.py
+++ b/tests/test_dev_mode.py
@@ -2022,6 +2022,80 @@ def test_demo_sets_content_source_type(index_html: str) -> None:
     assert "contentSourceType = 'demo'" in match.group(1)
 
 
+def test_demo_loads_editors(index_html: str) -> None:
+    """launchDemo should pre-load DEMO_SCHEMA and DEMO_TEMPLATE into editor variables."""
+    match = re.search(
+        r"async function launchDemo\(\)([\s\S]*?)^(?:async )?function ",
+        index_html,
+        re.M,
+    )
+    assert match
+    body = match.group(1)
+    assert "DEMO_SCHEMA" in body
+    assert "DEMO_TEMPLATE" in body
+    assert "devSchemaText" in body
+    assert "devTemplateText" in body
+    assert "devSampleDataText" in body
+    assert "devSaveEditorState" in body
+
+
+def test_demo_reset_schema_button_exists(index_html: str) -> None:
+    """Schema toolbar has a demo reset button."""
+    assert 'id="schemaDemoResetBtn"' in index_html
+    assert "devResetDemoSchema()" in index_html
+
+
+def test_demo_reset_template_button_exists(index_html: str) -> None:
+    """Template toolbar has a demo reset button."""
+    assert 'id="templateDemoResetBtn"' in index_html
+    assert "devResetDemoTemplate()" in index_html
+
+
+def test_demo_reset_schema_function(index_html: str) -> None:
+    """devResetDemoSchema restores DEMO_SCHEMA into editor."""
+    body = _extract_func(index_html, "devResetDemoSchema")
+    assert "DEMO_SCHEMA" in body
+    assert "devSchemaText" in body
+    assert "schemaJar" in body
+
+
+def test_demo_reset_template_function(index_html: str) -> None:
+    """devResetDemoTemplate restores DEMO_TEMPLATE into editor."""
+    body = _extract_func(index_html, "devResetDemoTemplate")
+    assert "DEMO_TEMPLATE" in body
+    assert "devTemplateText" in body
+    assert "templateJar" in body
+
+
+def test_demo_reset_buttons_visibility_function(index_html: str) -> None:
+    """devUpdateDemoResetButtons shows buttons only in demo mode with edits."""
+    body = _extract_func(index_html, "devUpdateDemoResetButtons")
+    assert "contentSourceType" in body
+    assert "schemaDemoResetBtn" in body
+    assert "templateDemoResetBtn" in body
+
+
+def test_init_schema_editor_demo_fallback(index_html: str) -> None:
+    """initSchemaEditor falls back to DEMO_SCHEMA when contentSourceType is demo."""
+    body = _extract_func(index_html, "initSchemaEditor")
+    assert "DEMO_SCHEMA" in body
+    assert "contentSourceType" in body
+
+
+def test_init_template_editor_demo_fallback(index_html: str) -> None:
+    """initTemplateEditor falls back to DEMO_TEMPLATE when contentSourceType is demo."""
+    body = _extract_func(index_html, "initTemplateEditor")
+    assert "DEMO_TEMPLATE" in body
+    assert "contentSourceType" in body
+
+
+def test_source_toolbar_shows_demo_label(index_html: str) -> None:
+    """updateSourceToolbar shows demo context label when contentSourceType is demo."""
+    body = _extract_func(index_html, "updateSourceToolbar")
+    assert "demo" in body.lower()
+    assert "isDemo" in body
+
+
 def test_picker_uses_abort_controller(index_html: str) -> None:
     """renderPicker should use AbortController to prevent listener accumulation."""
     match = re.search(


### PR DESCRIPTION
## Summary
- **Auto-loads** `DEMO_SCHEMA` and `DEMO_TEMPLATE` into Schema/Template editors when the demo is launched, so users can explore how the form and template are built
- **Shows demo source context** in the source toolbar ("demo · Employee Onboarding") with git controls hidden
- **Adds "Reset Demo" buttons** that appear only when content has been modified in demo mode, restoring original demo content on click
- **Falls back to demo content** in `initSchemaEditor()`/`initTemplateEditor()` when editors are first initialized in demo mode

## Test plan
- [x] 593 tests pass (10 new demo-specific tests added)
- [x] `ruff check` and `ruff format` clean
- [ ] Manual: Click "Try Demo" → navigate to Schema tab → verify demo JSON appears in editor with live preview
- [ ] Manual: Click "Try Demo" → navigate to Template tab → verify demo Python appears in editor
- [ ] Manual: Edit schema in demo mode → verify "Reset Demo" button appears → click it → content restores
- [ ] Manual: Connect a GitHub repo → verify demo reset buttons disappear and source toolbar shows repo info
- [ ] Manual: Use "Fill Form" from Schema editor and "Preview DOCX" from Template editor in demo mode

Closes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)