### PR TITLE
Rename Stamp class to Stencil

### DIFF
--- a/docs/DEVLOG.md
+++ b/docs/DEVLOG.md
@@ -14,17 +14,17 @@
 
 ## Log
 
-### 2026-03-25 — Add Stamp Class to Stencils (#230)
+### 2026-03-25 — Add Stencil Class to Stencils (#230)
 
-Added `Stamp` fluent builder class to `stencils.py`. Every public stencil function is exposed as a chainable method (returns `self`), with `finalize()` returning DOCX bytes. Supports method chaining, sequential calls, and mixed patterns with conditionals. Instance-scoped `set_theme()` does not modify the module global.
+Added `Stencil` fluent builder class to `stencils.py`. Every public stencil function is exposed as a chainable method (returns `self`), with `finalize()` returning DOCX bytes. Supports method chaining, sequential calls, and mixed patterns with conditionals. Instance-scoped `set_theme()` does not modify the module global.
 
-- Updated all 4 templates (`onboarding.py`, `expense-report.py`, `coverpage-demo.py`, `field-type-demo.py`) to use `Stamp` with sequential calls
+- Updated all 4 templates (`onboarding.py`, `expense-report.py`, `coverpage-demo.py`, `field-type-demo.py`) to use `Stencil` with sequential calls
 - Added 28 new tests covering construction, every method's return value, chaining, sequential, mixed, content round-trip, and theme isolation
-- Updated `docs/TEMPLATE_GUIDE.md` with Stamp documentation, method table, and usage patterns
+- Updated `docs/TEMPLATE_GUIDE.md` with Stencil documentation, method table, and usage patterns
 - All existing module-level functions preserved for backward compatibility
 
 **Decisions:**
-- `Stamp.set_theme()` is instance-scoped to avoid global side effects between templates
+- `Stencil.set_theme()` is instance-scoped to avoid global side effects between templates
 - Content methods auto-create the document if `new_doc()` was not called, for convenience
 - Pass-through methods (`add_heading`, `add_paragraph`, `add_page_break`) and a `.doc` property provided for advanced python-docx usage
 

--- a/docs/TEMPLATE_GUIDE.md
+++ b/docs/TEMPLATE_GUIDE.md
@@ -44,23 +44,23 @@ import stencils
 
 This works identically in Pyodide and in standard Python (for local testing).
 
-## The `Stamp` Class (Recommended)
+## The `Stencil` Class (Recommended)
 
-`Stamp` is a fluent builder that wraps the internal `Document` and exposes every stencil function as a chainable method. Instead of passing `doc` to each function, you call methods on the `Stamp` instance — every method returns `self` except `finalize()`, which returns the finished DOCX bytes.
+`Stencil` is a fluent builder that wraps the internal `Document` and exposes every stencil function as a chainable method. Instead of passing `doc` to each function, you call methods on the `Stencil` instance — every method returns `self` except `finalize()`, which returns the finished DOCX bytes.
 
-Import `Stamp` and any constants you need directly:
+Import `Stencil` and any constants you need directly:
 
 ```python
-from stencils import Stamp, THEME_CLASSIC
+from stencils import Stencil, THEME_CLASSIC
 ```
 
 ### Sequential calls (recommended for templates with conditionals)
 
 ```python
-from stencils import Stamp, THEME_CLASSIC
+from stencils import Stencil, THEME_CLASSIC
 
 def generate_docx(data):
-    doc = Stamp()
+    doc = Stencil()
     doc.set_theme(THEME_CLASSIC)
     doc.new_doc("Employee Onboarding", f"Prepared for {data.get('name', '')}")
 
@@ -81,10 +81,10 @@ def generate_docx(data):
 ### Method chaining
 
 ```python
-from stencils import Stamp, THEME_CLASSIC
+from stencils import Stencil, THEME_CLASSIC
 
 def generate_docx(data):
