### PR TITLE
Fix signature canvas drawing offset on high-DPI displays

### DIFF
--- a/docs/DEVLOG.md
+++ b/docs/DEVLOG.md
@@ -14,6 +14,12 @@
 
 ## Log
 
+### 2026-03-25 — Fix Signature Canvas Drawing Offset (#233)
+
+Fixed double-DPR scaling bug in `createSignatureField()` where `getPos()` multiplied coordinates by `canvas.width / rect.width` (= devicePixelRatio), but the canvas context was already scaled by DPR via `ctx.scale(dpr, dpr)`. Strokes appeared offset from the actual touch/cursor position on high-DPI displays (2× offset on retina, 3× on ultra-high-DPI). Removed the redundant scaling so `getPos()` returns raw CSS-pixel coordinates.
+
+---
+
 ### 2026-03-25 — Add Stencil Class to Stencils (#230)
 
 Added `Stencil` fluent builder class to `stencils.py`. Every public stencil function is exposed as a chainable method (returns `self`), with `finalize()` returning DOCX bytes. Supports method chaining, sequential calls, and mixed patterns with conditionals. Instance-scoped `set_theme()` does not modify the module global.

--- a/index.html
+++ b/index.html
@@ -5484,12 +5484,8 @@ function createSignatureField(field, group) {
   function getPos(e) {
     const rect = canvas.getBoundingClientRect();
     if (rect.width === 0) return { x: 0, y: 0 };
-    const scaleX = canvas.width / rect.width;
-    const scaleY = canvas.height / rect.height;
-    if (e.touches) {
-      return { x: (e.touches[0].clientX - rect.left) * scaleX, y: (e.touches[0].clientY - rect.top) * scaleY };
-    }
-    return { x: (e.clientX - rect.left) * scaleX, y: (e.clientY - rect.top) * scaleY };
+    const t = e.touches ? e.touches[0] : e;
+    return { x: t.clientX - rect.left, y: t.clientY - rect.top };
   }
   const ctx = canvas.getContext('2d');
   function startDraw(e) { e.preventDefault(); initCanvas(); drawing = true; hasDrawn = true; const p = getPos(e); ctx.beginPath(); ctx.moveTo(p.x, p.y); }

--- a/tests/test_dev_mode.py
+++ b/tests/test_dev_mode.py
@@ -2582,6 +2582,25 @@ def test_preset_setup_called_from_post_launch(index_html: str) -> None:
     assert "setupPresets()" in body
 
 
+def test_signature_getpos_no_dpr_scaling(index_html: str) -> None:
+    """getPos in createSignatureField must not double-scale by DPR (#233)."""
+    body = _extract_func(index_html, "createSignatureField")
+    assert "getPos" in body
+    # getPos must NOT reference scaleX/scaleY (old double-DPR bug)
+    # Extract just the getPos inner function body
+    import re
+
+    m = re.search(r"function getPos\b[^{]*\{([\s\S]*?)\n  \}", body)
+    assert m, "getPos function not found inside createSignatureField"
+    getpos_body = m.group(1)
+    assert "scaleX" not in getpos_body, "getPos should not scale by DPR"
+    assert "scaleY" not in getpos_body, "getPos should not scale by DPR"
+    assert "canvas.width" not in getpos_body, "getPos should use CSS coords, not canvas dims"
+    assert "clientX" in getpos_body
+    assert "clientY" in getpos_body
+    assert "rect.left" in getpos_body
+
+
 def test_preset_hidden_on_reset(index_html: str) -> None:
     """hidePresetDropdown is called from resetForm."""
     body = _extract_func(index_html, "resetForm")


### PR DESCRIPTION
## Summary

- Fix double-DPR scaling bug in `createSignatureField()` where `getPos()` multiplied coordinates by `devicePixelRatio` redundantly — the canvas context was already scaled via `ctx.scale(dpr, dpr)`
- Strokes now draw exactly where the finger/cursor touches on all DPR values (1×, 2×, 3×)
- Added structural test verifying `getPos` uses raw CSS coordinates (no `scaleX`/`scaleY`)

Closes #233

## Test plan

- [x] 679 tests pass (1 new structural test)
- [x] Lint clean
- [ ] Manual: verify signature draws at cursor position on high-DPI display
- [ ] Manual: verify clear button still works
- [ ] Manual: verify exported PNG is still sharp

🤖 Generated with [Claude Code](https://claude.com/claude-code)