### PR TITLE
Add Stamp fluent builder class to stencils

### DIFF
--- a/docs/DEVLOG.md
+++ b/docs/DEVLOG.md
@@ -19,7 +19,7 @@
 Added `Stamp` fluent builder class to `stencils.py`. Every public stencil function is exposed as a chainable method (returns `self`), with `finalize()` returning DOCX bytes. Supports method chaining, sequential calls, and mixed patterns with conditionals. Instance-scoped `set_theme()` does not modify the module global.
 
 - Updated all 4 templates (`onboarding.py`, `expense-report.py`, `coverpage-demo.py`, `field-type-demo.py`) to use `Stamp` with sequential calls
-- Added 27 new tests covering construction, every method's return value, chaining, sequential, mixed, content round-trip, and theme isolation
+- Added 28 new tests covering construction, every method's return value, chaining, sequential, mixed, content round-trip, and theme isolation
 - Updated `docs/TEMPLATE_GUIDE.md` with Stamp documentation, method table, and usage patterns
 - All existing module-level functions preserved for backward compatibility
 
@@ -36,11 +36,26 @@ Made `title_text` parameter in `stencils.new_doc()` default to `""` so callers t
 
 ---
 
-### 2026-03-25 — Issue Created: SVG Support & Coverpage Layout Constraints (#226)
+### 2026-03-25 — SVG Support & Coverpage Layout Constraints (#226)
+**Issues:** #226
 
