### PR TITLE
Cursor-aware flat context menus for editor tabs

### DIFF
--- a/docs/DEVLOG.md
+++ b/docs/DEVLOG.md
@@ -14,6 +14,33 @@
 
 ## Log
 
+### 2026-03-25 — Editor Context Menu Improvements (#215, #216, #217, #218, #219)
+
+Redesigned Schema and Template editor context menus to be cursor-aware, flat, and editor-clamped.
+
+**#216 — Clamp to editor pane bounds:**
+- `showContextMenu()` accepts optional `boundingEl` for pane-clamped positioning
+- Added `overflow-y: auto` and dynamic `max-height` for scrollable menus
+
+**#217 — Schema editor cursor-aware flat menu:**
+- `getSchemaEditorContext()` detects root/section/field level via JSON bracket tracking
+- Root: Add Section, Wrap in Wizard; Section: 24 field types with group labels; Field: type-specific property snippets
+- New `getFieldPropertySnippets()` and `devInsertProperty()` for field-level editing
+
+**#218 — Template editor cursor-aware flat menu:**
+- `getTemplateEditorContext()` detects top-level vs function body via `def` line scanning
+- Top: imports, scaffold, themes; Body: stencil helpers, schema field accessors
+- `TEMPLATE_SNIPPETS` entries now tagged with `category: 'top'|'body'`
+
+**#219 — Base scaffold:** `BASE_SCAFFOLD` constant shown at root level when editor is empty
+
+**Decisions:**
+- Preview pane context menu unchanged (keeps submenus for field insertion)
+- Schema cursor detection uses string-stripped bracket/key state machine
+- Template cursor detection uses backward scan for `def` lines with indentation check
+
+---
+
 ### 2026-03-25 — Tokenize Sidebar CSS (#212)
 
 Replaced ~20 hard-coded pixel values in the sidebar CSS with CSS custom properties. Added new `:root` token categories:

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -5,10 +5,6 @@
 
 ---
 
-TODO: Schema context menu improvements — add option to add base scaffold (e.g. editor is blank)
-
----
-
 ## Active Plans
 
 *(No active plans.)*
@@ -16,6 +12,13 @@ TODO: Schema context menu improvements — add option to add base scaffold (e.g.
 ---
 
 ## Completed Plans
+
+### Issue #215 — Improve Editor Context Menus ✅
+
+**Branch:** `feature/215-context-menu-improvements`
+**Issues:** #215 (parent), #216, #217, #218, #219
+
+Redesigned Schema and Template editor context menus: cursor-aware (root/section/field and top/body contexts), flat (group labels, no submenus), editor-clamped (bounding element positioning), with field property snippets and base scaffold option.
 
 ### Issue #202 — Commit New Files from Editors to GitHub ✅
 

--- a/index.html
+++ b/index.html
@@ -1904,6 +1904,7 @@
     padding: 6px 14px 3px; font-family: var(--font-mono);
     font-size: var(--text-2xs); color: var(--text-muted);
     text-transform: uppercase; letter-spacing: 0.05em;
+    user-select: none; cursor: default;
   }
   .ctx-menu-item.has-sub::after {
     content: '▸'; margin-left: auto; padding-left: 12px;
@@ -11008,7 +11009,6 @@ function showContextMenu(x, y, items, boundingEl) {
   });
 
   // Clamping — use bounding element rect if provided, else viewport