-    return (Stamp()
+    return (Stencil()
         .set_theme(THEME_CLASSIC)
         .new_doc("My Document")
         .table_section("Info", [("Name", data.get("name", ""))])
@@ -97,10 +97,10 @@ def generate_docx(data):
 ### Mixed (chain setup, sequential for body)
 
 ```python
-from stencils import Stamp, THEME_CLASSIC
+from stencils import Stencil, THEME_CLASSIC
 
 def generate_docx(data):
-    doc = Stamp().set_theme(THEME_CLASSIC).new_doc("Report")
+    doc = Stencil().set_theme(THEME_CLASSIC).new_doc("Report")
 
     if data.get("body", "").strip():
         doc.longtext("Content", data["body"])
@@ -109,11 +109,11 @@ def generate_docx(data):
     return doc.footer().finalize()
 ```
 
-### Stamp methods
+### Stencil methods
 
 | Method | Returns | Description |
 |---|---|---|
-| `Stamp()` | instance | Create a new builder |
+| `Stencil()` | instance | Create a new builder |
 | `.set_theme(theme)` | `self` | Set theme for this instance (does not change the module global) |
 | `.new_doc(title, subtitle, ...)` | `self` | Create the internal document (auto-called if omitted) |
 | `.coverpage(title, ...)` | `self` | Add a cover page |
@@ -134,12 +134,12 @@ def generate_docx(data):
 
 ### Advanced: accessing the underlying Document
 
-For python-docx operations not covered by Stamp methods, use the `.doc` property:
+For python-docx operations not covered by Stencil methods, use the `.doc` property:
 
 ```python
 from docx.shared import Pt
 
-doc = Stamp().set_theme(THEME_CLASSIC).new_doc("Report")
+doc = Stencil().set_theme(THEME_CLASSIC).new_doc("Report")
 # Direct Document access for custom formatting
 d = doc.doc
 d.add_heading("Custom Section", level=2)
@@ -613,10 +613,10 @@ for item in skills.split("\n"):
 ## Minimal Template
 
 ```python
-from stencils import Stamp, THEME_CLASSIC
+from stencils import Stencil, THEME_CLASSIC
 
 def generate_docx(data):
-    doc = Stamp()
+    doc = Stencil()
     doc.set_theme(THEME_CLASSIC)
     doc.new_doc("My Document", data.get("title", ""))
     doc.table_section("Details", [

--- a/index.html
+++ b/index.html
@@ -8650,23 +8650,23 @@ import stencils
 
 This works identically in Pyodide and in standard Python (for local testing).
 
-## The \`Stamp\` Class (Recommended)
+## The \`Stencil\` Class (Recommended)
 
-\`Stamp\` is a fluent builder that wraps the internal \`Document\` and exposes every stencil function as a chainable method. Instead of passing \`doc\` to each function, you call methods on the \`Stamp\` instance — every method returns \`self\` except \`finalize()\`, which returns the finished DOCX bytes.
+\`Stencil\` is a fluent builder that wraps the internal \`Document\` and exposes every stencil function as a chainable method. Instead of passing \`doc\` to each function, you call methods on the \`Stencil\` instance — every method returns \`self\` except \`finalize()\`, which returns the finished DOCX bytes.
 
-Import \`Stamp\` and any constants you need directly:
+Import \`Stencil\` and any constants you need directly:
 
 \`\`\`python
-from stencils import Stamp, THEME_CLASSIC
+from stencils import Stencil, THEME_CLASSIC
 \`\`\`
 
 ### Sequential calls (recommended for templates with conditionals)
 
 \`\`\`python
-from stencils import Stamp, THEME_CLASSIC
+from stencils import Stencil, THEME_CLASSIC
 
 def generate_docx(data):
-    doc = Stamp()
+    doc = Stencil()
     doc.set_theme(THEME_CLASSIC)
     doc.new_doc("Employee Onboarding", f"Prepared for {data.get('name', '')}")
 
@@ -8687,10 +8687,10 @@ def generate_docx(data):
 ### Method chaining
 
 \`\`\`python
-from stencils import Stamp, THEME_CLASSIC
+from stencils import Stencil, THEME_CLASSIC
 
 def generate_docx(data):
-    return (Stamp()
+    return (Stencil()
         .set_theme(THEME_CLASSIC)
         .new_doc("My Document")
         .table_section("Info", [("Name", data.get("name", ""))])
@@ -8703,10 +8703,10 @@ def generate_docx(data):
 ### Mixed (chain setup, sequential for body)
 
 \`\`\`python
-from stencils import Stamp, THEME_CLASSIC
+from stencils import Stencil, THEME_CLASSIC
 
 def generate_docx(data):
-    doc = Stamp().set_theme(THEME_CLASSIC).new_doc("Report")
+    doc = Stencil().set_theme(THEME_CLASSIC).new_doc("Report")
 
     if data.get("body", "").strip():
         doc.longtext("Content", data["body"])
@@ -8715,11 +8715,11 @@ def generate_docx(data):
     return doc.footer().finalize()
 \`\`\`
 
-### Stamp methods
+### Stencil methods
 
 | Method | Returns | Description |
 |---|---|---|
-| \`Stamp()\` | instance | Create a new builder |
+| \`Stencil()\` | instance | Create a new builder |
 | \`.set_theme(theme)\` | \`self\` | Set theme for this instance (does not change the module global) |
 | \`.new_doc(title, subtitle, ...)\` | \`self\` | Create the internal document (auto-called if omitted) |
 | \`.coverpage(title, ...)\` | \`self\` | Add a cover page |
@@ -8740,12 +8740,12 @@ def generate_docx(data):
 
 ### Advanced: accessing the underlying Document
 
-For python-docx operations not covered by Stamp methods, use the \`.doc\` property:
+For python-docx operations not covered by Stencil methods, use the \`.doc\` property:
 
 \`\`\`python
 from docx.shared import Pt
 
-doc = Stamp().set_theme(THEME_CLASSIC).new_doc("Report")
+doc = Stencil().set_theme(THEME_CLASSIC).new_doc("Report")
 # Direct Document access for custom formatting
 d = doc.doc
 d.add_heading("Custom Section", level=2)
@@ -9219,10 +9219,10 @@ for item in skills.split("\\n"):
 ## Minimal Template
 
 \`\`\`python
-from stencils import Stamp, THEME_CLASSIC
+from stencils import Stencil, THEME_CLASSIC
 
 def generate_docx(data):
-    doc = Stamp()
+    doc = Stencil()
     doc.set_theme(THEME_CLASSIC)
     doc.new_doc("My Document", data.get("title", ""))
     doc.table_section("Details", [

--- a/templates/coverpage-demo.py
+++ b/templates/coverpage-demo.py
@@ -9,7 +9,7 @@ The `data` dict keys match the field `id` values in
 schemas/coverpage-demo.json.
 """
 
-from stencils import Stamp, THEME_CLASSIC
+from stencils import Stencil, THEME_CLASSIC
 
 
 def generate_docx(data: dict[str, str]) -> bytes:
@@ -22,7 +22,7 @@ def generate_docx(data: dict[str, str]) -> bytes:
     Returns:
         bytes: The generated .docx file as raw bytes.
     """
-    doc = Stamp()
+    doc = Stencil()
     doc.set_theme(THEME_CLASSIC)
     doc.new_doc()
 

--- a/templates/expense-report.py
+++ b/templates/expense-report.py
@@ -19,7 +19,7 @@ Field type notes:
 
 import json
 
-from stencils import Stamp, THEME_MODERN
+from stencils import Stencil, THEME_MODERN
 
 
 def generate_docx(data: dict[str, str]) -> bytes:
@@ -37,7 +37,7 @@ def generate_docx(data: dict[str, str]) -> bytes:
     report_date = data.get("report_date", "")
     form_ver = data.get("form_version", "")
 
-    doc = Stamp()
+    doc = Stencil()
     doc.set_theme(THEME_MODERN)
     doc.new_doc(
         "Expense Report",

--- a/templates/field-type-demo.py
+++ b/templates/field-type-demo.py
@@ -25,7 +25,7 @@ Field type value formats:
 import json
 from docx.shared import Pt
 
-from stencils import Stamp, THEME_MINIMAL, format_time
+from stencils import Stencil, THEME_MINIMAL, format_time
 
 
 def generate_docx(data: dict[str, str]) -> bytes:
@@ -43,7 +43,7 @@ def generate_docx(data: dict[str, str]) -> bytes:
     event_date = data.get("event_date", "")
     form_ver = data.get("form_version", "")
 
-    doc = Stamp()
+    doc = Stencil()
     doc.set_theme(THEME_MINIMAL)
     doc.new_doc(
         "Event Registration",

--- a/templates/onboarding.py
+++ b/templates/onboarding.py
@@ -15,7 +15,7 @@ Field type notes:
   - list → newline-separated str (e.g. "Python\\nJavaScript\\nRust")
 """
 
-from stencils import Stamp, THEME_CLASSIC
+from stencils import Stencil, THEME_CLASSIC
 
 
 def generate_docx(data: dict[str, str]) -> bytes:
@@ -32,7 +32,7 @@ def generate_docx(data: dict[str, str]) -> bytes:
     last = data.get("last_name", "")
     start = data.get("start_date", "TBD")
 
-    doc = Stamp()
+    doc = Stencil()
     doc.set_theme(THEME_CLASSIC)
     doc.new_doc(
         "Employee Onboarding Document",

--- a/templates/stencils.py
+++ b/templates/stencils.py
@@ -4,12 +4,12 @@ FormForge Shared Template Stencils
 Shared helper functions for all FormForge DOCX templates.
 Works in both standard Python (import stencils) and Pyodide (via exec()).
 
-Stamp class (recommended)::
+Stencil class (recommended)::
 
-    from stencils import Stamp, THEME_CLASSIC
+    from stencils import Stencil, THEME_CLASSIC
 
     def generate_docx(data):
-        doc = Stamp()
+        doc = Stencil()
         doc.set_theme(THEME_CLASSIC)
         doc.new_doc("My Form Title", "Subtitle here")
         doc.table_section("Section Name", [("Label", "Value"), ...])
@@ -1117,11 +1117,11 @@ def repeater_table(
 
 
 # ---------------------------------------------------------------------------
-#  Stamp — fluent document builder
+#  Stencil — fluent document builder
 # ---------------------------------------------------------------------------
 
 
-class Stamp:
+class Stencil:
     """Fluent builder for DOCX documents using stencils helpers.
 
     Wraps an internal ``Document`` and exposes every public stencil function
@@ -1130,10 +1130,10 @@ class Stamp:
 
     Usage::
 
-        from stencils import Stamp, THEME_CLASSIC
+        from stencils import Stencil, THEME_CLASSIC
 
         def generate_docx(data):
-            doc = Stamp()
+            doc = Stencil()
             doc.set_theme(THEME_CLASSIC)
             doc.new_doc("My Title")
             doc.table_section("Info", [("Name", data.get("name", ""))])
@@ -1142,7 +1142,7 @@ class Stamp:
 
     Or with method chaining::
 
-        return (Stamp()
+        return (Stencil()
             .set_theme(THEME_CLASSIC)
             .new_doc("My Title")
             .table_section("Info", [("Name", data.get("name", ""))])
@@ -1154,11 +1154,11 @@ class Stamp:
         self._doc: Document | None = None
         self._theme: DocTheme | None = None
 
-    def set_theme(self, theme: DocTheme) -> "Stamp":
+    def set_theme(self, theme: DocTheme) -> "Stencil":
         """Set the theme for this document.
 
         Unlike the module-level ``set_theme()``, this only affects the
-        current ``Stamp`` instance — it does not modify the global theme.
+        current ``Stencil`` instance — it does not modify the global theme.
         """
         missing = [f for f in _THEME_FIELDS if not hasattr(theme, f)]
         if missing:
@@ -1172,7 +1172,7 @@ class Stamp:
         subtitle_text: str = "",
         font_name: str | None = None,
         font_size: int | None = None,
-    ) -> "Stamp":
+    ) -> "Stencil":
         """Create the internal document with optional title and subtitle.
 
         If not called explicitly, the document is created automatically on
@@ -1204,7 +1204,7 @@ class Stamp:
         logo_width: float = 2.0,
         max_logo_height: float = 1.0,
         bar_color: str | None = None,
-    ) -> "Stamp":
+    ) -> "Stencil":
         """Add a professional cover page. See ``coverpage()`` module function."""
         coverpage(
             self._ensure_doc(),
@@ -1219,32 +1219,32 @@ class Stamp:
         )
         return self
 
-    def table_section(self, heading: str, rows: list[tuple[str, str]]) -> "Stamp":
+    def table_section(self, heading: str, rows: list[tuple[str, str]]) -> "Stencil":
         """Add a heading + key/value table. See ``table_section()``."""
         table_section(self._ensure_doc(), heading, rows, theme=self._theme)
         return self
 
-    def longtext(self, heading: str, text: str) -> "Stamp":
+    def longtext(self, heading: str, text: str) -> "Stencil":
         """Add a heading + paragraphs. See ``longtext()``."""
         longtext(self._ensure_doc(), heading, text, theme=self._theme)
         return self
 
-    def bullet_list(self, heading: str, items_str: str) -> "Stamp":
+    def bullet_list(self, heading: str, items_str: str) -> "Stencil":
         """Add a heading + bulleted list. See ``bullet_list()``."""
         bullet_list(self._ensure_doc(), heading, items_str, theme=self._theme)
         return self
 
-    def signatures(self, labels: list[str]) -> "Stamp":
+    def signatures(self, labels: list[str]) -> "Stencil":
         """Add a signature grid. See ``signatures()``."""
         signatures(self._ensure_doc(), labels, theme=self._theme)
         return self
 
-    def footer(self) -> "Stamp":
+    def footer(self) -> "Stencil":
         """Add the standard FormForge footer. See ``footer()``."""
         footer(self._ensure_doc(), theme=self._theme)
         return self
 
-    def address(self, heading: str, raw_json: str) -> "Stamp":
+    def address(self, heading: str, raw_json: str) -> "Stencil":
         """Add a formatted address block. See ``address()``."""
         address(self._ensure_doc(), heading, raw_json, theme=self._theme)
         return self
@@ -1255,7 +1255,7 @@ class Stamp:
         width_inches: float = 3.0,
         max_height: float | None = None,
         placeholder: str = "No image uploaded.",
-    ) -> "Stamp":
+    ) -> "Stencil":
         """Embed a base64 image or placeholder. See ``image()``."""
         image(
             self._ensure_doc(),
@@ -1267,7 +1267,9 @@ class Stamp:
         )
         return self
 
-    def signature(self, b64_str: str, label: str, width_inches: float = 2.5) -> "Stamp":
+    def signature(
+        self, b64_str: str, label: str, width_inches: float = 2.5
+    ) -> "Stencil":
         """Add a signature image with label. See ``signature()``."""
         signature(
             self._ensure_doc(),
@@ -1284,7 +1286,7 @@ class Stamp:
         items: list[dict[str, str]],
         field_keys: list[str],
         currency_keys: list[str] | None = None,
-    ) -> "Stamp":
+    ) -> "Stencil":
         """Render a repeater as a headed table. See ``repeater_table()``."""
         repeater_table(
             self._ensure_doc(),
@@ -1296,17 +1298,17 @@ class Stamp:
         )
         return self
 
-    def add_heading(self, text: str, level: int = 1) -> "Stamp":
+    def add_heading(self, text: str, level: int = 1) -> "Stencil":
         """Add a heading paragraph directly (pass-through to Document)."""
         self._ensure_doc().add_heading(text, level=level)
         return self
 
-    def add_paragraph(self, text: str = "") -> "Stamp":
+    def add_paragraph(self, text: str = "") -> "Stencil":
         """Add a paragraph directly (pass-through to Document)."""
         self._ensure_doc().add_paragraph(text)
         return self
 
-    def add_page_break(self) -> "Stamp":
+    def add_page_break(self) -> "Stencil":
         """Add a page break (pass-through to Document)."""
         self._ensure_doc().add_page_break()
         return self

--- a/tests/test_stencils.py
+++ b/tests/test_stencils.py
@@ -910,55 +910,55 @@ def test_image_without_max_height_unchanged():
 
 
 # ---------------------------------------------------------------------------
-#  Stamp class
+#  Stencil class
 # ---------------------------------------------------------------------------
 
 
-def test_stamp_importable():
-    """Stamp and theme constants are importable via from-import."""
-    from stencils import Stamp, THEME_CLASSIC, THEME_MINIMAL, THEME_MODERN, DocTheme
+def test_stencil_importable():
+    """Stencil and theme constants are importable via from-import."""
+    from stencils import Stencil, THEME_CLASSIC, THEME_MINIMAL, THEME_MODERN, DocTheme
 
-    assert Stamp is not None
+    assert Stencil is not None
     assert THEME_CLASSIC is not None
     assert THEME_MINIMAL is not None
     assert THEME_MODERN is not None
     assert DocTheme is not None
 
 
-def test_stamp_construction():
-    """Stamp() creates an instance with no document yet."""
-    s = stencils.Stamp()
+def test_stencil_construction():
+    """Stencil() creates an instance with no document yet."""
+    s = stencils.Stencil()
     assert s._doc is None
     assert s._theme is None
 
 
-def test_stamp_set_theme_returns_self():
-    s = stencils.Stamp()
+def test_stencil_set_theme_returns_self():
+    s = stencils.Stencil()
     result = s.set_theme(stencils.THEME_CLASSIC)
     assert result is s
     assert s._theme is stencils.THEME_CLASSIC
 
 
-def test_stamp_set_theme_invalid():
+def test_stencil_set_theme_invalid():
     """set_theme with an incomplete theme should raise ValueError."""
 
     class BadTheme:
         pass
 
-    s = stencils.Stamp()
+    s = stencils.Stencil()
     with pytest.raises(ValueError, match="missing required fields"):
         s.set_theme(BadTheme())
 
 
-def test_stamp_new_doc_returns_self():
-    s = stencils.Stamp()
+def test_stencil_new_doc_returns_self():
+    s = stencils.Stencil()
     result = s.new_doc("Test Title")
     assert result is s
     assert s._doc is not None
 
 
-def test_stamp_new_doc_creates_titled_doc():
-    s = stencils.Stamp()
+def test_stencil_new_doc_creates_titled_doc():
+    s = stencils.Stencil()
     s.set_theme(stencils.THEME_CLASSIC)
     s.new_doc("My Title", "My Subtitle")
     texts = [p.text for p in s.doc.paragraphs]
@@ -966,107 +966,107 @@ def test_stamp_new_doc_creates_titled_doc():
     assert any("My Subtitle" in t for t in texts)
 
 
-def test_stamp_lazy_doc_creation():
+def test_stencil_lazy_doc_creation():
     """Content methods should auto-create the doc if new_doc() was not called."""
-    s = stencils.Stamp()
+    s = stencils.Stencil()
     s.set_theme(stencils.THEME_CLASSIC)
     s.table_section("Info", [("Key", "Value")])
     assert s._doc is not None
 
 
-def test_stamp_table_section_returns_self():
-    s = stencils.Stamp()
+def test_stencil_table_section_returns_self():
+    s = stencils.Stencil()
     s.new_doc("Test")
     result = s.table_section("Section", [("A", "B")])
     assert result is s
 
 
-def test_stamp_longtext_returns_self():
-    s = stencils.Stamp()
+def test_stencil_longtext_returns_self():
+    s = stencils.Stencil()
     s.new_doc("Test")
     result = s.longtext("Heading", "Some text")
     assert result is s
 
 
-def test_stamp_bullet_list_returns_self():
-    s = stencils.Stamp()
+def test_stencil_bullet_list_returns_self():
+    s = stencils.Stencil()
     s.new_doc("Test")
     result = s.bullet_list("Items", "a\nb\nc")
     assert result is s
 
 
-def test_stamp_signatures_returns_self():
-    s = stencils.Stamp()
+def test_stencil_signatures_returns_self():
+    s = stencils.Stencil()
     s.new_doc("Test")
     result = s.signatures(["Signer 1", "Date"])
     assert result is s
 
 
-def test_stamp_footer_returns_self():
-    s = stencils.Stamp()
+def test_stencil_footer_returns_self():
+    s = stencils.Stencil()
     s.new_doc("Test")
     result = s.footer()
     assert result is s
 
 
-def test_stamp_address_returns_self():
-    s = stencils.Stamp()
+def test_stencil_address_returns_self():
+    s = stencils.Stencil()
     s.new_doc("Test")
     result = s.address("Addr", '{"street":"123 Main"}')
     assert result is s
 
 
-def test_stamp_image_returns_self():
-    s = stencils.Stamp()
+def test_stencil_image_returns_self():
+    s = stencils.Stencil()
     s.new_doc("Test")
     result = s.image("")
     assert result is s
 
 
-def test_stamp_signature_returns_self():
-    s = stencils.Stamp()
+def test_stencil_signature_returns_self():
+    s = stencils.Stencil()
     s.new_doc("Test")
     result = s.signature("", "Label")
     assert result is s
 
 
-def test_stamp_repeater_table_returns_self():
-    s = stencils.Stamp()
+def test_stencil_repeater_table_returns_self():
+    s = stencils.Stencil()
     s.new_doc("Test")
     result = s.repeater_table(headers=["Col"], items=[], field_keys=["col"])
     assert result is s
 
 
-def test_stamp_coverpage_returns_self():
-    s = stencils.Stamp()
+def test_stencil_coverpage_returns_self():
+    s = stencils.Stencil()
     s.new_doc()
     result = s.coverpage("Title")
     assert result is s
 
 
-def test_stamp_add_heading_returns_self():
-    s = stencils.Stamp()
+def test_stencil_add_heading_returns_self():
+    s = stencils.Stencil()
     s.new_doc("Test")
     result = s.add_heading("H1", level=1)
     assert result is s
 
 
-def test_stamp_add_paragraph_returns_self():
-    s = stencils.Stamp()
+def test_stencil_add_paragraph_returns_self():
+    s = stencils.Stencil()
     s.new_doc("Test")
     result = s.add_paragraph("text")
     assert result is s
 
 
-def test_stamp_add_page_break_returns_self():
-    s = stencils.Stamp()
+def test_stencil_add_page_break_returns_self():
+    s = stencils.Stencil()
     s.new_doc("Test")
     result = s.add_page_break()
     assert result is s
 
 
-def test_stamp_finalize_returns_bytes():
-    s = stencils.Stamp()
+def test_stencil_finalize_returns_bytes():
+    s = stencils.Stencil()
     s.new_doc("Test")
     result = s.finalize()
     assert isinstance(result, bytes)
@@ -1074,10 +1074,10 @@ def test_stamp_finalize_returns_bytes():
     assert result[:2] == b"PK"
 
 
-def test_stamp_method_chaining():
+def test_stencil_method_chaining():
     """Full method-chaining workflow produces valid DOCX bytes."""
     result = (
-        stencils.Stamp()
+        stencils.Stencil()
         .set_theme(stencils.THEME_CLASSIC)
         .new_doc("Chained Doc")
         .table_section("Info", [("Name", "Test")])
@@ -1091,9 +1091,9 @@ def test_stamp_method_chaining():
     assert result[:2] == b"PK"
 
 
-def test_stamp_sequential_calls():
+def test_stencil_sequential_calls():
     """Sequential (non-chained) workflow produces valid DOCX bytes."""
-    s = stencils.Stamp()
+    s = stencils.Stencil()
     s.set_theme(stencils.THEME_MODERN)
     s.new_doc("Sequential Doc")
     s.table_section("Details", [("Key", "Value")])
@@ -1103,9 +1103,9 @@ def test_stamp_sequential_calls():
     assert result[:2] == b"PK"
 
 
-def test_stamp_mixed_chain_and_sequential():
+def test_stencil_mixed_chain_and_sequential():
     """Mixed chaining + sequential with conditionals."""
-    s = stencils.Stamp().set_theme(stencils.THEME_CLASSIC).new_doc("Mixed Doc")
+    s = stencils.Stencil().set_theme(stencils.THEME_CLASSIC).new_doc("Mixed Doc")
 
     # Conditional content
     include_notes = True
@@ -1118,9 +1118,9 @@ def test_stamp_mixed_chain_and_sequential():
     assert result[:2] == b"PK"
 
 
-def test_stamp_doc_property():
+def test_stencil_doc_property():
     """The doc property provides access to the underlying Document."""
-    s = stencils.Stamp()
+    s = stencils.Stencil()
     s.new_doc("Test")
     # python-docx Document is a function; check the returned object has
     # the expected document attributes instead.
@@ -1129,23 +1129,23 @@ def test_stamp_doc_property():
     assert hasattr(s.doc, "styles")
 
 
-def test_stamp_set_theme_does_not_mutate_global():
-    """Setting theme on Stamp does not change the module-level global."""
+def test_stencil_set_theme_does_not_mutate_global():
+    """Setting theme on Stencil does not change the module-level global."""
     original = stencils._active_theme
-    s = stencils.Stamp()
+    s = stencils.Stencil()
     s.set_theme(stencils.THEME_CLASSIC)
     assert stencils._active_theme is original
 
 
-def test_stamp_instance_theme_used_for_content():
-    """Content methods use the Stamp's instance theme, not the global."""
+def test_stencil_instance_theme_used_for_content():
+    """Content methods use the Stencil's instance theme, not the global."""
     from io import BytesIO
     from docx import Document
 
     # CLASSIC footer color = RGBColor(0x6B, 0x6B, 0x6B)
     # MODERN footer color  = RGBColor(0x4D, 0x6E, 0x78)
-    # The module global is THEME_MODERN; Stamp uses THEME_CLASSIC.
-    s = stencils.Stamp()
+    # The module global is THEME_MODERN; Stencil uses THEME_CLASSIC.
+    s = stencils.Stencil()
     s.set_theme(stencils.THEME_CLASSIC)
     s.new_doc("Test")
     s.footer()
@@ -1165,13 +1165,13 @@ def test_stamp_instance_theme_used_for_content():
     assert footer_color != stencils.THEME_MODERN.color_footer
 
 
-def test_stamp_content_round_trip():
-    """Content added via Stamp methods is present in the output DOCX."""
+def test_stencil_content_round_trip():
+    """Content added via Stencil methods is present in the output DOCX."""
     from io import BytesIO
     from docx import Document
 
     result = (
-        stencils.Stamp()
+        stencils.Stencil()
         .set_theme(stencils.THEME_CLASSIC)
         .new_doc("Round Trip")
         .table_section("People", [("Name", "Alice"), ("Role", "Dev")])


### PR DESCRIPTION
## Summary
- Renamed the `Stamp` fluent builder class to `Stencil` in `stencils.py` for consistency with the module name
- Updated all 4 templates (`onboarding.py`, `expense-report.py`, `coverpage-demo.py`, `field-type-demo.py`)
- Updated `docs/TEMPLATE_GUIDE.md`, `docs/DEVLOG.md`, embedded docs in `index.html`, and all test function names in `test_stencils.py`

## Test plan
- [x] All 678 tests pass
- [x] Lint and format clean
- [x] No remaining `Stamp` references in codebase

https://claude.ai/code/session_01SKJYAf9NsnefxyNpyof4h5