-Created issue #226 to address two related problems:
-1. SVG image uploads (common for company logos) silently fail in python-docx — will add client-side SVG→PNG rasterization via canvas in `createFileField()`
-2. Coverpage layout can overflow to a second page with tall logos or many metadata rows — will add `max_logo_height` param, cap bar padding, and make the vertical spacer adaptive
+Implemented SVG image upload support and coverpage layout constraints:
+
+**SVG → PNG rasterization (index.html):**
+- `createFileField()` now detects `image/svg+xml` uploads and rasterizes via canvas to PNG data URI
+- Respects SVG intrinsic aspect ratio (`naturalWidth`/`naturalHeight`), capped at 1200px max dimension
+- Existing raster uploads (PNG, JPEG, WebP) are unaffected
+
+**Coverpage layout constraints (stencils.py):**
+- `coverpage()` gains `max_logo_height` param (default 1.0") — scales logo down proportionally if it exceeds this height
+- Bar cell padding reduced from 0.5" to 0.3" (bar + logo region capped at ~2.5" total)
+- Vertical spacer now adapts based on metadata row count to ensure title + metadata fit on page 1
+
+**`image()` height capping (stencils.py):**
+- `image()` gains optional `max_height` param (inches) for general-purpose height capping
+
+**Tests:** 13 new tests (7 in test_stencils.py, 6 in test_dev_mode.py)
+**Docs:** Updated TEMPLATE_GUIDE.md, FIELD_TYPES.md, synced embedded docs
 
 ---
 

--- a/docs/DEVLOG.md
+++ b/docs/DEVLOG.md
@@ -14,32 +14,33 @@
 
 ## Log
 
-### 2026-03-25 — SVG Support & Coverpage Layout Constraints (#226)
-**Issues:** #226
+### 2026-03-25 — Add Stamp Class to Stencils (#230)
 
-Implemented SVG image upload support and coverpage layout constraints:
+Added `Stamp` fluent builder class to `stencils.py`. Every public stencil function is exposed as a chainable method (returns `self`), with `finalize()` returning DOCX bytes. Supports method chaining, sequential calls, and mixed patterns with conditionals. Instance-scoped `set_theme()` does not modify the module global.
 
-**SVG → PNG rasterization (index.html):**
-- `createFileField()` now detects `image/svg+xml` uploads and rasterizes via canvas to PNG data URI
-- Respects SVG intrinsic aspect ratio (`naturalWidth`/`naturalHeight`), capped at 1200px max dimension
-- Existing raster uploads (PNG, JPEG, WebP) are unaffected
+- Updated all 4 templates (`onboarding.py`, `expense-report.py`, `coverpage-demo.py`, `field-type-demo.py`) to use `Stamp` with sequential calls
+- Added 27 new tests covering construction, every method's return value, chaining, sequential, mixed, content round-trip, and theme isolation
+- Updated `docs/TEMPLATE_GUIDE.md` with Stamp documentation, method table, and usage patterns
+- All existing module-level functions preserved for backward compatibility
 
-**Coverpage layout constraints (stencils.py):**
-- `coverpage()` gains `max_logo_height` param (default 1.0") — scales logo down proportionally if it exceeds this height
-- Bar cell padding reduced from 0.5" to 0.3" (bar + logo region capped at ~2.5" total)
-- Vertical spacer now adapts based on metadata row count to ensure title + metadata fit on page 1
-
-**`image()` height capping (stencils.py):**
-- `image()` gains optional `max_height` param (inches) for general-purpose height capping
-
-**Tests:** 13 new tests (7 in test_stencils.py, 6 in test_dev_mode.py)
-**Docs:** Updated TEMPLATE_GUIDE.md, FIELD_TYPES.md, synced embedded docs
+**Decisions:**
+- `Stamp.set_theme()` is instance-scoped to avoid global side effects between templates
+- Content methods auto-create the document if `new_doc()` was not called, for convenience
+- Pass-through methods (`add_heading`, `add_paragraph`, `add_page_break`) and a `.doc` property provided for advanced python-docx usage
 
 ---
 
 ### 2026-03-25 — Make new_doc() title_text Optional (#227)
 
 Made `title_text` parameter in `stencils.new_doc()` default to `""` so callers that don't need a document heading (e.g., templates using `coverpage()`) can simply call `new_doc()` with no arguments instead of `new_doc("", "")`. Added unit test for zero-argument call. No breaking changes to existing callers.
+
+---
+
+### 2026-03-25 — Issue Created: SVG Support & Coverpage Layout Constraints (#226)
+
+Created issue #226 to address two related problems:
+1. SVG image uploads (common for company logos) silently fail in python-docx — will add client-side SVG→PNG rasterization via canvas in `createFileField()`
+2. Coverpage layout can overflow to a second page with tall logos or many metadata rows — will add `max_logo_height` param, cap bar padding, and make the vertical spacer adaptive
 
 ---
 

--- a/docs/TEMPLATE_GUIDE.md
+++ b/docs/TEMPLATE_GUIDE.md
@@ -44,6 +44,116 @@ import stencils
 
 This works identically in Pyodide and in standard Python (for local testing).
 
+## The `Stamp` Class (Recommended)
+
+`Stamp` is a fluent builder that wraps the internal `Document` and exposes every stencil function as a chainable method. Instead of passing `doc` to each function, you call methods on the `Stamp` instance — every method returns `self` except `finalize()`, which returns the finished DOCX bytes.
+
+Import `Stamp` and any constants you need directly:
+
+```python
+from stencils import Stamp, THEME_CLASSIC
+```
+
+### Sequential calls (recommended for templates with conditionals)
+
+```python
+from stencils import Stamp, THEME_CLASSIC
+
+def generate_docx(data):
+    doc = Stamp()
+    doc.set_theme(THEME_CLASSIC)
+    doc.new_doc("Employee Onboarding", f"Prepared for {data.get('name', '')}")
+
+    doc.table_section("Personal Info", [
+        ("Name", data.get("name", "")),
+        ("Email", data.get("email", "")),
+    ])
+
+    notes = data.get("notes", "")
+    if notes and notes.strip():
+        doc.longtext("Notes", notes)
+
+    doc.signatures(["Employee", "Date"])
+    doc.footer()
+    return doc.finalize()
+```
+
+### Method chaining
+
+```python
+from stencils import Stamp, THEME_CLASSIC
+
+def generate_docx(data):
+    return (Stamp()
+        .set_theme(THEME_CLASSIC)
+        .new_doc("My Document")
+        .table_section("Info", [("Name", data.get("name", ""))])
+        .bullet_list("Skills", data.get("skills", ""))
+        .signatures(["Signer", "Date"])
+        .footer()
+        .finalize())
+```
+
+### Mixed (chain setup, sequential for body)
+
+```python
+from stencils import Stamp, THEME_CLASSIC
+
+def generate_docx(data):
+    doc = Stamp().set_theme(THEME_CLASSIC).new_doc("Report")
+
+    if data.get("body", "").strip():
+        doc.longtext("Content", data["body"])
+
+    doc.bullet_list("Findings", data.get("findings", ""))
+    return doc.footer().finalize()
+```
+
+### Stamp methods
+
+| Method | Returns | Description |
+|---|---|---|
+| `Stamp()` | instance | Create a new builder |
+| `.set_theme(theme)` | `self` | Set theme for this instance (does not change the module global) |
+| `.new_doc(title, subtitle, ...)` | `self` | Create the internal document (auto-called if omitted) |
+| `.coverpage(title, ...)` | `self` | Add a cover page |
+| `.table_section(heading, rows)` | `self` | Add heading + key/value table |
+| `.longtext(heading, text)` | `self` | Add heading + paragraphs |
+| `.bullet_list(heading, items_str)` | `self` | Add heading + bullet list |
+| `.signatures(labels)` | `self` | Add signature grid |
+| `.footer()` | `self` | Add FormForge footer |
+| `.address(heading, raw_json)` | `self` | Add formatted address |
+| `.image(b64_str, ...)` | `self` | Embed image or placeholder |
+| `.signature(b64_str, label, ...)` | `self` | Add signature image with label |
+| `.repeater_table(headers, items, field_keys, ...)` | `self` | Render repeater as table |
+| `.add_heading(text, level)` | `self` | Pass-through to Document |
+| `.add_paragraph(text)` | `self` | Pass-through to Document |
+| `.add_page_break()` | `self` | Pass-through to Document |
+| `.doc` | `Document` | Access the underlying Document for advanced usage |
+| `.finalize()` | `bytes` | Serialize to DOCX bytes |
+
+### Advanced: accessing the underlying Document
+
+For python-docx operations not covered by Stamp methods, use the `.doc` property:
+
+```python
+from docx.shared import Pt
+
+doc = Stamp().set_theme(THEME_CLASSIC).new_doc("Report")
+# Direct Document access for custom formatting
+d = doc.doc
+d.add_heading("Custom Section", level=2)
+p = d.add_paragraph()
+r = p.add_run("Custom formatted text")
+r.font.size = Pt(10)
+
+return doc.footer().finalize()
+```
+
+## Module-Level Functions (Backward-Compatible)
+
+The original module-level functions still work exactly as before. All existing templates using `stencils.function(doc, ...)` will continue to work without changes.
+
 ### `stencils.new_doc(title_text, subtitle_text="", font_name=None, font_size=None, theme=None)`
 
 Creates a styled `Document` cloned from a pre-built template. The template has all heading styles, page margins, and base font configured from the active (or given) theme. Returns the `Document` instance.
@@ -503,19 +613,18 @@ for item in skills.split("\n"):
 ## Minimal Template
 
 ```python
-import stencils
+from stencils import Stamp, THEME_CLASSIC
 
 def generate_docx(data):
-    doc = stencils.new_doc("My Document", data.get("title", ""))
-
-    stencils.table_section(doc, "Details", [
+    doc = Stamp()
+    doc.set_theme(THEME_CLASSIC)
+    doc.new_doc("My Document", data.get("title", ""))
+    doc.table_section("Details", [
         ("Name", data.get("name", "")),
         ("Date", data.get("date", "")),
     ])
-
-    stencils.bullet_list(doc, "Action Items", data.get("actions", ""))
-
-    return stencils.finalize(doc)
+    doc.bullet_list("Action Items", data.get("actions", ""))
+    return doc.finalize()
 ```
 
 ## Template Without `stencils` (Standalone)

--- a/index.html
+++ b/index.html
@@ -8650,6 +8650,116 @@ import stencils
 
 This works identically in Pyodide and in standard Python (for local testing).
 
+## The \`Stamp\` Class (Recommended)
+
+\`Stamp\` is a fluent builder that wraps the internal \`Document\` and exposes every stencil function as a chainable method. Instead of passing \`doc\` to each function, you call methods on the \`Stamp\` instance — every method returns \`self\` except \`finalize()\`, which returns the finished DOCX bytes.
+
+Import \`Stamp\` and any constants you need directly:
+
+\`\`\`python
+from stencils import Stamp, THEME_CLASSIC
+\`\`\`
+
+### Sequential calls (recommended for templates with conditionals)
+
+\`\`\`python
+from stencils import Stamp, THEME_CLASSIC
+
+def generate_docx(data):
+    doc = Stamp()
+    doc.set_theme(THEME_CLASSIC)
+    doc.new_doc("Employee Onboarding", f"Prepared for {data.get('name', '')}")
+
+    doc.table_section("Personal Info", [
+        ("Name", data.get("name", "")),
+        ("Email", data.get("email", "")),
+    ])
+
+    notes = data.get("notes", "")
+    if notes and notes.strip():
+        doc.longtext("Notes", notes)
+
+    doc.signatures(["Employee", "Date"])
+    doc.footer()
+    return doc.finalize()
+\`\`\`
+
+### Method chaining
+
+\`\`\`python
+from stencils import Stamp, THEME_CLASSIC
+
+def generate_docx(data):
+    return (Stamp()
+        .set_theme(THEME_CLASSIC)
+        .new_doc("My Document")
+        .table_section("Info", [("Name", data.get("name", ""))])
+        .bullet_list("Skills", data.get("skills", ""))
+        .signatures(["Signer", "Date"])
+        .footer()
+        .finalize())
+\`\`\`
+
+### Mixed (chain setup, sequential for body)
+
+\`\`\`python
+from stencils import Stamp, THEME_CLASSIC
+
+def generate_docx(data):
+    doc = Stamp().set_theme(THEME_CLASSIC).new_doc("Report")
+
+    if data.get("body", "").strip():
+        doc.longtext("Content", data["body"])
+
+    doc.bullet_list("Findings", data.get("findings", ""))
+    return doc.footer().finalize()
+\`\`\`
+
+### Stamp methods
+
+| Method | Returns | Description |
+|---|---|---|
+| \`Stamp()\` | instance | Create a new builder |
+| \`.set_theme(theme)\` | \`self\` | Set theme for this instance (does not change the module global) |
+| \`.new_doc(title, subtitle, ...)\` | \`self\` | Create the internal document (auto-called if omitted) |
+| \`.coverpage(title, ...)\` | \`self\` | Add a cover page |
+| \`.table_section(heading, rows)\` | \`self\` | Add heading + key/value table |
+| \`.longtext(heading, text)\` | \`self\` | Add heading + paragraphs |
+| \`.bullet_list(heading, items_str)\` | \`self\` | Add heading + bullet list |
+| \`.signatures(labels)\` | \`self\` | Add signature grid |
+| \`.footer()\` | \`self\` | Add FormForge footer |
+| \`.address(heading, raw_json)\` | \`self\` | Add formatted address |
+| \`.image(b64_str, ...)\` | \`self\` | Embed image or placeholder |
+| \`.signature(b64_str, label, ...)\` | \`self\` | Add signature image with label |
+| \`.repeater_table(headers, items, field_keys, ...)\` | \`self\` | Render repeater as table |
+| \`.add_heading(text, level)\` | \`self\` | Pass-through to Document |
+| \`.add_paragraph(text)\` | \`self\` | Pass-through to Document |
+| \`.add_page_break()\` | \`self\` | Pass-through to Document |
+| \`.doc\` | \`Document\` | Access the underlying Document for advanced usage |
+| \`.finalize()\` | \`bytes\` | Serialize to DOCX bytes |
+
+### Advanced: accessing the underlying Document
+
+For python-docx operations not covered by Stamp methods, use the \`.doc\` property:
+
+\`\`\`python
+from docx.shared import Pt
+
+doc = Stamp().set_theme(THEME_CLASSIC).new_doc("Report")
+# Direct Document access for custom formatting
+d = doc.doc
+d.add_heading("Custom Section", level=2)
+p = d.add_paragraph()
+r = p.add_run("Custom formatted text")
+r.font.size = Pt(10)
+
+return doc.footer().finalize()
+\`\`\`
+
+## Module-Level Functions (Backward-Compatible)
+
+The original module-level functions still work exactly as before. All existing templates using \`stencils.function(doc, ...)\` will continue to work without changes.
+
 ### \`stencils.new_doc(title_text, subtitle_text="", font_name=None, font_size=None, theme=None)\`
 
 Creates a styled \`Document\` cloned from a pre-built template. The template has all heading styles, page margins, and base font configured from the active (or given) theme. Returns the \`Document\` instance.
@@ -9109,19 +9219,18 @@ for item in skills.split("\\n"):
 ## Minimal Template
 
 \`\`\`python
-import stencils
+from stencils import Stamp, THEME_CLASSIC
 
 def generate_docx(data):
-    doc = stencils.new_doc("My Document", data.get("title", ""))
-
-    stencils.table_section(doc, "Details", [
+    doc = Stamp()
+    doc.set_theme(THEME_CLASSIC)
+    doc.new_doc("My Document", data.get("title", ""))
+    doc.table_section("Details", [
         ("Name", data.get("name", "")),
         ("Date", data.get("date", "")),
     ])
-
-    stencils.bullet_list(doc, "Action Items", data.get("actions", ""))
-
-    return stencils.finalize(doc)
+    doc.bullet_list("Action Items", data.get("actions", ""))
+    return doc.finalize()
 \`\`\`
 
 ## Template Without \`stencils\` (Standalone)

--- a/templates/coverpage-demo.py
+++ b/templates/coverpage-demo.py
@@ -9,7 +9,7 @@ The `data` dict keys match the field `id` values in
 schemas/coverpage-demo.json.
 """
 
-import stencils
+from stencils import Stamp, THEME_CLASSIC
 
 
 def generate_docx(data: dict[str, str]) -> bytes:
@@ -22,13 +22,12 @@ def generate_docx(data: dict[str, str]) -> bytes:
     Returns:
         bytes: The generated .docx file as raw bytes.
     """
-    stencils.set_theme(stencils.THEME_CLASSIC)
-
-    doc = stencils.new_doc()
+    doc = Stamp()
+    doc.set_theme(THEME_CLASSIC)
+    doc.new_doc()
 
     # ── Cover page ──────────────────────────────────────────────
-    stencils.coverpage(
-        doc,
+    doc.coverpage(
         title=data.get("doc_title", "Untitled Document"),
         doc_type=data.get("doc_type", ""),
         metadata=[
@@ -43,13 +42,13 @@ def generate_docx(data: dict[str, str]) -> bytes:
     # ── Body content (page 2+) ──────────────────────────────────
     heading = data.get("body_heading", "").strip()
     if heading:
-        stencils.longtext(doc, heading, data.get("body_content", ""))
+        doc.longtext(heading, data.get("body_content", ""))
     elif data.get("body_content", "").strip():
-        stencils.longtext(doc, "Content", data.get("body_content", ""))
+        doc.longtext("Content", data.get("body_content", ""))
 
-    stencils.bullet_list(doc, "Key Findings", data.get("key_findings", ""))
+    doc.bullet_list("Key Findings", data.get("key_findings", ""))
 
     # ── Footer ──────────────────────────────────────────────────
-    stencils.footer(doc)
+    doc.footer()
 
-    return stencils.finalize(doc)
+    return doc.finalize()

--- a/templates/expense-report.py
+++ b/templates/expense-report.py
@@ -19,7 +19,7 @@ Field type notes:
 
 import json
 
-import stencils
+from stencils import Stamp, THEME_MODERN
 
 
 def generate_docx(data: dict[str, str]) -> bytes:
@@ -32,14 +32,14 @@ def generate_docx(data: dict[str, str]) -> bytes:
     Returns:
         bytes: The generated .docx file as raw bytes.
     """
-    stencils.set_theme(stencils.THEME_MODERN)
-
     name = data.get("employee_name", "")
     dept = data.get("department", "")
     report_date = data.get("report_date", "")
     form_ver = data.get("form_version", "")
 
-    doc = stencils.new_doc(
+    doc = Stamp()
+    doc.set_theme(THEME_MODERN)
+    doc.new_doc(
         "Expense Report",
         f"{name} — {dept} — {report_date}",
     )
@@ -51,8 +51,7 @@ def generate_docx(data: dict[str, str]) -> bytes:
     except (ValueError, TypeError):
         total_fmt = f"${total}"
 
-    stencils.table_section(
-        doc,
+    doc.table_section(
         "Report Details",
         [
             ("Employee", name),
@@ -72,8 +71,7 @@ def generate_docx(data: dict[str, str]) -> bytes:
     except (json.JSONDecodeError, TypeError):
         items = []
 
-    stencils.repeater_table(
-        doc,
+    doc.repeater_table(
         headers=["Description", "Amount", "Category"],
         items=items,
         field_keys=["description", "amount", "category"],
@@ -81,16 +79,14 @@ def generate_docx(data: dict[str, str]) -> bytes:
     )
 
     # ── Number of Receipts (number field) ───────────────────
-    stencils.table_section(
-        doc,
+    doc.table_section(
         "Receipts",
         [("Number of receipts attached", data.get("item_count", "0"))],
     )
 
     # ── Receipt Photo (file field) ──────────────────────────
     doc.add_heading("Receipt / Invoice", level=1)
-    stencils.image(
-        doc,
+    doc.image(
         data.get("receipt_photo", ""),
         width_inches=3.0,
         placeholder="No receipt uploaded.",
@@ -100,11 +96,10 @@ def generate_docx(data: dict[str, str]) -> bytes:
     # ── Notes ───────────────────────────────────────────────
     notes = data.get("notes", "")
     if notes and notes.strip():
-        stencils.longtext(doc, "Additional Notes", notes)
+        doc.longtext("Additional Notes", notes)
 
     # ── Mailing Address (address field) ─────────────────────
-    stencils.address(
-        doc,
+    doc.address(
         "Reimbursement Mailing Address",
         data.get("mailing_address", "{}"),
     )
@@ -115,10 +110,10 @@ def generate_docx(data: dict[str, str]) -> bytes:
         ("Employee Signature", "employee_signature"),
         ("Manager Signature", "manager_signature"),
     ]:
-        stencils.signature(doc, data.get(field_id, ""), label)
+        doc.signature(data.get(field_id, ""), label)
     doc.add_paragraph("")
 
     # ── Footer ──────────────────────────────────────────────
-    stencils.footer(doc)
+    doc.footer()
 
-    return stencils.finalize(doc)
+    return doc.finalize()

--- a/templates/field-type-demo.py
+++ b/templates/field-type-demo.py
@@ -79,12 +79,12 @@ def generate_docx(data: dict[str, str]) -> bytes:
     # textarea — brief description
     description = data.get("event_description", "")
     if description and description.strip():
-        d = doc.doc
-        d.add_heading("Brief Description", level=2)
-        p = d.add_paragraph()
+        raw = doc.doc
+        raw.add_heading("Brief Description", level=2)
+        p = raw.add_paragraph()
         r = p.add_run(description)
         r.font.size = Pt(10)
-        d.add_paragraph("")
+        raw.add_paragraph("")
 
     # longtext — detailed proposal
     proposal = data.get("detailed_proposal", "")
@@ -110,12 +110,12 @@ def generate_docx(data: dict[str, str]) -> bytes:
     # text (conditional — virtual platform)
     virtual_platform = data.get("virtual_platform", "")
     if virtual_platform and virtual_platform.strip():
-        d = doc.doc
-        d.add_heading("Virtual Platform", level=2)
-        p = d.add_paragraph()
+        raw = doc.doc
+        raw.add_heading("Virtual Platform", level=2)
+        p = raw.add_paragraph()
         r = p.add_run(virtual_platform)
         r.font.size = Pt(10)
-        d.add_paragraph("")
+        raw.add_paragraph("")
 
     # multi_select — session topics
     topics = data.get("session_topics", "")

--- a/templates/field-type-demo.py
+++ b/templates/field-type-demo.py
@@ -25,7 +25,7 @@ Field type value formats:
 import json
 from docx.shared import Pt
 
-import stencils
+from stencils import Stamp, THEME_MINIMAL, format_time
 
 
 def generate_docx(data: dict[str, str]) -> bytes:
@@ -38,28 +38,27 @@ def generate_docx(data: dict[str, str]) -> bytes:
     Returns:
         bytes: The generated .docx file as raw bytes.
     """
-    stencils.set_theme(stencils.THEME_MINIMAL)
-
     name = data.get("full_name", "")
     email = data.get("email", "")
     event_date = data.get("event_date", "")
     form_ver = data.get("form_version", "")
 
-    doc = stencils.new_doc(
+    doc = Stamp()
+    doc.set_theme(THEME_MINIMAL)
+    doc.new_doc(
         "Event Registration",
         f"{name} — {event_date}",
     )
 
     # ── Step 1: Applicant Info ────────────────────────────
-    stencils.table_section(
-        doc,
+    doc.table_section(
         "Applicant Info",
         [
             ("Full Name", name),
             ("Email", email),
             ("Phone", data.get("phone", "")),
             ("Preferred Date", event_date),
-            ("Preferred Time", stencils.format_time(data.get("event_time", ""))),
+            ("Preferred Time", format_time(data.get("event_time", ""))),
             ("Website", data.get("website", "")),
             ("Form Version", form_ver),
         ],
@@ -69,8 +68,7 @@ def generate_docx(data: dict[str, str]) -> bytes:
     event_type = data.get("event_type", "")
     attendance = data.get("attendance_mode", "")
 
-    stencils.table_section(
-        doc,
+    doc.table_section(
         "Event Details",
         [
             ("Event Type", event_type),
@@ -81,16 +79,17 @@ def generate_docx(data: dict[str, str]) -> bytes:
     # textarea — brief description
     description = data.get("event_description", "")
     if description and description.strip():
-        doc.add_heading("Brief Description", level=2)
-        p = doc.add_paragraph()
+        d = doc.doc
+        d.add_heading("Brief Description", level=2)
+        p = d.add_paragraph()
         r = p.add_run(description)
         r.font.size = Pt(10)
-        doc.add_paragraph("")
+        d.add_paragraph("")
 
     # longtext — detailed proposal
     proposal = data.get("detailed_proposal", "")
     if proposal and proposal.strip():
-        stencils.longtext(doc, "Detailed Proposal", proposal)
+        doc.longtext("Detailed Proposal", proposal)
 
     # address (conditional — in-person only)
     raw_addr = data.get("venue_address", "{}")
@@ -100,28 +99,29 @@ def generate_docx(data: dict[str, str]) -> bytes:
         addr = {}
 
     if addr.get("street"):
-        stencils.address(doc, "Venue Address", raw_addr)
+        doc.address("Venue Address", raw_addr)
 
     # checkbox (conditional — in-person dietary restrictions)
     dietary = data.get("dietary_restrictions", "")
     if dietary and dietary.strip():
         dietary_nl = "\n".join(d.strip() for d in dietary.split(",") if d.strip())
-        stencils.bullet_list(doc, "Dietary Restrictions", dietary_nl)
+        doc.bullet_list("Dietary Restrictions", dietary_nl)
 
     # text (conditional — virtual platform)
     virtual_platform = data.get("virtual_platform", "")
     if virtual_platform and virtual_platform.strip():
-        doc.add_heading("Virtual Platform", level=2)
-        p = doc.add_paragraph()
+        d = doc.doc
+        d.add_heading("Virtual Platform", level=2)
+        p = d.add_paragraph()
         r = p.add_run(virtual_platform)
         r.font.size = Pt(10)
-        doc.add_paragraph("")
+        d.add_paragraph("")
 
     # multi_select — session topics
     topics = data.get("session_topics", "")
     if topics and topics.strip():
         topics_nl = "\n".join(t.strip() for t in topics.split(",") if t.strip())
-        stencils.bullet_list(doc, "Session Topics", topics_nl)
+        doc.bullet_list("Session Topics", topics_nl)
 
     # ── Step 3: Budget & Items ────────────────────────────
     budget = data.get("budget_amount", "0")
@@ -132,8 +132,7 @@ def generate_docx(data: dict[str, str]) -> bytes:
 
     attendees = data.get("attendee_count", "")
 
-    stencils.table_section(
-        doc,
+    doc.table_section(
         "Budget & Logistics",
         [
             ("Estimated Budget", budget_fmt),
@@ -149,8 +148,7 @@ def generate_docx(data: dict[str, str]) -> bytes:
     except (json.JSONDecodeError, TypeError):
         items = []
 
-    stencils.repeater_table(
-        doc,
+    doc.repeater_table(
         headers=["Item", "Qty", "Unit Cost", "Category"],
         items=items,
         field_keys=["item_name", "quantity", "unit_cost", "category"],
@@ -160,15 +158,13 @@ def generate_docx(data: dict[str, str]) -> bytes:
     # list — special requests
     special = data.get("special_requests", "")
     if special and special.strip():
-        stencils.bullet_list(doc, "Special Requests", special)
+        doc.bullet_list("Special Requests", special)
 
     # datetime — submission deadline
     deadline = data.get("submission_deadline", "")
     if deadline and deadline.strip():
-        # Format datetime-local value (e.g. "2026-05-01T17:00" → "2026-05-01 at 5:00 PM")
-        deadline_display = stencils.format_time(deadline)
-        stencils.table_section(
-            doc,
+        deadline_display = format_time(deadline)
+        doc.table_section(
             "Deadline",
             [("Proposal Submission Deadline", deadline_display)],
         )
@@ -177,8 +173,7 @@ def generate_docx(data: dict[str, str]) -> bytes:
 
     # file — supporting document
     doc.add_heading("Supporting Document", level=1)
-    stencils.image(
-        doc,
+    doc.image(
         data.get("supporting_doc", ""),
         width_inches=3.0,
         placeholder="No document uploaded.",
@@ -188,22 +183,21 @@ def generate_docx(data: dict[str, str]) -> bytes:
     # textarea — additional notes
     notes = data.get("additional_notes", "")
     if notes and notes.strip():
-        stencils.longtext(doc, "Additional Notes", notes)
+        doc.longtext("Additional Notes", notes)
 
     # toggle — terms agreement
     agree = data.get("agree_terms", "false")
-    stencils.table_section(
-        doc,
+    doc.table_section(
         "Terms",
         [("Agreed to Terms & Conditions", "Yes" if agree == "true" else "No")],
     )
 
     # signature — applicant signature
     doc.add_heading("Applicant Signature", level=1)
-    stencils.signature(doc, data.get("applicant_signature", ""), "Applicant Signature")
+    doc.signature(data.get("applicant_signature", ""), "Applicant Signature")
     doc.add_paragraph("")
 
     # ── Footer ────────────────────────────────────────────
-    stencils.footer(doc)
+    doc.footer()
 
-    return stencils.finalize(doc)
+    return doc.finalize()

--- a/templates/onboarding.py
+++ b/templates/onboarding.py
@@ -15,7 +15,7 @@ Field type notes:
   - list → newline-separated str (e.g. "Python\\nJavaScript\\nRust")
 """
 
-import stencils
+from stencils import Stamp, THEME_CLASSIC
 
 
 def generate_docx(data: dict[str, str]) -> bytes:
@@ -28,20 +28,19 @@ def generate_docx(data: dict[str, str]) -> bytes:
     Returns:
         bytes: The generated .docx file as raw bytes.
     """
-    stencils.set_theme(stencils.THEME_CLASSIC)
-
     first = data.get("first_name", "")
     last = data.get("last_name", "")
     start = data.get("start_date", "TBD")
 
-    doc = stencils.new_doc(
+    doc = Stamp()
+    doc.set_theme(THEME_CLASSIC)
+    doc.new_doc(
         "Employee Onboarding Document",
         f"Prepared for {first} {last} — Start Date: {start}",
     )
 
     # ── Section: Personal Information ──────────────────────────
-    stencils.table_section(
-        doc,
+    doc.table_section(
         "Personal Information",
         [
             ("First Name", data.get("first_name", "")),
@@ -54,8 +53,7 @@ def generate_docx(data: dict[str, str]) -> bytes:
     )
 
     # ── Section: Role & Department ─────────────────────────────
-    stencils.table_section(
-        doc,
+    doc.table_section(
         "Role & Department",
         [
             ("Department", data.get("department", "")),
@@ -69,8 +67,7 @@ def generate_docx(data: dict[str, str]) -> bytes:
     equipment = data.get("equipment_needs", "")
     software = data.get("software_access", "")
 
-    stencils.table_section(
-        doc,
+    doc.table_section(
         "Equipment & Access",
         [
             ("Laptop", data.get("laptop_preference", "")),
@@ -81,17 +78,13 @@ def generate_docx(data: dict[str, str]) -> bytes:
 
     # ── Section: Skills & Experience ───────────────────────────
     doc.add_heading("Skills & Experience", level=1)
-
-    stencils.longtext(doc, "Professional Bio", data.get("bio", ""))
-    stencils.bullet_list(doc, "Key Skills", data.get("skills", ""))
-    stencils.bullet_list(
-        doc, "Certifications & Licenses", data.get("certifications", "")
-    )
-    stencils.longtext(doc, "Notable Prior Projects", data.get("prior_projects", ""))
+    doc.longtext("Professional Bio", data.get("bio", ""))
+    doc.bullet_list("Key Skills", data.get("skills", ""))
+    doc.bullet_list("Certifications & Licenses", data.get("certifications", ""))
+    doc.longtext("Notable Prior Projects", data.get("prior_projects", ""))
 
     # ── Section: Additional Information ────────────────────────
-    stencils.table_section(
-        doc,
+    doc.table_section(
         "Additional Information",
         [
             ("Emergency Contact", data.get("emergency_contact", "")),
@@ -101,11 +94,10 @@ def generate_docx(data: dict[str, str]) -> bytes:
         ],
     )
 
-    stencils.bullet_list(doc, "First 90 Days Goals", data.get("onboarding_goals", ""))
+    doc.bullet_list("First 90 Days Goals", data.get("onboarding_goals", ""))
 
     # ── Signatures ─────────────────────────────────────────────
-    stencils.signatures(
-        doc,
+    doc.signatures(
         [
             "Employee Signature",
             "Date",
@@ -115,6 +107,6 @@ def generate_docx(data: dict[str, str]) -> bytes:
     )
 
     # ── Footer ─────────────────────────────────────────────────
-    stencils.footer(doc)
+    doc.footer()
 
-    return stencils.finalize(doc)
+    return doc.finalize()

--- a/templates/stencils.py
+++ b/templates/stencils.py
@@ -4,7 +4,23 @@ FormForge Shared Template Stencils
 Shared helper functions for all FormForge DOCX templates.
 Works in both standard Python (import stencils) and Pyodide (via exec()).
 
-Usage in templates:
+Stamp class (recommended)::
+
+    from stencils import Stamp, THEME_CLASSIC
+
+    def generate_docx(data):
+        doc = Stamp()
+        doc.set_theme(THEME_CLASSIC)
+        doc.new_doc("My Form Title", "Subtitle here")
+        doc.table_section("Section Name", [("Label", "Value"), ...])
+        doc.longtext("Notes", some_text)
+        doc.bullet_list("Skills", newline_separated_str)
+        doc.signatures(["Signer 1", "Signer 2"])
+        doc.footer()
+        return doc.finalize()
+
+Module-level functions (backward-compatible)::
+
     import stencils
     doc = stencils.new_doc("My Form Title", "Subtitle here")
     stencils.table_section(doc, "Section Name", [("Label", "Value"), ...])
@@ -1058,6 +1074,202 @@ def repeater_table(
         r.font.color.rgb = t.color_muted
 
     doc.add_paragraph("")
+
+
+# ---------------------------------------------------------------------------
+#  Stamp — fluent document builder
+# ---------------------------------------------------------------------------
+
+
+class Stamp:
+    """Fluent builder for DOCX documents using stencils helpers.
+
+    Wraps an internal ``Document`` and exposes every public stencil function
+    as a chainable method (returns ``self``), except ``finalize()`` which
+    returns the finished DOCX bytes.
+
+    Usage::
+
+        from stencils import Stamp, THEME_CLASSIC
+
+        def generate_docx(data):
+            doc = Stamp()
+            doc.set_theme(THEME_CLASSIC)
+            doc.new_doc("My Title")
+            doc.table_section("Info", [("Name", data.get("name", ""))])
+            doc.footer()
+            return doc.finalize()
+
+    Or with method chaining::
+
+        return (Stamp()
+            .set_theme(THEME_CLASSIC)
+            .new_doc("My Title")
+            .table_section("Info", [("Name", data.get("name", ""))])
+            .footer()
+            .finalize())
+    """
+
+    def __init__(self) -> None:
+        self._doc: Document | None = None
+        self._theme: DocTheme | None = None
+
+    def set_theme(self, theme: DocTheme) -> "Stamp":
+        """Set the theme for this document.
+
+        Unlike the module-level ``set_theme()``, this only affects the
+        current ``Stamp`` instance — it does not modify the global theme.
+        """
+        missing = [f for f in _THEME_FIELDS if not hasattr(theme, f)]
+        if missing:
+            raise ValueError(f"Theme missing required fields: {', '.join(missing)}")
+        self._theme = theme
+        return self
+
+    def new_doc(
+        self,
+        title_text: str = "",
+        subtitle_text: str = "",
+        font_name: str | None = None,
+        font_size: int | None = None,
+    ) -> "Stamp":
+        """Create the internal document with optional title and subtitle.
+
+        Must be called before any content methods. The document is cloned
+        from a pre-built template configured from the instance theme (set
+        via ``set_theme()``) or the module-level active theme.
+        """
+        self._doc = new_doc(
+            title_text,
+            subtitle_text,
+            font_name=font_name,
+            font_size=font_size,
+            theme=self._theme,
+        )
+        return self
+
+    def _ensure_doc(self) -> Document:
+        """Lazily create the document if ``new_doc()`` was not called."""
+        if self._doc is None:
+            self._doc = new_doc(theme=self._theme)
+        return self._doc
+
+    def coverpage(
+        self,
+        title: str,
+        doc_type: str = "",
+        metadata: list[tuple[str, str]] | None = None,
+        logo_b64: str = "",
+        logo_width: float = 2.0,
+        max_logo_height: float = 1.0,
+        bar_color: str | None = None,
+    ) -> "Stamp":
+        """Add a professional cover page. See ``coverpage()`` module function."""
+        coverpage(
+            self._ensure_doc(),
+            title,
+            doc_type=doc_type,
+            metadata=metadata,
+            logo_b64=logo_b64,
+            logo_width=logo_width,
+            max_logo_height=max_logo_height,
+            bar_color=bar_color,
+            theme=self._theme,
+        )
+        return self
+
+    def table_section(self, heading: str, rows: list[tuple[str, str]]) -> "Stamp":
+        """Add a heading + key/value table. See ``table_section()``."""
+        table_section(self._ensure_doc(), heading, rows)
+        return self
+
+    def longtext(self, heading: str, text: str) -> "Stamp":
+        """Add a heading + paragraphs. See ``longtext()``."""
+        longtext(self._ensure_doc(), heading, text)
+        return self
+
+    def bullet_list(self, heading: str, items_str: str) -> "Stamp":
+        """Add a heading + bulleted list. See ``bullet_list()``."""
+        bullet_list(self._ensure_doc(), heading, items_str)
+        return self
+
+    def signatures(self, labels: list[str]) -> "Stamp":
+        """Add a signature grid. See ``signatures()``."""
+        signatures(self._ensure_doc(), labels)
+        return self
+
+    def footer(self) -> "Stamp":
+        """Add the standard FormForge footer. See ``footer()``."""
+        footer(self._ensure_doc())
+        return self
+
+    def address(self, heading: str, raw_json: str) -> "Stamp":
+        """Add a formatted address block. See ``address()``."""
+        address(self._ensure_doc(), heading, raw_json)
+        return self
+
+    def image(
+        self,
+        b64_str: str,
+        width_inches: float = 3.0,
+        max_height: float | None = None,
+        placeholder: str = "No image uploaded.",
+    ) -> "Stamp":
+        """Embed a base64 image or placeholder. See ``image()``."""
+        image(
+            self._ensure_doc(),
+            b64_str,
+            width_inches=width_inches,
+            max_height=max_height,
+            placeholder=placeholder,
+        )
+        return self
+
+    def signature(self, b64_str: str, label: str, width_inches: float = 2.5) -> "Stamp":
+        """Add a signature image with label. See ``signature()``."""
+        signature(self._ensure_doc(), b64_str, label, width_inches=width_inches)
+        return self
+
+    def repeater_table(
+        self,
+        headers: list[str],
+        items: list[dict[str, str]],
+        field_keys: list[str],
+        currency_keys: list[str] | None = None,
+    ) -> "Stamp":
+        """Render a repeater as a headed table. See ``repeater_table()``."""
+        repeater_table(
+            self._ensure_doc(),
+            headers,
+            items,
+            field_keys,
+            currency_keys=currency_keys,
+        )
+        return self
+
+    def add_heading(self, text: str, level: int = 1) -> "Stamp":
+        """Add a heading paragraph directly (pass-through to Document)."""
+        self._ensure_doc().add_heading(text, level=level)
+        return self
+
+    def add_paragraph(self, text: str = "") -> "Stamp":
+        """Add a paragraph directly (pass-through to Document)."""
+        self._ensure_doc().add_paragraph(text)
+        return self
+
+    def add_page_break(self) -> "Stamp":
+        """Add a page break (pass-through to Document)."""
+        self._ensure_doc().add_page_break()
+        return self
+
+    @property
+    def doc(self) -> Document:
+        """Access the underlying Document for advanced usage."""
+        return self._ensure_doc()
+
+    def finalize(self) -> bytes:
+        """Serialize the document to DOCX bytes."""
+        return finalize(self._ensure_doc())
 
 
 def format_time(value: str) -> str:

--- a/templates/stencils.py
+++ b/templates/stencils.py
@@ -726,7 +726,12 @@ def _coverpage_logo_placeholder(paragraph: object, theme: DocTheme) -> None:
     run.font.color.rgb = RGBColor(0xFF, 0xFF, 0xFF)
 
 
-def table_section(doc: Document, heading: str, rows: list[tuple[str, str]]) -> None:
+def table_section(
+    doc: Document,
+    heading: str,
+    rows: list[tuple[str, str]],
+    theme: DocTheme | None = None,
+) -> None:
     """
     Add a heading followed by a borderless two-column key/value table.
     Labels in the first column use the heading font (semibold).
@@ -735,8 +740,9 @@ def table_section(doc: Document, heading: str, rows: list[tuple[str, str]]) -> N
         doc: The Document instance.
         heading: Section heading string.
         rows: List of (label, value) tuples.
+        theme: Optional DocTheme override. If None, uses the active theme.
     """
-    t = _active_theme
+    t = theme if theme is not None else _active_theme
     doc.add_heading(heading, level=1)
 
     table = doc.add_table(rows=0, cols=2)
@@ -761,7 +767,12 @@ def table_section(doc: Document, heading: str, rows: list[tuple[str, str]]) -> N
     doc.add_paragraph("")
 
 
-def longtext(doc: Document, heading: str, text: str) -> None:
+def longtext(
+    doc: Document,
+    heading: str,
+    text: str,
+    theme: DocTheme | None = None,
+) -> None:
     """
     Add a sub-heading followed by one or more paragraphs of body text.
     Respects newline characters as paragraph breaks.
@@ -770,8 +781,9 @@ def longtext(doc: Document, heading: str, text: str) -> None:
         doc: The Document instance.
         heading: Sub-heading string.
         text: The long-form text content (may contain newlines).
+        theme: Optional DocTheme override. If None, uses the active theme.
     """
-    t = _active_theme
+    t = theme if theme is not None else _active_theme
     doc.add_heading(heading, level=2)
 
     if text and text.strip():
@@ -790,7 +802,12 @@ def longtext(doc: Document, heading: str, text: str) -> None:
     doc.add_paragraph("")
 
 
-def bullet_list(doc: Document, heading: str, items_str: str) -> None:
+def bullet_list(
+    doc: Document,
+    heading: str,
+    items_str: str,
+    theme: DocTheme | None = None,
+) -> None:
     """
     Add a sub-heading followed by a bulleted list.
     Items are expected as a newline-separated string.
@@ -799,8 +816,9 @@ def bullet_list(doc: Document, heading: str, items_str: str) -> None:
         doc: The Document instance.
         heading: Sub-heading string.
         items_str: Newline-separated string of list items.
+        theme: Optional DocTheme override. If None, uses the active theme.
     """
-    t = _active_theme
+    t = theme if theme is not None else _active_theme
     doc.add_heading(heading, level=2)
 
     if items_str and items_str.strip():
@@ -827,7 +845,11 @@ def bullet_list(doc: Document, heading: str, items_str: str) -> None:
     doc.add_paragraph("")
 
 
-def signatures(doc: Document, labels: list[str]) -> None:
+def signatures(
+    doc: Document,
+    labels: list[str],
+    theme: DocTheme | None = None,
+) -> None:
     """
     Add a signature block with underlines and labels in a grid layout.
     Labels are arranged in pairs (two per row).
@@ -836,8 +858,9 @@ def signatures(doc: Document, labels: list[str]) -> None:
         doc: The Document instance.
         labels: List of signature label strings (e.g. ["Employee Signature",
                 "Date", "HR Representative", "Date"]).
+        theme: Optional DocTheme override. If None, uses the active theme.
     """
-    t = _active_theme
+    t = theme if theme is not None else _active_theme
     doc.add_paragraph("")
     doc.add_heading("Signatures", level=1)
 
@@ -858,14 +881,15 @@ def signatures(doc: Document, labels: list[str]) -> None:
         run.font.color.rgb = t.color_muted
 
 
-def footer(doc: Document) -> None:
+def footer(doc: Document, theme: DocTheme | None = None) -> None:
     """
     Add the standard FormForge auto-generated footer paragraph.
 
     Args:
         doc: The Document instance.
+        theme: Optional DocTheme override. If None, uses the active theme.
     """
-    t = _active_theme
+    t = theme if theme is not None else _active_theme
     doc.add_paragraph("")
     fp = doc.add_paragraph()
     fp.alignment = WD_ALIGN_PARAGRAPH.CENTER
@@ -879,7 +903,12 @@ def footer(doc: Document) -> None:
     fr.italic = True
 
 
-def address(doc: Document, heading: str, raw_json: str) -> None:
+def address(
+    doc: Document,
+    heading: str,
+    raw_json: str,
+    theme: DocTheme | None = None,
+) -> None:
     """
     Add a formatted mailing address block under a heading.
     Parses a JSON string with keys: street, city, state, zip.
@@ -889,8 +918,9 @@ def address(doc: Document, heading: str, raw_json: str) -> None:
         doc: The Document instance.
         heading: Sub-heading string.
         raw_json: JSON string with address fields, or "{}".
+        theme: Optional DocTheme override. If None, uses the active theme.
     """
-    t = _active_theme
+    t = theme if theme is not None else _active_theme
     doc.add_heading(heading, level=2)
 
     try:
@@ -935,6 +965,7 @@ def image(
     width_inches: float = 3.0,
     max_height: float | None = None,
     placeholder: str = "No image uploaded.",
+    theme: DocTheme | None = None,
 ) -> None:
     """
     Embed a base64 data-URI image or render a placeholder if absent/invalid.
@@ -947,7 +978,9 @@ def image(
                     this height at the given width, it is scaled down
                     proportionally.
         placeholder: Text to show when no image is available.
+        theme: Optional DocTheme override. If None, uses the active theme.
     """
+    t = theme if theme is not None else _active_theme
     if b64_str and "," in b64_str:
         try:
             img_data = b64_str.split(",")[1]
@@ -968,11 +1001,15 @@ def image(
     p = doc.add_paragraph()
     r = p.add_run(placeholder)
     r.italic = True
-    r.font.color.rgb = _active_theme.color_muted
+    r.font.color.rgb = t.color_muted
 
 
 def signature(
-    doc: Document, b64_str: str, label: str, width_inches: float = 2.5
+    doc: Document,
+    b64_str: str,
+    label: str,
+    width_inches: float = 2.5,
+    theme: DocTheme | None = None,
 ) -> None:
     """
     Add a signature image (or placeholder underline) with a label beneath.
@@ -982,8 +1019,9 @@ def signature(
         b64_str: Base64 data URI string or "".
         label: Label text below the signature (e.g. "Employee Signature").
         width_inches: Signature image width in inches (default: 2.5).
+        theme: Optional DocTheme override. If None, uses the active theme.
     """
-    t = _active_theme
+    t = theme if theme is not None else _active_theme
     p = doc.add_paragraph()
     if b64_str and "," in b64_str:
         try:
@@ -1007,6 +1045,7 @@ def repeater_table(
     items: list[dict[str, str]],
     field_keys: list[str],
     currency_keys: list[str] | None = None,
+    theme: DocTheme | None = None,
 ) -> None:
     """
     Render a repeater field as a headed table with a shaded header row.
@@ -1018,10 +1057,11 @@ def repeater_table(
         field_keys: List of dict keys corresponding to each column.
         currency_keys: Optional set/list of field_keys that should be
                        formatted as currency (e.g. ["amount", "unit_cost"]).
+        theme: Optional DocTheme override. If None, uses the active theme.
     """
     _currency_set = set(currency_keys) if currency_keys else set()
 
-    t = _active_theme
+    t = theme if theme is not None else _active_theme
 
     if items:
         table = doc.add_table(rows=1, cols=len(headers))
@@ -1135,9 +1175,10 @@ class Stamp:
     ) -> "Stamp":
         """Create the internal document with optional title and subtitle.
 
-        Must be called before any content methods. The document is cloned
-        from a pre-built template configured from the instance theme (set
-        via ``set_theme()``) or the module-level active theme.
+        If not called explicitly, the document is created automatically on
+        the first content method call. The document is cloned from a
+        pre-built template configured from the instance theme (set via
+        ``set_theme()``) or the module-level active theme.
         """
         self._doc = new_doc(
             title_text,
@@ -1149,7 +1190,7 @@ class Stamp:
         return self
 
     def _ensure_doc(self) -> Document:
-        """Lazily create the document if ``new_doc()`` was not called."""
+        """Lazily create the document using the instance theme if ``new_doc()`` was not called."""
         if self._doc is None:
             self._doc = new_doc(theme=self._theme)
         return self._doc
@@ -1180,32 +1221,32 @@ class Stamp:
 
     def table_section(self, heading: str, rows: list[tuple[str, str]]) -> "Stamp":
         """Add a heading + key/value table. See ``table_section()``."""
-        table_section(self._ensure_doc(), heading, rows)
+        table_section(self._ensure_doc(), heading, rows, theme=self._theme)
         return self
 
     def longtext(self, heading: str, text: str) -> "Stamp":
         """Add a heading + paragraphs. See ``longtext()``."""
-        longtext(self._ensure_doc(), heading, text)
+        longtext(self._ensure_doc(), heading, text, theme=self._theme)
         return self
 
     def bullet_list(self, heading: str, items_str: str) -> "Stamp":
         """Add a heading + bulleted list. See ``bullet_list()``."""
-        bullet_list(self._ensure_doc(), heading, items_str)
+        bullet_list(self._ensure_doc(), heading, items_str, theme=self._theme)
         return self
 
     def signatures(self, labels: list[str]) -> "Stamp":
         """Add a signature grid. See ``signatures()``."""
-        signatures(self._ensure_doc(), labels)
+        signatures(self._ensure_doc(), labels, theme=self._theme)
         return self
 
     def footer(self) -> "Stamp":
         """Add the standard FormForge footer. See ``footer()``."""
-        footer(self._ensure_doc())
+        footer(self._ensure_doc(), theme=self._theme)
         return self
 
     def address(self, heading: str, raw_json: str) -> "Stamp":
         """Add a formatted address block. See ``address()``."""
-        address(self._ensure_doc(), heading, raw_json)
+        address(self._ensure_doc(), heading, raw_json, theme=self._theme)
         return self
 
     def image(
@@ -1222,12 +1263,19 @@ class Stamp:
             width_inches=width_inches,
             max_height=max_height,
             placeholder=placeholder,
+            theme=self._theme,
         )
         return self
 
     def signature(self, b64_str: str, label: str, width_inches: float = 2.5) -> "Stamp":
         """Add a signature image with label. See ``signature()``."""
-        signature(self._ensure_doc(), b64_str, label, width_inches=width_inches)
+        signature(
+            self._ensure_doc(),
+            b64_str,
+            label,
+            width_inches=width_inches,
+            theme=self._theme,
+        )
         return self
 
     def repeater_table(
@@ -1244,6 +1292,7 @@ class Stamp:
             items,
             field_keys,
             currency_keys=currency_keys,
+            theme=self._theme,
         )
         return self
 

--- a/tests/test_stencils.py
+++ b/tests/test_stencils.py
@@ -596,9 +596,7 @@ def test_new_doc_no_arguments():
     """new_doc() with no arguments returns a valid doc with no title heading."""
     doc = stencils.new_doc()
     assert doc is not None
-    heading_paras = [
-        p for p in doc.paragraphs if p.style.name == "Title" and p.text
-    ]
+    heading_paras = [p for p in doc.paragraphs if p.style.name == "Title" and p.text]
     assert heading_paras == []
 
 
@@ -909,3 +907,259 @@ def test_image_without_max_height_unchanged():
     stencils.image(doc, small_png, width_inches=3.0)
     shapes = doc.inline_shapes
     assert len(shapes) >= 1
+
+
+# ---------------------------------------------------------------------------
+#  Stamp class
+# ---------------------------------------------------------------------------
+
+
+def test_stamp_importable():
+    """Stamp and theme constants are importable via from-import."""
+    from stencils import Stamp, THEME_CLASSIC, THEME_MINIMAL, THEME_MODERN, DocTheme
+
+    assert Stamp is not None
+    assert THEME_CLASSIC is not None
+    assert THEME_MINIMAL is not None
+    assert THEME_MODERN is not None
+    assert DocTheme is not None
+
+
+def test_stamp_construction():
+    """Stamp() creates an instance with no document yet."""
+    s = stencils.Stamp()
+    assert s._doc is None
+    assert s._theme is None
+
+
+def test_stamp_set_theme_returns_self():
+    s = stencils.Stamp()
+    result = s.set_theme(stencils.THEME_CLASSIC)
+    assert result is s
+    assert s._theme is stencils.THEME_CLASSIC
+
+
+def test_stamp_set_theme_invalid():
+    """set_theme with an incomplete theme should raise ValueError."""
+
+    class BadTheme:
+        pass
+
+    s = stencils.Stamp()
+    with pytest.raises(ValueError, match="missing required fields"):
+        s.set_theme(BadTheme())
+
+
+def test_stamp_new_doc_returns_self():
+    s = stencils.Stamp()
+    result = s.new_doc("Test Title")
+    assert result is s
+    assert s._doc is not None
+
+
+def test_stamp_new_doc_creates_titled_doc():
+    s = stencils.Stamp()
+    s.set_theme(stencils.THEME_CLASSIC)
+    s.new_doc("My Title", "My Subtitle")
+    texts = [p.text for p in s.doc.paragraphs]
+    assert any("My Title" in t for t in texts)
+    assert any("My Subtitle" in t for t in texts)
+
+
+def test_stamp_lazy_doc_creation():
+    """Content methods should auto-create the doc if new_doc() was not called."""
+    s = stencils.Stamp()
+    s.set_theme(stencils.THEME_CLASSIC)
+    s.table_section("Info", [("Key", "Value")])
+    assert s._doc is not None
+
+
+def test_stamp_table_section_returns_self():
+    s = stencils.Stamp()
+    s.new_doc("Test")
+    result = s.table_section("Section", [("A", "B")])
+    assert result is s
+
+
+def test_stamp_longtext_returns_self():
+    s = stencils.Stamp()
+    s.new_doc("Test")
+    result = s.longtext("Heading", "Some text")
+    assert result is s
+
+
+def test_stamp_bullet_list_returns_self():
+    s = stencils.Stamp()
+    s.new_doc("Test")
+    result = s.bullet_list("Items", "a\nb\nc")
+    assert result is s
+
+
+def test_stamp_signatures_returns_self():
+    s = stencils.Stamp()
+    s.new_doc("Test")
+    result = s.signatures(["Signer 1", "Date"])
+    assert result is s
+
+
+def test_stamp_footer_returns_self():
+    s = stencils.Stamp()
+    s.new_doc("Test")
+    result = s.footer()
+    assert result is s
+
+
+def test_stamp_address_returns_self():
+    s = stencils.Stamp()
+    s.new_doc("Test")
+    result = s.address("Addr", '{"street":"123 Main"}')
+    assert result is s
+
+
+def test_stamp_image_returns_self():
+    s = stencils.Stamp()
+    s.new_doc("Test")
+    result = s.image("")
+    assert result is s
+
+
+def test_stamp_signature_returns_self():
+    s = stencils.Stamp()
+    s.new_doc("Test")
+    result = s.signature("", "Label")
+    assert result is s
+
+
+def test_stamp_repeater_table_returns_self():
+    s = stencils.Stamp()
+    s.new_doc("Test")
+    result = s.repeater_table(headers=["Col"], items=[], field_keys=["col"])
+    assert result is s
+
+
+def test_stamp_coverpage_returns_self():
+    s = stencils.Stamp()
+    s.new_doc()
+    result = s.coverpage("Title")
+    assert result is s
+
+
+def test_stamp_add_heading_returns_self():
+    s = stencils.Stamp()
+    s.new_doc("Test")
+    result = s.add_heading("H1", level=1)
+    assert result is s
+
+
+def test_stamp_add_paragraph_returns_self():
+    s = stencils.Stamp()
+    s.new_doc("Test")
+    result = s.add_paragraph("text")
+    assert result is s
+
+
+def test_stamp_add_page_break_returns_self():
+    s = stencils.Stamp()
+    s.new_doc("Test")
+    result = s.add_page_break()
+    assert result is s
+
+
+def test_stamp_finalize_returns_bytes():
+    s = stencils.Stamp()
+    s.new_doc("Test")
+    result = s.finalize()
+    assert isinstance(result, bytes)
+    assert len(result) > 0
+    assert result[:2] == b"PK"
+
+
+def test_stamp_method_chaining():
+    """Full method-chaining workflow produces valid DOCX bytes."""
+    result = (
+        stencils.Stamp()
+        .set_theme(stencils.THEME_CLASSIC)
+        .new_doc("Chained Doc")
+        .table_section("Info", [("Name", "Test")])
+        .longtext("Notes", "Some notes here")
+        .bullet_list("Skills", "Python\nRust")
+        .signatures(["Signer", "Date"])
+        .footer()
+        .finalize()
+    )
+    assert isinstance(result, bytes)
+    assert result[:2] == b"PK"
+
+
+def test_stamp_sequential_calls():
+    """Sequential (non-chained) workflow produces valid DOCX bytes."""
+    s = stencils.Stamp()
+    s.set_theme(stencils.THEME_MODERN)
+    s.new_doc("Sequential Doc")
+    s.table_section("Details", [("Key", "Value")])
+    s.footer()
+    result = s.finalize()
+    assert isinstance(result, bytes)
+    assert result[:2] == b"PK"
+
+
+def test_stamp_mixed_chain_and_sequential():
+    """Mixed chaining + sequential with conditionals."""
+    s = stencils.Stamp().set_theme(stencils.THEME_CLASSIC).new_doc("Mixed Doc")
+
+    # Conditional content
+    include_notes = True
+    if include_notes:
+        s.longtext("Notes", "Important notes")
+
+    s.footer()
+    result = s.finalize()
+    assert isinstance(result, bytes)
+    assert result[:2] == b"PK"
+
+
+def test_stamp_doc_property():
+    """The doc property provides access to the underlying Document."""
+    s = stencils.Stamp()
+    s.new_doc("Test")
+    # python-docx Document is a function; check the returned object has
+    # the expected document attributes instead.
+    assert hasattr(s.doc, "paragraphs")
+    assert hasattr(s.doc, "add_paragraph")
+    assert hasattr(s.doc, "styles")
+
+
+def test_stamp_theme_is_instance_scoped():
+    """Setting theme on Stamp does not change the module-level global."""
+    original = stencils._active_theme
+    s = stencils.Stamp()
+    s.set_theme(stencils.THEME_CLASSIC)
+    assert stencils._active_theme is original
+
+
+def test_stamp_content_round_trip():
+    """Content added via Stamp methods is present in the output DOCX."""
+    from io import BytesIO
+    from docx import Document
+
+    result = (
+        stencils.Stamp()
+        .set_theme(stencils.THEME_CLASSIC)
+        .new_doc("Round Trip")
+        .table_section("People", [("Name", "Alice"), ("Role", "Dev")])
+        .bullet_list("Skills", "Python\nGo")
+        .footer()
+        .finalize()
+    )
+    doc = Document(BytesIO(result))
+    all_text = "\n".join(p.text for p in doc.paragraphs)
+    for table in doc.tables:
+        for row in table.rows:
+            for cell in row.cells:
+                all_text += "\n" + cell.text
+
+    assert "Round Trip" in all_text
+    assert "People" in all_text
+    assert "Alice" in all_text
+    assert "Python" in all_text
+    assert "FormForge" in all_text  # footer text

--- a/tests/test_stencils.py
+++ b/tests/test_stencils.py
@@ -1129,12 +1129,40 @@ def test_stamp_doc_property():
     assert hasattr(s.doc, "styles")
 
 
-def test_stamp_theme_is_instance_scoped():
+def test_stamp_set_theme_does_not_mutate_global():
     """Setting theme on Stamp does not change the module-level global."""
     original = stencils._active_theme
     s = stencils.Stamp()
     s.set_theme(stencils.THEME_CLASSIC)
     assert stencils._active_theme is original
+
+
+def test_stamp_instance_theme_used_for_content():
+    """Content methods use the Stamp's instance theme, not the global."""
+    from io import BytesIO
+    from docx import Document
+
+    # CLASSIC footer color = RGBColor(0x6B, 0x6B, 0x6B)
+    # MODERN footer color  = RGBColor(0x4D, 0x6E, 0x78)
+    # The module global is THEME_MODERN; Stamp uses THEME_CLASSIC.
+    s = stencils.Stamp()
+    s.set_theme(stencils.THEME_CLASSIC)
+    s.new_doc("Test")
+    s.footer()
+    result = s.finalize()
+
+    doc = Document(BytesIO(result))
+    # Find the footer paragraph (contains "FormForge")
+    footer_runs = []
+    for p in doc.paragraphs:
+        for run in p.runs:
+            if "FormForge" in run.text:
+                footer_runs.append(run)
+
+    assert len(footer_runs) > 0, "Footer paragraph not found"
+    footer_color = footer_runs[0].font.color.rgb
+    assert footer_color == stencils.THEME_CLASSIC.color_footer
+    assert footer_color != stencils.THEME_MODERN.color_footer
 
 
 def test_stamp_content_round_trip():


### PR DESCRIPTION
## Summary

- Add `Stamp` class to `templates/stencils.py` — a fluent document builder that wraps the internal `Document` and exposes every public stencil function as a chainable method (returns `self`), with `finalize()` returning DOCX bytes
- Instance-scoped `set_theme()` avoids global side effects between templates
- Updated all 4 templates (`onboarding.py`, `expense-report.py`, `coverpage-demo.py`, `field-type-demo.py`) to use `Stamp` with sequential calls
- Added 27 new tests covering construction, each method's return value, chaining, sequential, mixed patterns, content round-trip, and theme isolation
- Updated `docs/TEMPLATE_GUIDE.md` with Stamp documentation, method reference table, and usage patterns (sequential, chaining, mixed)
- All existing module-level functions preserved for backward compatibility

Closes #230

## Test plan

- [x] All 677 existing tests continue to pass (no regressions)
- [x] 27 new Stamp-specific tests pass
- [x] Lint clean (`ruff check` + `ruff format`)
- [x] Embedded docs sync passes
- [ ] Verify templates produce identical DOCX output in browser via Pyodide

🤖 Generated with [Claude Code](https://claude.com/claude-code)