-  const rect = menu.getBoundingClientRect();
   let boundsRight, boundsBottom, boundsLeft, boundsTop;
   if (boundingEl) {
     const bRect = boundingEl.getBoundingClientRect();
@@ -11016,6 +11016,7 @@ function showContextMenu(x, y, items, boundingEl) {
     boundsBottom = bRect.bottom;
     boundsLeft = bRect.left;
     boundsTop = bRect.top;
+    // Set maxHeight before measuring so rect reflects constrained height
     menu.style.maxHeight = (bRect.height - 16) + 'px';
   } else {
     boundsRight = window.innerWidth;
@@ -11023,6 +11024,7 @@ function showContextMenu(x, y, items, boundingEl) {
     boundsLeft = 0;
     boundsTop = 0;
   }
+  const rect = menu.getBoundingClientRect();
   if (x + rect.width > boundsRight) x = boundsRight - rect.width - 8;
   if (y + rect.height > boundsBottom) y = boundsBottom - rect.height - 8;
   menu.style.left = Math.max(boundsLeft, x) + 'px';
@@ -11158,7 +11160,7 @@ const FIELD_SNIPPETS = {
   select:   { id: "select_field", label: "Select", type: "select", required: false, options: ["Option A", "Option B", "Option C"] },
   multi_select: { id: "multi_field", label: "Multi Select", type: "multi_select", required: false, options: ["Option A", "Option B", "Option C"] },
   radio:    { id: "radio_field", label: "Radio Choice", type: "radio", required: false, options: ["Option A", "Option B"] },
-  checkbox: { id: "checkbox_field", label: "Agree to terms", type: "checkbox", required: false },
+  checkbox: { id: "checkbox_field", label: "Agree to terms", type: "checkbox", required: false, options: ["Option A", "Option B"] },
   toggle:   { id: "toggle_field", label: "Enable feature", type: "toggle", required: false },
   address:  { id: "address_field", label: "Address", type: "address", required: false },
   repeater: { id: "items", label: "Items", type: "repeater", fields: [{ id: "item_name", label: "Name", type: "text" }, { id: "item_qty", label: "Qty", type: "number" }] },
@@ -11166,7 +11168,7 @@ const FIELD_SNIPPETS = {
   signature:{ id: "signature_field", label: "Signature", type: "signature", required: false },
   list:     { id: "list_field", label: "Items List", type: "list", required: false },
   heading:  { id: "heading_1", label: "Section Heading", type: "heading" },
-  hidden:   { id: "hidden_field", label: "", type: "hidden", default: "value" },
+  hidden:   { id: "hidden_field", label: "hidden_field", type: "hidden", default_value: "value" },
   info:     { id: "info_1", label: "Important Notice", type: "info", content: "This is an informational message.", style: "info" },
   textarea: { id: "notes", label: "Notes", type: "textarea", required: false },
   longtext: { id: "description", label: "Description", type: "longtext", required: false }
@@ -11850,7 +11852,9 @@ function getSchemaEditorContext(text, cursorOffset) {
   }
 
   const current = stack.length > 0 ? stack[stack.length - 1].ctx : 'outside';
-  if (current === 'field') {
+  // Check current context and ancestors — cursor inside a nested property
+  // (visible_when object, options array, etc.) should still resolve to field level
+  if (current === 'field' || stack.some(s => s.ctx === 'field')) {
     const fieldType = _detectFieldType(text, fieldStartPos);
     return { level: 'field', fieldType, sectionIndex: sectionIdx, fieldIndex: fieldIdx };
   }
@@ -11997,9 +12001,11 @@ function devSchemaContextItems(ctx) {
       { label: 'Add Section', action: () => devInsertSection() },
       { label: 'Wrap in Wizard', action: () => devWrapInWizard() },
     ];
-    // Show scaffold option when editor is empty or near-empty
-    const trimmed = devSchemaText.replace(/[\s{}[\]]/g, '');
-    if (!trimmed || trimmed.length < 5) {
+    // Show scaffold option when editor is empty or has no sections
+    let showScaffold = false;
+    try { const p = JSON.parse(devSchemaText); showScaffold = !p.sections || p.sections.length === 0; }
+    catch { showScaffold = !devSchemaText.trim(); }
+    if (showScaffold) {
       items.unshift({ label: 'Base Scaffold', action: () => {
         devSchemaText = JSON.stringify(BASE_SCAFFOLD, null, 2);
         if (schemaJar) schemaJar.updateCode(devSchemaText);
@@ -12050,7 +12056,8 @@ function devSchemaContextItems(ctx) {
   // Field level: property snippets for the detected field type
   if (ctx.level === 'field' && ctx.fieldType) {
     const props = getFieldPropertySnippets(ctx.fieldType);
-    const items = [{ groupLabel: ctx.fieldType + ' properties' }];
+    const typeName = ctx.fieldType.replace(/_/g, ' ');
+    const items = [{ groupLabel: typeName + ' properties' }];
     props.forEach(p => {
       items.push({
         label: p.label,

--- a/index.html
+++ b/index.html
@@ -1887,6 +1887,7 @@
     border-radius: var(--radius-md); padding: 4px 0;
     box-shadow: var(--shadow-lg);
     font-family: var(--font-sans); font-size: var(--text-sm);
+    overflow-y: auto;
   }
   .ctx-menu-item {
     display: flex; align-items: center; gap: 8px;
@@ -10421,10 +10422,13 @@ function initSchemaEditor() {
   el.addEventListener('scroll', () => { if (!_schemaScrollRAF) { _schemaScrollRAF = true; requestAnimationFrame(() => { gutterEl.scrollTop = el.scrollTop; _schemaScrollRAF = false; }); } });
   el.addEventListener('keydown', (e) => devEditorKeydownHandler(e, schemaJar, 'json'));
 
-  // Right-click context menu
+  // Right-click context menu — cursor-aware, clamped to editor pane
   el.addEventListener('contextmenu', (e) => {
     e.preventDefault();
-    showContextMenu(e.clientX, e.clientY, devSchemaContextItems());
+    const offset = devGetCursorOffset(el);
+    const ctx = getSchemaEditorContext(devSchemaText, offset);
+    const pane = document.getElementById('schemaEditorPane');
+    showContextMenu(e.clientX, e.clientY, devSchemaContextItems(ctx), pane);
   });
 
   devUpdateLineNumbers(el, gutterEl);
@@ -10948,10 +10952,11 @@ function devSaveSchema() {
 
 let ctxMenuReturnFocus = null; // Element to restore focus to when menu closes
 
-function showContextMenu(x, y, items) {
+function showContextMenu(x, y, items, boundingEl) {
   const menu = document.getElementById('ctxMenu');
   menu.innerHTML = '';
   menu.style.display = 'block';
+  menu.style.maxHeight = '';
   ctxMenuReturnFocus = document.activeElement;
 
   items.forEach(item => {
@@ -11002,12 +11007,26 @@ function showContextMenu(x, y, items) {
     menu.appendChild(el);
   });
 
-  // Viewport clamping
+  // Clamping — use bounding element rect if provided, else viewport
   const rect = menu.getBoundingClientRect();
-  if (x + rect.width > window.innerWidth) x = window.innerWidth - rect.width - 8;
-  if (y + rect.height > window.innerHeight) y = window.innerHeight - rect.height - 8;
-  menu.style.left = Math.max(0, x) + 'px';
-  menu.style.top = Math.max(0, y) + 'px';
+  let boundsRight, boundsBottom, boundsLeft, boundsTop;
+  if (boundingEl) {
+    const bRect = boundingEl.getBoundingClientRect();
+    boundsRight = bRect.right;
+    boundsBottom = bRect.bottom;
+    boundsLeft = bRect.left;
+    boundsTop = bRect.top;
+    menu.style.maxHeight = (bRect.height - 16) + 'px';
+  } else {
+    boundsRight = window.innerWidth;
+    boundsBottom = window.innerHeight;
+    boundsLeft = 0;
+    boundsTop = 0;
+  }
+  if (x + rect.width > boundsRight) x = boundsRight - rect.width - 8;
+  if (y + rect.height > boundsBottom) y = boundsBottom - rect.height - 8;
+  menu.style.left = Math.max(boundsLeft, x) + 'px';
+  menu.style.top = Math.max(boundsTop, y) + 'px';
 
   // Focus first item
   const firstItem = menu.querySelector('[role="menuitem"]');
@@ -11769,43 +11788,280 @@ function copySchemaAIContext() {
   });
 }
 
-function devSchemaContextItems() {
-  const insertField = (type) => () => devInsertSnippet('schema', FIELD_SNIPPETS[type]);
+// ---- Schema editor cursor context detection ----
+
+function getSchemaEditorContext(text, cursorOffset) {
+  const before = text.substring(0, cursorOffset);
+  // Strip string contents, preserving length so indices stay aligned
+  let stripped = '';
+  let inStr = false, esc = false;
+  for (let i = 0; i < before.length; i++) {
+    const c = before[i];
+    if (esc) { esc = false; stripped += ' '; continue; }
+    if (c === '\\' && inStr) { esc = true; stripped += ' '; continue; }
+    if (c === '"') { inStr = !inStr; stripped += '"'; continue; }
+    stripped += inStr ? ' ' : c;
+  }
+
+  let stack = []; // { ctx, pos }
+  let lastKey = null;
+  let fieldStartPos = -1;
+  let sectionIdx = -1;
+  let fieldIdx = -1;
+
+  for (let i = 0; i < stripped.length; i++) {
+    const c = stripped[i];
+    if (c === '"') {
+      const end = stripped.indexOf('"', i + 1);
+      if (end !== -1) {
+        const key = text.substring(i + 1, end);
+        const rest = stripped.substring(end + 1).trimStart();
+        if (rest[0] === ':') lastKey = key;
+        i = end;
+      }
+      continue;
+    }
+    if (c === '{') {
+      const parentCtx = stack.length > 0 ? stack[stack.length - 1].ctx : null;
+      if (!parentCtx) {
+        stack.push({ ctx: 'root' });
+      } else if (parentCtx === 'sections-array') {
+        sectionIdx++;
+        fieldIdx = -1;
+        stack.push({ ctx: 'section' });
+      } else if (parentCtx === 'fields-array') {
+        fieldIdx++;
+        fieldStartPos = i;
+        stack.push({ ctx: 'field' });
+      } else {
+        stack.push({ ctx: 'other' });
+      }
+      lastKey = null;
+    } else if (c === '}') {
+      stack.pop();
+    } else if (c === '[') {
+      if (lastKey === 'sections') stack.push({ ctx: 'sections-array' });
+      else if (lastKey === 'fields') stack.push({ ctx: 'fields-array' });
+      else stack.push({ ctx: 'other-array' });
+      lastKey = null;
+    } else if (c === ']') {
+      stack.pop();
+    }
+  }
+
+  const current = stack.length > 0 ? stack[stack.length - 1].ctx : 'outside';
+  if (current === 'field') {
+    const fieldType = _detectFieldType(text, fieldStartPos);
+    return { level: 'field', fieldType, sectionIndex: sectionIdx, fieldIndex: fieldIdx };
+  }
+  if (current === 'section' || current === 'fields-array' || current === 'sections-array') {
+    return { level: 'section', sectionIndex: Math.max(0, sectionIdx) };
+  }
+  return { level: 'root' };
+}
+
+function _detectFieldType(fullText, bracePos) {
+  // Find "type": "xxx" at depth 1 within the field object starting at bracePos
+  let depth = 0, inStr = false, esc = false;
+  let endPos = fullText.length;
+  for (let i = bracePos; i < fullText.length; i++) {
+    const c = fullText[i];
+    if (esc) { esc = false; continue; }
+    if (c === '\\' && inStr) { esc = true; continue; }
+    if (c === '"') { inStr = !inStr; continue; }
+    if (inStr) continue;
+    if (c === '{') depth++;
+    if (c === '}') { depth--; if (depth === 0) { endPos = i; break; } }
+  }
+  const m = fullText.substring(bracePos, endPos + 1).match(/"type"\s*:\s*"([^"]+)"/);
+  return m ? m[1] : null;
+}
+
+function getFieldPropertySnippets(fieldType) {
+  const items = [];
+  const noRequired = ['heading', 'hidden', 'info'];
+  if (!noRequired.includes(fieldType)) {
+    items.push({ label: 'required', key: 'required', value: true });
+  }
+  const hasPlaceholder = ['text','email','tel','number','currency','url','date','time','datetime','textarea','longtext','select','multi_select','toggle'];
+  if (hasPlaceholder.includes(fieldType)) {
+    items.push({ label: 'placeholder', key: 'placeholder', value: 'Enter value...' });
+  }
+  const hasHint = ['text','email','tel','number','currency','url','date','time','datetime','textarea','longtext','select','multi_select','radio','checkbox','toggle','address','file','signature','list'];
+  if (hasHint.includes(fieldType)) {
+    items.push({ label: 'hint', key: 'hint', value: 'Help text here' });
+  }
+  const hasDefault = ['text','email','tel','number','currency','url','date','time','datetime','textarea','longtext','select','multi_select','radio','checkbox','toggle','address','signature','list'];
+  if (hasDefault.includes(fieldType)) {
+    items.push({ label: 'default_value', key: 'default_value', value: '' });
+  }
+  if (['select','multi_select','radio','checkbox'].includes(fieldType)) {
+    items.push({ label: 'options', key: 'options', value: ['Option 1', 'Option 2', 'Option 3'] });
+  }
+  if (fieldType === 'repeater') {
+    items.push({ label: 'fields', key: 'fields', value: [{ id: 'col1', label: 'Column 1', type: 'text' }] });
+    items.push({ label: 'display', key: 'display', value: 'table' });
+  }
+  if (fieldType === 'number' || fieldType === 'currency') {
+    items.push({ label: 'min', key: 'min', value: 0 });
+    items.push({ label: 'max', key: 'max', value: 100 });
+    items.push({ label: 'step', key: 'step', value: 1 });
+  }
+  if (fieldType === 'currency') {
+    items.push({ label: 'currency_symbol', key: 'currency_symbol', value: '$' });
+  }
+  if (fieldType === 'textarea' || fieldType === 'longtext') {
+    items.push({ label: 'min_rows', key: 'min_rows', value: 3 });
+    items.push({ label: 'max_rows', key: 'max_rows', value: 10 });
+  }
+  if (fieldType === 'text') {
+    items.push({ label: 'maxLength', key: 'maxLength', value: 100 });
+  }
+  if (fieldType === 'file') {
+    items.push({ label: 'accept', key: 'accept', value: '.pdf,.docx,.jpg,.png' });
+    items.push({ label: 'max_size_mb', key: 'max_size_mb', value: 10 });
+  }
+  if (fieldType === 'info') {
+    items.push({ label: 'content', key: 'content', value: 'Informational text here' });
+    items.push({ label: 'style', key: 'style', value: 'info' });
+  }
+  if (fieldType === 'heading') {
+    items.push({ label: 'level', key: 'level', value: 2 });
+  }
+  items.push({ label: 'visible_when', key: 'visible_when', value: { field: '', equals: '' } });
+  return items;
+}
+
+function devInsertProperty(sectionIndex, fieldIndex, key, value) {
+  try {
+    const schema = JSON.parse(devSchemaText);
+    const section = schema.sections && schema.sections[sectionIndex];
+    if (!section) return;
+    const field = section.fields && section.fields[fieldIndex];
+    if (!field) return;
+    if (field[key] !== undefined) {
+      showToast(`Property "${key}" already exists`, 'warning');
+      return;
+    }
+    field[key] = value;
+    devSchemaText = JSON.stringify(schema, null, 2);
+    if (schemaJar) schemaJar.updateCode(devSchemaText);
+    devUpdateSchemaPreview();
+    showToast(`Added "${key}"`);
+  } catch (e) {
+    showToast('Cannot insert — fix JSON errors first', 'error');
+  }
+}
+
+const BASE_SCAFFOLD = {
+  title: "New Form",
+  description: "",
+  icon: "📋",
+  template: "templates/new_form.py",
+  sections: [{
+    title: "Section 1",
+    fields: [{ id: "field_1", label: "Field 1", type: "text", required: false }]
+  }]
+};
+
+// ---- Template editor cursor context detection ----
+
+function getTemplateEditorContext(text, cursorOffset) {
+  const allLines = text.split('\n');
+  const before = text.substring(0, cursorOffset);
+  const cursorLine = before.split('\n').length - 1;
+
+  for (let i = cursorLine; i >= 0; i--) {
+    const line = allLines[i];
+    if (/^\s*def\s/.test(line)) {
+      // Cursor on the def line itself → top level
+      if (i === cursorLine) return { level: 'top' };
+      return { level: 'body' };
+    }
+    // Non-empty, non-indented, non-comment/decorator line → stop
+    if (i < cursorLine && /^\S/.test(line) && !line.startsWith('#') && !line.startsWith('@')) {
+      return { level: 'top' };
+    }
+  }
+  return { level: 'top' };
+}
+
+// ---- Context-aware menu builders ----
+
+function devSchemaContextItems(ctx) {
+  if (!ctx) ctx = { level: 'root' };
+
+  // Root level: structural operations
+  if (ctx.level === 'root') {
+    const items = [
+      { label: 'Add Section', action: () => devInsertSection() },
+      { label: 'Wrap in Wizard', action: () => devWrapInWizard() },
+    ];
+    // Show scaffold option when editor is empty or near-empty
+    const trimmed = devSchemaText.replace(/[\s{}[\]]/g, '');
+    if (!trimmed || trimmed.length < 5) {
+      items.unshift({ label: 'Base Scaffold', action: () => {
+        devSchemaText = JSON.stringify(BASE_SCAFFOLD, null, 2);
+        if (schemaJar) schemaJar.updateCode(devSchemaText);
+        devUpdateSchemaPreview();
+        showToast('Schema scaffold inserted');
+      }});
+    }
+    return items;
+  }
+
+  // Section level: flat list of all field types with group labels
+  if (ctx.level === 'section') {
+    const sIdx = ctx.sectionIndex;
+    const ins = (type) => () => devInsertSnippet('schema', FIELD_SNIPPETS[type], sIdx);
+    return [
+      { groupLabel: 'Input Fields' },
+      { label: 'Text',      action: ins('text') },
+      { label: 'Email',     action: ins('email') },
+      { label: 'Phone',     action: ins('tel') },
+      { label: 'Number',    action: ins('number') },
+      { label: 'Currency',  action: ins('currency') },
+      { label: 'URL',       action: ins('url') },
+      { label: 'Date',      action: ins('date') },
+      { label: 'Time',      action: ins('time') },
+      { label: 'DateTime',  action: ins('datetime') },
+      { label: 'Textarea',  action: ins('textarea') },
+      { label: 'Long Text', action: ins('longtext') },
+      { groupLabel: 'Choice Fields' },
+      { label: 'Select',       action: ins('select') },
+      { label: 'Multi Select', action: ins('multi_select') },
+      { label: 'Radio',        action: ins('radio') },
+      { label: 'Checkbox',     action: ins('checkbox') },
+      { label: 'Toggle',       action: ins('toggle') },
+      { groupLabel: 'Complex Fields' },
+      { label: 'Address',   action: ins('address') },
+      { label: 'Repeater',  action: ins('repeater') },
+      { label: 'Repeater (Table)', action: () => devInsertSnippet('schema', { id: "items", label: "Items", type: "repeater", display: "table", fields: [{ id: "item_name", label: "Name", type: "text" }, { id: "item_qty", label: "Qty", type: "number" }] }, sIdx) },
+      { label: 'File',      action: ins('file') },
+      { label: 'Signature', action: ins('signature') },
+      { label: 'List',      action: ins('list') },
+      { groupLabel: 'Layout' },
+      { label: 'Heading', action: ins('heading') },
+      { label: 'Hidden',  action: ins('hidden') },
+      { label: 'Info',    action: ins('info') },
+    ];
+  }
+
+  // Field level: property snippets for the detected field type
+  if (ctx.level === 'field' && ctx.fieldType) {
+    const props = getFieldPropertySnippets(ctx.fieldType);
+    const items = [{ groupLabel: ctx.fieldType + ' properties' }];
+    props.forEach(p => {
+      items.push({
+        label: p.label,
+        action: () => devInsertProperty(ctx.sectionIndex, ctx.fieldIndex, p.key, JSON.parse(JSON.stringify(p.value)))
+      });
+    });
+    return items;
+  }
+
+  // Fallback: root-level items
   return [
-    { label: 'Input Fields', children: [
-      { label: 'Text',     action: insertField('text') },
-      { label: 'Email',    action: insertField('email') },
-      { label: 'Phone',    action: insertField('tel') },
-      { label: 'Number',   action: insertField('number') },
-      { label: 'Currency', action: insertField('currency') },
-      { label: 'URL',      action: insertField('url') },
-      { label: 'Date',     action: insertField('date') },
-      { label: 'Time',     action: insertField('time') },
-      { label: 'DateTime', action: insertField('datetime') },
-      { label: 'Textarea', action: insertField('textarea') },
-      { label: 'Long Text',action: insertField('longtext') },
-    ]},
-    { label: 'Choice Fields', children: [
-      { label: 'Select',       action: insertField('select') },
-      { label: 'Multi Select', action: insertField('multi_select') },
-      { label: 'Radio',        action: insertField('radio') },
-      { label: 'Checkbox',     action: insertField('checkbox') },
-      { label: 'Toggle',       action: insertField('toggle') },
-    ]},
-    { label: 'Complex Fields', children: [
-      { label: 'Address',   action: insertField('address') },
-      { label: 'Repeater',  action: insertField('repeater') },
-      { label: 'Repeater (Table)', action: () => devInsertSnippet('schema', { id: "items", label: "Items", type: "repeater", display: "table", fields: [{ id: "item_name", label: "Name", type: "text" }, { id: "item_qty", label: "Qty", type: "number" }] }) },
-      { label: 'File',      action: insertField('file') },
-      { label: 'Signature', action: insertField('signature') },
-      { label: 'List',      action: insertField('list') },
-    ]},
-    { label: 'Layout', children: [
-      { label: 'Heading', action: insertField('heading') },
-      { label: 'Hidden',  action: insertField('hidden') },
-      { label: 'Info',    action: insertField('info') },
-    ]},
-    { separator: true },
     { label: 'Add Section', action: () => devInsertSection() },
     { label: 'Wrap in Wizard', action: () => devWrapInWizard() },
   ];
@@ -11925,20 +12181,20 @@ def generate_docx(data):
 `;
 
 const TEMPLATE_SNIPPETS = [
-  { label: 'Import stencils', text: 'import stencils\n' },
-  { label: 'generate_docx scaffold', text: `def generate_docx(data):\n    doc = stencils.new_doc(data.get("title", "Document"))\n    # Build document here\n    return stencils.finalize(doc)\n` },
-  { label: 'set_theme (built-in)', text: `# THEME_MODERN (default) | THEME_CLASSIC | THEME_MINIMAL\nstencils.set_theme(stencils.THEME_CLASSIC)\n` },
-  { label: 'set_theme (custom)', text: `from docx.shared import RGBColor\nstencils.set_theme(stencils.DocTheme(\n    color_title=RGBColor(0x1B, 0x5E, 0x6E),\n    color_subtitle=RGBColor(0x3A, 0x7A, 0x8C),\n    color_muted=RGBColor(0x5A, 0x7A, 0x85),\n    color_footer=RGBColor(0x4D, 0x6E, 0x78),\n    color_accent=RGBColor(0x0D, 0x3D, 0x4A),\n    font_body="Segoe UI",\n    font_heading="Segoe UI Semibold",\n    font_caption="Segoe UI Semilight",\n    size_body=11, size_title=26,\n    size_heading1=16, size_heading2=13, size_heading3=12,\n    size_heading4=11, size_heading5=11, size_heading6=11,\n    size_subtitle=12, size_table=10, size_caption=9, size_footer=8,\n    margin_top=1.0, margin_bottom=0.75, margin_left=1.0, margin_right=1.0,\n))\n` },
-  { label: 'table_section', text: `    stencils.table_section(doc, "Section Title", [\n        ("Label", data.get("field_id", "")),\n    ])\n` },
-  { label: 'longtext', text: `    stencils.longtext(doc, "Section Title", data.get("field_id", ""))\n` },
-  { label: 'bullet_list', text: `    stencils.bullet_list(doc, "List Title", items)\n` },
-  { label: 'signatures', text: `    stencils.signatures(doc, [("Name", "Title")])\n` },
-  { label: 'footer', text: `    stencils.footer(doc)\n` },
-  { label: 'address', text: `    stencils.address(doc, json.loads(data.get("address_field", "{}")))\n` },
-  { label: 'repeater_table', text: `    stencils.repeater_table(doc, "Items", json.loads(data.get("items", "[]")), ["col1", "col2"])\n` },
-  { label: 'image', text: `    stencils.image(doc, data.get("file_field", ""))\n` },
-  { label: 'signature', text: `    stencils.signature(doc, data.get("signature_field", ""))\n` },
-  { label: 'finalize', text: `    return stencils.finalize(doc)\n` },
+  { label: 'Import stencils', text: 'import stencils\n', category: 'top' },
+  { label: 'generate_docx scaffold', text: `def generate_docx(data):\n    doc = stencils.new_doc(data.get("title", "Document"))\n    # Build document here\n    return stencils.finalize(doc)\n`, category: 'top' },
+  { label: 'set_theme (built-in)', text: `# THEME_MODERN (default) | THEME_CLASSIC | THEME_MINIMAL\nstencils.set_theme(stencils.THEME_CLASSIC)\n`, category: 'top' },
+  { label: 'set_theme (custom)', text: `from docx.shared import RGBColor\nstencils.set_theme(stencils.DocTheme(\n    color_title=RGBColor(0x1B, 0x5E, 0x6E),\n    color_subtitle=RGBColor(0x3A, 0x7A, 0x8C),\n    color_muted=RGBColor(0x5A, 0x7A, 0x85),\n    color_footer=RGBColor(0x4D, 0x6E, 0x78),\n    color_accent=RGBColor(0x0D, 0x3D, 0x4A),\n    font_body="Segoe UI",\n    font_heading="Segoe UI Semibold",\n    font_caption="Segoe UI Semilight",\n    size_body=11, size_title=26,\n    size_heading1=16, size_heading2=13, size_heading3=12,\n    size_heading4=11, size_heading5=11, size_heading6=11,\n    size_subtitle=12, size_table=10, size_caption=9, size_footer=8,\n    margin_top=1.0, margin_bottom=0.75, margin_left=1.0, margin_right=1.0,\n))\n`, category: 'top' },
+  { label: 'table_section', text: `    stencils.table_section(doc, "Section Title", [\n        ("Label", data.get("field_id", "")),\n    ])\n`, category: 'body' },
+  { label: 'longtext', text: `    stencils.longtext(doc, "Section Title", data.get("field_id", ""))\n`, category: 'body' },
+  { label: 'bullet_list', text: `    stencils.bullet_list(doc, "List Title", items)\n`, category: 'body' },
+  { label: 'signatures', text: `    stencils.signatures(doc, [("Name", "Title")])\n`, category: 'body' },
+  { label: 'footer', text: `    stencils.footer(doc)\n`, category: 'body' },
+  { label: 'address', text: `    stencils.address(doc, json.loads(data.get("address_field", "{}")))\n`, category: 'body' },
+  { label: 'repeater_table', text: `    stencils.repeater_table(doc, "Items", json.loads(data.get("items", "[]")), ["col1", "col2"])\n`, category: 'body' },
+  { label: 'image', text: `    stencils.image(doc, data.get("file_field", ""))\n`, category: 'body' },
+  { label: 'signature', text: `    stencils.signature(doc, data.get("signature_field", ""))\n`, category: 'body' },
+  { label: 'finalize', text: `    return stencils.finalize(doc)\n`, category: 'body' },
 ];
 
 function getFieldAccessor(field) {
@@ -11961,11 +12217,28 @@ function devCountTemplateFieldRefs(schema, templateText) {
   return { used, total };
 }
 
-function devTemplateContextItems() {
-  const items = TEMPLATE_SNIPPETS.map(s => ({
-    label: s.label,
-    action: () => devInsertSnippet('template', s.text)
-  }));
+function devTemplateContextItems(ctx) {
+  if (!ctx) ctx = { level: 'body' };
+  const items = [];
+
+  if (ctx.level === 'top') {
+    // Top-level: imports, scaffold, theme
+    TEMPLATE_SNIPPETS.forEach(s => {
+      if (s.category === 'top') {
+        items.push({ label: s.label, action: () => devInsertSnippet('template', s.text) });
+      }
+    });
+    return items;
+  }
+
+  // Body-level: stencil helpers + schema field accessors
+  items.push({ groupLabel: 'Helpers' });
+  TEMPLATE_SNIPPETS.forEach(s => {
+    if (s.category === 'body') {
+      items.push({ label: s.label, action: () => devInsertSnippet('template', s.text) });
+    }
+  });
+
   if (devParsedSchema && devParsedSchema.sections) {
     const fieldItems = [];
     devParsedSchema.sections.forEach(sec => {
@@ -11979,8 +12252,8 @@ function devTemplateContextItems() {
       });
     });
     if (fieldItems.length > 0) {
-      items.push({ separator: true });
-      items.push({ label: 'Schema Fields', children: fieldItems });
+      items.push({ groupLabel: 'Schema Fields' });
+      fieldItems.forEach(fi => items.push(fi));
     }
   }
   return items;
@@ -12163,10 +12436,13 @@ function initTemplateEditor() {
   el.addEventListener('scroll', () => { if (!_templateScrollRAF) { _templateScrollRAF = true; requestAnimationFrame(() => { tplGutter.scrollTop = el.scrollTop; _templateScrollRAF = false; }); } });
   el.addEventListener('keydown', (e) => devEditorKeydownHandler(e, templateJar, 'python'));
 
-  // Right-click context menu
+  // Right-click context menu — cursor-aware, clamped to editor pane
   el.addEventListener('contextmenu', (e) => {
     e.preventDefault();
-    showContextMenu(e.clientX, e.clientY, devTemplateContextItems());
+    const offset = devGetCursorOffset(el);
+    const ctx = getTemplateEditorContext(devTemplateText, offset);
+    const pane = document.getElementById('templateEditorPane');
+    showContextMenu(e.clientX, e.clientY, devTemplateContextItems(ctx), pane);
   });
 
   // Init sample data editor

--- a/tests/test_context_menu.py
+++ b/tests/test_context_menu.py
@@ -2,10 +2,11 @@
 
 Uses Playwright to exercise runtime behavior:
 - Right-click in schema/template editors opens context menus
-- Menu structure (submenus, items, separators)
+- Cursor-aware menu structure (flat items with group labels, no submenus)
 - Snippet insertion into editors
 - Menu close behavior (click-outside, Escape)
 - Error handling (invalid JSON toast)
+- Bounding element clamping (menu stays within editor pane)
 
 Requires: pip install playwright && python -m playwright install chromium
 """
@@ -147,37 +148,76 @@ class TestSchemaContextMenuAppears:
 
 
 class TestSchemaMenuStructure:
-    """Menu has 4 grouped submenus plus action items."""
+    """Menu shows cursor-aware flat items with group labels (no submenus).
 
-    def test_has_four_submenus(self, page):
+    The default starter schema has sections with fields, so right-clicking
+    in the editor lands inside a section/field context. The menu should show
+    flat field type items with category group labels.
+    """
+
+    def test_no_submenus(self, page):
+        """Editor context menus are flat — no submenu items."""
         open_schema_context_menu(page)
         submenus = page.locator("#ctxMenu > .ctx-menu-item.has-sub")
-        assert submenus.count() == 4
+        assert submenus.count() == 0
 
-    def test_submenu_labels(self, page):
+    def test_has_group_labels(self, page):
+        """Section-level context shows group labels for field categories."""
+        # Place cursor inside a section (click on "Section 1" text area)
+        page.evaluate(
+            """(() => {
+                const text = devSchemaText;
+                const sectionPos = text.indexOf('"fields"');
+                if (sectionPos > 0) {
+                    const el = document.getElementById('schemaEditor');
+                    el.focus();
+                    devSetCursorOffset(el, sectionPos + 10);
+                }
+            })()"""
+        )
+        page.wait_for_timeout(100)
         open_schema_context_menu(page)
-        subs = page.locator("#ctxMenu > .ctx-menu-item.has-sub")
-        labels = [subs.nth(i).text_content().strip() for i in range(4)]
-        assert "Input Fields" in labels[0]
-        assert "Choice Fields" in labels[1]
-        assert "Complex Fields" in labels[2]
-        assert "Layout" in labels[3]
+        labels = page.locator("#ctxMenu > .ctx-menu-group-label")
+        texts = [labels.nth(i).text_content().strip() for i in range(labels.count())]
+        assert "Input Fields" in texts
+        assert "Choice Fields" in texts
 
-    def test_has_separator(self, page):
+    def test_field_type_items_visible(self, page):
+        """Section-level context shows flat field type items."""
+        page.evaluate(
+            """(() => {
+                const text = devSchemaText;
+                const pos = text.indexOf('"fields"');
+                if (pos > 0) {
+                    const el = document.getElementById('schemaEditor');
+                    el.focus();
+                    devSetCursorOffset(el, pos + 10);
+                }
+            })()"""
+        )
+        page.wait_for_timeout(100)
         open_schema_context_menu(page)
-        separators = page.locator("#ctxMenu > .ctx-menu-separator")
-        assert separators.count() >= 1
+        items = page.locator("#ctxMenu > .ctx-menu-item")
+        texts = [items.nth(i).text_content().strip() for i in range(items.count())]
+        assert "Text" in texts
+        assert "Select" in texts
+        assert "Address" in texts
 
-    def test_add_section_item(self, page):
+    def test_root_level_shows_structural_items(self, page):
+        """When cursor is at root level, shows Add Section and Wrap in Wizard."""
+        # Place cursor at the very start (root level)
+        page.evaluate(
+            """(() => {
+                const el = document.getElementById('schemaEditor');
+                el.focus();
+                devSetCursorOffset(el, 1);
+            })()"""
+        )
+        page.wait_for_timeout(100)
         open_schema_context_menu(page)
-        items = page.locator("#ctxMenu > .ctx-menu-item:not(.has-sub)")
+        items = page.locator("#ctxMenu > .ctx-menu-item")
         texts = [items.nth(i).text_content().strip() for i in range(items.count())]
         assert "Add Section" in texts
-
-    def test_wrap_in_wizard_item(self, page):
-        open_schema_context_menu(page)
-        items = page.locator("#ctxMenu > .ctx-menu-item:not(.has-sub)")
-        texts = [items.nth(i).text_content().strip() for i in range(items.count())]
         assert "Wrap in Wizard" in texts
 
 
@@ -185,16 +225,25 @@ class TestSchemaSnippetInsertion:
     """Clicking a field type inserts a snippet into the schema JSON."""
 
     def test_insert_text_field(self, page):
+        """Insert a Text field from the section-level context menu."""
         text_before = get_editor_text(page, "schemaEditor")
+        # Position cursor inside the fields array of section
+        page.evaluate(
+            """(() => {
+                const text = devSchemaText;
+                const pos = text.indexOf('"fields"');
+                if (pos > 0) {
+                    const el = document.getElementById('schemaEditor');
+                    el.focus();
+                    devSetCursorOffset(el, pos + 10);
+                }
+            })()"""
+        )
+        page.wait_for_timeout(100)
         open_schema_context_menu(page)
 
-        # Hover the "Input Fields" submenu to reveal children
-        sub = page.locator("#ctxMenu > .ctx-menu-item.has-sub").first
-        sub.hover()
-        page.wait_for_timeout(200)
-
-        # Click "Text" item
-        text_item = sub.locator(".ctx-menu-sub .ctx-menu-item", has_text="Text").first
+        # Click "Text" item directly (no submenu hover needed)
+        text_item = page.locator("#ctxMenu > .ctx-menu-item", has_text="Text").first
         text_item.click()
 
         # Menu should close
@@ -206,61 +255,131 @@ class TestSchemaSnippetInsertion:
         assert len(text_after) > len(text_before)
 
     def test_insert_select_field(self, page):
-        open_schema_context_menu(page)
-        sub = page.locator(
-            "#ctxMenu > .ctx-menu-item.has-sub", has_text="Choice Fields"
+        page.evaluate(
+            """(() => {
+                const text = devSchemaText;
+                const pos = text.indexOf('"fields"');
+                if (pos > 0) {
+                    const el = document.getElementById('schemaEditor');
+                    el.focus();
+                    devSetCursorOffset(el, pos + 10);
+                }
+            })()"""
         )
-        sub.hover()
-        page.wait_for_timeout(200)
-
-        select_item = sub.locator(
-            ".ctx-menu-sub .ctx-menu-item", has_text="Select"
+        page.wait_for_timeout(100)
+        open_schema_context_menu(page)
+        select_item = page.locator(
+            "#ctxMenu > .ctx-menu-item", has_text="Select"
         ).first
         select_item.click()
-
         text = get_editor_text(page, "schemaEditor")
         assert "select_field" in text
 
     def test_unique_id_on_duplicate(self, page):
         """Inserting the same field type twice gives unique IDs."""
-        # Insert text field first time
-        open_schema_context_menu(page)
-        sub = page.locator("#ctxMenu > .ctx-menu-item.has-sub").first
-        sub.hover()
-        page.wait_for_timeout(200)
-        sub.locator(".ctx-menu-sub .ctx-menu-item", has_text="Text").first.click()
-        page.wait_for_timeout(100)
+        # Helper to position cursor and insert Text field
+        def insert_text_field():
+            page.evaluate(
+                """(() => {
+                    const text = devSchemaText;
+                    const pos = text.indexOf('"fields"');
+                    if (pos > 0) {
+                        const el = document.getElementById('schemaEditor');
+                        el.focus();
+                        devSetCursorOffset(el, pos + 10);
+                    }
+                })()"""
+            )
+            page.wait_for_timeout(100)
+            open_schema_context_menu(page)
+            page.locator("#ctxMenu > .ctx-menu-item", has_text="Text").first.click()
+            page.wait_for_timeout(100)
 
-        # Insert text field second time
-        open_schema_context_menu(page)
-        sub = page.locator("#ctxMenu > .ctx-menu-item.has-sub").first
-        sub.hover()
-        page.wait_for_timeout(200)
-        sub.locator(".ctx-menu-sub .ctx-menu-item", has_text="Text").first.click()
-
+        insert_text_field()
+        insert_text_field()
         text = get_editor_text(page, "schemaEditor")
-        # Should have both text_field and text_field_2 (or similar suffix)
         assert "text_field" in text
         assert "text_field_2" in text or "text_field_3" in text
 
     def test_add_section(self, page):
+        # Place cursor at root level
+        page.evaluate(
+            """(() => {
+                const el = document.getElementById('schemaEditor');
+                el.focus();
+                devSetCursorOffset(el, 1);
+            })()"""
+        )
+        page.wait_for_timeout(100)
         open_schema_context_menu(page)
         page.locator(
-            "#ctxMenu > .ctx-menu-item:not(.has-sub)", has_text="Add Section"
+            "#ctxMenu > .ctx-menu-item", has_text="Add Section"
         ).click()
-
         text = get_editor_text(page, "schemaEditor")
         assert "Section" in text
 
     def test_wrap_in_wizard(self, page):
+        page.evaluate(
+            """(() => {
+                const el = document.getElementById('schemaEditor');
+                el.focus();
+                devSetCursorOffset(el, 1);
+            })()"""
+        )
+        page.wait_for_timeout(100)
         open_schema_context_menu(page)
         page.locator(
-            "#ctxMenu > .ctx-menu-item:not(.has-sub)",
+            "#ctxMenu > .ctx-menu-item",
             has_text="Wrap in Wizard",
         ).click()
-
         text = get_editor_text(page, "schemaEditor")
         assert '"wizard"' in text or "wizard" in text
+
+
+class TestSchemaFieldPropertyInsertion:
+    """Field-level context shows property snippets for the detected type."""
+
+    def test_field_level_shows_properties(self, page):
+        """When cursor is inside a field object, shows property snippets."""
+        # Position cursor inside the field_1 object (after "type": "text")
+        page.evaluate(
+            """(() => {
+                const text = devSchemaText;
+                const pos = text.indexOf('"type": "text"');
+                if (pos > 0) {
+                    const el = document.getElementById('schemaEditor');
+                    el.focus();
+                    devSetCursorOffset(el, pos + 5);
+                }
+            })()"""
+        )
+        page.wait_for_timeout(100)
+        open_schema_context_menu(page)
+        items = page.locator("#ctxMenu > .ctx-menu-item")
+        texts = [items.nth(i).text_content().strip() for i in range(items.count())]
+        # Text field should show common properties
+        assert "placeholder" in texts
+        assert "visible_when" in texts
+
+    def test_insert_property(self, page):
+        """Clicking a property snippet adds it to the field."""
+        page.evaluate(
+            """(() => {
+                const text = devSchemaText;
+                const pos = text.indexOf('"type": "text"');
+                if (pos > 0) {
+                    const el = document.getElementById('schemaEditor');
+                    el.focus();
+                    devSetCursorOffset(el, pos + 5);
+                }
+            })()"""
+        )
+        page.wait_for_timeout(100)
+        open_schema_context_menu(page)
+        page.locator("#ctxMenu > .ctx-menu-item", has_text="placeholder").click()
+        page.wait_for_timeout(300)
+        text = get_editor_text(page, "schemaEditor")
+        assert "placeholder" in text
 
 
 class TestSchemaInvalidJson:
@@ -283,10 +402,10 @@ class TestSchemaInvalidJson:
 
         # Open menu and try to insert a field
         open_schema_context_menu(page)
-        sub = page.locator("#ctxMenu > .ctx-menu-item.has-sub").first
-        sub.hover()
-        page.wait_for_timeout(200)
-        sub.locator(".ctx-menu-sub .ctx-menu-item").first.click()
+        # With invalid JSON, context detection falls back to root level
+        items = page.locator("#ctxMenu > .ctx-menu-item")
+        if items.count() > 0:
+            items.first.click()
 
         # Wait for toast to appear
         toast = page.locator(".toast", has_text="fix JSON errors")
@@ -321,11 +440,20 @@ class TestSchemaLivePreview:
     """Live preview updates after snippet insertion."""
 
     def test_preview_updates_after_insert(self, page):
+        page.evaluate(
+            """(() => {
+                const text = devSchemaText;
+                const pos = text.indexOf('"fields"');
+                if (pos > 0) {
+                    const el = document.getElementById('schemaEditor');
+                    el.focus();
+                    devSetCursorOffset(el, pos + 10);
+                }
+            })()"""
+        )
+        page.wait_for_timeout(100)
         open_schema_context_menu(page)
-        sub = page.locator("#ctxMenu > .ctx-menu-item.has-sub").first
-        sub.hover()
-        page.wait_for_timeout(200)
-        sub.locator(".ctx-menu-sub .ctx-menu-item", has_text="Text").first.click()
+        page.locator("#ctxMenu > .ctx-menu-item", has_text="Text").first.click()
 
         # Wait for preview debounce (300ms)
         page.wait_for_timeout(500)
@@ -335,15 +463,101 @@ class TestSchemaLivePreview:
         assert badge.is_visible()
 
     def test_validation_badge_valid_after_insert(self, page):
+        page.evaluate(
+            """(() => {
+                const text = devSchemaText;
+                const pos = text.indexOf('"fields"');
+                if (pos > 0) {
+                    const el = document.getElementById('schemaEditor');
+                    el.focus();
+                    devSetCursorOffset(el, pos + 10);
+                }
+            })()"""
+        )
+        page.wait_for_timeout(100)
         open_schema_context_menu(page)
-        sub = page.locator("#ctxMenu > .ctx-menu-item.has-sub").first
-        sub.hover()
-        page.wait_for_timeout(200)
-        sub.locator(".ctx-menu-sub .ctx-menu-item", has_text="Email").first.click()
+        page.locator("#ctxMenu > .ctx-menu-item", has_text="Email").first.click()
 
         page.wait_for_timeout(500)
         badge_text = page.locator("#schemaValidText").text_content()
         assert badge_text == "valid"
+
+
+class TestSchemaMenuClamping:
+    """Context menu stays within editor pane bounds."""
+
+    def test_menu_within_editor_pane(self, page):
+        """Menu position does not exceed the editor pane right/bottom edges."""
+        open_schema_context_menu(page)
+        result = page.evaluate(
+            """(() => {
+                const menu = document.getElementById('ctxMenu');
+                const pane = document.getElementById('schemaEditorPane');
+                const menuRect = menu.getBoundingClientRect();
+                const paneRect = pane.getBoundingClientRect();
+                return {
+                    menuRight: menuRect.right,
+                    menuBottom: menuRect.bottom,
+                    paneRight: paneRect.right,
+                    paneBottom: paneRect.bottom,
+                };
+            })()"""
+        )
+        # Menu should not exceed pane bounds (with small tolerance for rounding)
+        assert result["menuRight"] <= result["paneRight"] + 2
+        assert result["menuBottom"] <= result["paneBottom"] + 2
+
+
+class TestBaseScaffold:
+    """Base scaffold option appears when editor is empty."""
+
+    def test_scaffold_shown_when_empty(self, page):
+        """Clearing the editor and right-clicking shows Base Scaffold."""
+        page.evaluate(
+            """(() => {
+                devSchemaText = '';
+                if (window.schemaJar) schemaJar.updateCode('');
+            })()"""
+        )
+        page.wait_for_timeout(200)
+        # Position cursor at start
+        page.evaluate(
+            """(() => {
+                const el = document.getElementById('schemaEditor');
+                el.focus();
+                devSetCursorOffset(el, 0);
+            })()"""
+        )
+        page.wait_for_timeout(100)
+        open_schema_context_menu(page)
+        items = page.locator("#ctxMenu > .ctx-menu-item")
+        texts = [items.nth(i).text_content().strip() for i in range(items.count())]
+        assert "Base Scaffold" in texts
+
+    def test_scaffold_inserts_valid_schema(self, page):
+        """Clicking Base Scaffold inserts a complete valid schema."""
+        page.evaluate(
+            """(() => {
+                devSchemaText = '';
+                if (window.schemaJar) schemaJar.updateCode('');
+            })()"""
+        )
+        page.wait_for_timeout(200)
+        page.evaluate(
+            """(() => {
+                const el = document.getElementById('schemaEditor');
+                el.focus();
+                devSetCursorOffset(el, 0);
+            })()"""
+        )
+        page.wait_for_timeout(100)
+        open_schema_context_menu(page)
+        page.locator("#ctxMenu > .ctx-menu-item", has_text="Base Scaffold").click()
+        page.wait_for_timeout(500)
+        text = get_editor_text(page, "schemaEditor")
+        assert "New Form" in text
+        assert "sections" in text
+        assert "fields" in text
 
 
 # ===========================================================================
@@ -360,7 +574,13 @@ class TestTemplateContextMenuAppears:
 
 
 class TestTemplateMenuStructure:
-    """Template menu has stencils helper snippet items."""
+    """Template menu has cursor-aware items — no submenus."""
+
+    def test_no_submenus(self, page):
+        """Template context menu has no submenu items."""
+        open_template_context_menu(page)
+        submenus = page.locator("#ctxMenu > .ctx-menu-item.has-sub")
+        assert submenus.count() == 0
 
     def test_has_snippet_items(self, page):
         open_template_context_menu(page)
@@ -420,3 +640,27 @@ class TestTemplateMenuCloses:
         page.wait_for_timeout(200)
 
         assert not ctx_menu_visible(page)
+
+
+class TestTemplateMenuClamping:
+    """Template context menu stays within editor pane bounds."""
+
+    def test_menu_within_editor_pane(self, page):
+        """Menu position does not exceed the template editor pane bounds."""
+        open_template_context_menu(page)
+        result = page.evaluate(
+            """(() => {
+                const menu = document.getElementById('ctxMenu');
+                const pane = document.getElementById('templateEditorPane');
+                const menuRect = menu.getBoundingClientRect();
+                const paneRect = pane.getBoundingClientRect();
+                return {
+                    menuRight: menuRect.right,
+                    menuBottom: menuRect.bottom,
+                    paneRight: paneRect.right,
+                    paneBottom: paneRect.bottom,
+                };
+            })()"""
+        )
+        assert result["menuRight"] <= result["paneRight"] + 2
+        assert result["menuBottom"] <= result["paneBottom"] + 2

--- a/tests/test_dev_mode.py
+++ b/tests/test_dev_mode.py
@@ -572,8 +572,8 @@ def test_context_menu_prevents_default(index_html: str) -> None:
     assert "contextmenu" in body
 
 
-def test_context_menu_four_submenus(index_html: str) -> None:
-    """devSchemaContextItems returns 4 grouped submenus."""
+def test_context_menu_four_group_labels(index_html: str) -> None:
+    """devSchemaContextItems returns 4 group labels for section-level context."""
     body = _extract_func(index_html, "devSchemaContextItems")
     assert "'Input Fields'" in body
     assert "'Choice Fields'" in body
@@ -694,11 +694,108 @@ def test_context_menu_closes_on_escape(index_html: str) -> None:
 
 
 def test_context_menu_viewport_clamped(index_html: str) -> None:
-    """showContextMenu clamps position to viewport edges."""
+    """showContextMenu clamps position to bounds (bounding element or viewport)."""
     body = _extract_func(index_html, "showContextMenu")
+    # Viewport fallback when no bounding element
     assert "window.innerWidth" in body
     assert "window.innerHeight" in body
-    assert "Math.max(0" in body
+    # Bounding element clamping
+    assert "boundingEl" in body
+    assert "getBoundingClientRect" in body
+    assert "boundsRight" in body
+    assert "boundsBottom" in body
+    assert "Math.max(boundsLeft" in body
+    assert "Math.max(boundsTop" in body
+
+
+def test_schema_context_menu_cursor_aware(index_html: str) -> None:
+    """Schema editor contextmenu listener calls getSchemaEditorContext."""
+    body = _extract_func(index_html, "initSchemaEditor")
+    assert "getSchemaEditorContext" in body
+    assert "schemaEditorPane" in body
+
+
+def test_get_schema_editor_context_exists(index_html: str) -> None:
+    """getSchemaEditorContext function is defined."""
+    body = _extract_func(index_html, "getSchemaEditorContext")
+    assert "'root'" in body
+    assert "'section'" in body
+    assert "'field'" in body
+
+
+def test_schema_context_root_level_items(index_html: str) -> None:
+    """Root-level context shows Add Section and Wrap in Wizard."""
+    body = _extract_func(index_html, "devSchemaContextItems")
+    assert "'Add Section'" in body
+    assert "'Wrap in Wizard'" in body
+
+
+def test_schema_context_field_level_properties(index_html: str) -> None:
+    """Field-level context calls getFieldPropertySnippets."""
+    body = _extract_func(index_html, "devSchemaContextItems")
+    assert "getFieldPropertySnippets" in body
+
+
+def test_get_field_property_snippets_exists(index_html: str) -> None:
+    """getFieldPropertySnippets returns type-specific property items."""
+    body = _extract_func(index_html, "getFieldPropertySnippets")
+    assert "'required'" in body
+    assert "'placeholder'" in body
+    assert "'options'" in body
+    assert "'visible_when'" in body
+
+
+def test_dev_insert_property_exists(index_html: str) -> None:
+    """devInsertProperty function adds properties to field objects."""
+    body = _extract_func(index_html, "devInsertProperty")
+    assert "already exists" in body
+    assert "schemaJar" in body
+
+
+def test_base_scaffold_defined(index_html: str) -> None:
+    """BASE_SCAFFOLD constant is defined with required schema structure."""
+    assert "const BASE_SCAFFOLD" in index_html
+    assert '"New Form"' in index_html or "'New Form'" in index_html
+
+
+def test_schema_context_root_scaffold_option(index_html: str) -> None:
+    """Root-level context includes Base Scaffold when editor is empty."""
+    body = _extract_func(index_html, "devSchemaContextItems")
+    assert "'Base Scaffold'" in body
+    assert "BASE_SCAFFOLD" in body
+
+
+def test_template_context_cursor_aware(index_html: str) -> None:
+    """Template editor contextmenu listener calls getTemplateEditorContext."""
+    body = _extract_func(index_html, "initTemplateEditor")
+    assert "getTemplateEditorContext" in body
+    assert "templateEditorPane" in body
+
+
+def test_get_template_editor_context_exists(index_html: str) -> None:
+    """getTemplateEditorContext function detects top vs body level."""
+    body = _extract_func(index_html, "getTemplateEditorContext")
+    assert "'top'" in body
+    assert "'body'" in body
+
+
+def test_template_snippets_have_categories(index_html: str) -> None:
+    """TEMPLATE_SNIPPETS entries have category field (top or body)."""
+    assert "category: 'top'" in index_html
+    assert "category: 'body'" in index_html
+
+
+def test_template_context_top_level_items(index_html: str) -> None:
+    """Top-level template context shows only top-category snippets."""
+    body = _extract_func(index_html, "devTemplateContextItems")
+    assert "category === 'top'" in body or "s.category === 'top'" in body
+
+
+def test_template_context_body_level_items(index_html: str) -> None:
+    """Body-level template context shows helpers and schema fields."""
+    body = _extract_func(index_html, "devTemplateContextItems")
+    assert "'Helpers'" in body
+    assert "'Schema Fields'" in body
 
 
 def test_insert_snippet_invalid_json_toast(index_html: str) -> None:


### PR DESCRIPTION
## Summary

- **#216** — `showContextMenu()` accepts optional `boundingEl` parameter; editor menus clamp to their pane rect instead of viewport; added `overflow-y: auto` + dynamic `max-height`
- **#217** — Schema editor context menu is now cursor-aware with 3 levels: root (Add Section, Wrap in Wizard, Base Scaffold), section (flat list of 24 field types with group labels), field (type-specific property snippets via `getFieldPropertySnippets()`)
- **#218** — Template editor context menu is now cursor-aware with 2 levels: top (imports, scaffold, themes), body (stencil helpers + schema field accessors); `TEMPLATE_SNIPPETS` entries tagged with `category`
- **#219** — `BASE_SCAFFOLD` constant inserted when schema editor is empty at root level

Preview context menu is unchanged (retains submenus).

Closes #215, closes #216, closes #217, closes #218, closes #219

## Test plan

- [x] Fast tests pass (597 passed)
- [x] Lint clean (`ruff check` + `ruff format`)
- [ ] E2e tests updated for flat menu structure (cursor positioning, no submenu hover)
- [ ] Manual: right-click in schema editor at root level → shows Add Section, Wrap in Wizard
- [ ] Manual: right-click inside a section → shows flat field type list with group labels
- [ ] Manual: right-click inside a field object → shows property snippets for that field type
- [ ] Manual: right-click in template at top level → shows import/scaffold/theme items
- [ ] Manual: right-click inside generate_docx body → shows helpers + field accessors
- [ ] Manual: menu stays within editor pane (doesn't overflow into preview)
- [ ] Manual: empty schema editor → Base Scaffold option appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)