### PR TITLE
Fix mobile responsiveness issues across all breakpoints

### DIFF
--- a/docs/DEVLOG.md
+++ b/docs/DEVLOG.md
@@ -14,6 +14,35 @@
 
 ## Log
 
+### 2026-03-26 — Fix Mobile Responsiveness Issues (#236)
+
+Implemented 15 of 17 findings from the responsiveness audit (P3-4 modal bottom-sheets and P3-5 fluid type tokens deferred).
+
+**P0 — Critical (3/3):**
+- Force `font-size: 16px` on inputs/textareas/selects at 600px breakpoint to prevent iOS Safari auto-zoom
+- Add `min-height: 44px` to mobile bottom nav tabs
+- Add `100dvh` fallback after `100vh` on body for mobile Safari address bar
+
+**P1 — High (5/5):**
+- Add `overflow-wrap: break-word` to body for global text wrapping
+- Add `::after` 44px touch expansion for 5 close/dismiss buttons (toast, dialog, sidebar, multi-select tag, disconnect)
+- Scale `.form-title` to 22px at 600px breakpoint
+- Add `.flip-left` CSS class + JS viewport-edge detection for context menu submenus
+- Force visibility of preset buttons, drag handles, and add-section dividers on mobile/tablet
+
+**P2 — Moderate (4/4):**
+- Reduce DOCX preview padding to `20px 16px` at 768px
+- Shrink help sidebar to 260px at 1024px breakpoint
+- Give editor pane `flex: 2` and preview `flex: 1` when stacked on mobile
+- Keep wizard circles at 32px minimum + add `::after` touch expansion
+
+**P3 — Polish (3/5, 2 deferred):**
+- Add `word-break: break-word` to `.toast-msg`
+- Add `flex-wrap: wrap` to `.progress-steps`
+- Set `.console-panel` opacity to 0.85 on `pointer: coarse` devices
+
+---
+
 ### 2026-03-25 — Fix Signature Canvas Drawing Offset (#233)
 
 Fixed double-DPR scaling bug in `createSignatureField()` where `getPos()` multiplied coordinates by `canvas.width / rect.width` (= devicePixelRatio), but the canvas context was already scaled by DPR via `ctx.scale(dpr, dpr)`. Strokes appeared offset from the actual touch/cursor position on high-DPI displays (2× offset on retina, 3× on ultra-high-DPI). Removed the redundant scaling so `getPos()` returns raw CSS-pixel coordinates.

--- a/index.html
+++ b/index.html
@@ -1370,7 +1370,7 @@
   }
 
   @media (max-width: 400px) {
-    .wizard-step-circle { width: 32px; height: 32px; font-size: var(--text-xs); }
+    .wizard-step-circle { width: 24px; height: 24px; font-size: var(--text-xs); }
     .wizard-step-connector { width: 16px; margin: 0 2px; }
   }
 
@@ -2375,8 +2375,8 @@
     }
     .mobile-bottom-nav .dev-nav-tab svg { width: var(--icon-sm); height: var(--icon-sm); }
     .dev-split { flex-direction: column; }
-    .dev-split > .dev-pane:first-child { flex: 2; }
-    .dev-split > .dev-pane:last-child { flex: 1; min-height: 200px; }
+    .dev-split > .dev-pane:first-child { flex: 2; min-height: 200px; }
+    .dev-split > .dev-pane:last-child { flex: 1; min-height: 150px; }
     .dev-pane-resizer { display: none; }
     .dev-docx-preview { padding: 20px 16px; }
     .help-sidebar.open {
@@ -11366,12 +11366,14 @@ function showContextMenu(x, y, items, boundingEl) {
         sub.appendChild(childEl);
       });
       parent.addEventListener('mouseenter', () => {
+        sub.style.display = 'block';
         const subRect = sub.getBoundingClientRect();
         if (subRect.right > window.innerWidth) {
           sub.classList.add('flip-left');
         } else {
           sub.classList.remove('flip-left');
         }
+        sub.style.display = '';
       });
       parent.appendChild(sub);
       menu.appendChild(parent);

--- a/index.html
+++ b/index.html
@@ -215,6 +215,7 @@
     color: var(--text);
     min-height: 100vh;
     line-height: 1.6;
+    overflow-wrap: break-word;
   }
 
   /* (header styles continued) */
@@ -338,7 +339,7 @@
 
   /* ===== 4. VIEWS & LAYOUT ===== */
   body {
-    height: 100vh; overflow: hidden;
+    height: 100vh; height: 100dvh; overflow: hidden;
     display: flex; flex-direction: column;
   }
   body > .app-header { flex-shrink: 0; }
@@ -1222,10 +1223,16 @@
     .branch-input-wrapper { max-width: none; }
     .config-card { padding: 20px; }
     .form-section { padding: 20px; }
+    .preset-edit-btn, .preset-delete-btn { opacity: 1 !important; }
+    .dev-preview-form .drag-handle { opacity: 0.4 !important; }
+    .dev-section-add { opacity: 0.4 !important; }
   }
 
   /* --- Mobile (max 600px) --- */
   @media (max-width: 600px) {
+    /* iOS Safari auto-zoom prevention: inputs below 16px trigger zoom on focus */
+    input, textarea, select { font-size: 16px !important; }
+
     /* Autofill dropdown: full-width bottom-sheet on mobile */
     .autofill-dropdown {
       position: fixed; bottom: 0; left: 0; right: 0; top: auto;
@@ -1254,6 +1261,7 @@
 
     /* Form sections */
     .form-section { padding: 16px; margin-bottom: 20px; }
+    .form-title { font-size: 22px; }
 
     /* Submit area: stack vertically */
     .submit-area-primary { width: 100%; }
@@ -1300,6 +1308,19 @@
       top: 50%; left: 50%; transform: translate(-50%, -50%);
       min-width: 44px; min-height: 44px;
     }
+    .toast-dismiss,
+    .connect-dialog-close,
+    .help-sidebar-close,
+    .multi-select-tag-remove,
+    .btn-disconnect { position: relative; }
+    .toast-dismiss::after,
+    .connect-dialog-close::after,
+    .help-sidebar-close::after,
+    .multi-select-tag-remove::after,
+    .btn-disconnect::after {
+      content: ''; position: absolute;
+      inset: -8px; min-width: 44px; min-height: 44px;
+    }
 
     /* Autosave prompt */
     .autosave-prompt { flex-direction: column; align-items: flex-start; }
@@ -1312,6 +1333,8 @@
     .wizard-step-circle { width: 28px; height: 28px; font-size: var(--text-sm); }
     .wizard-step-connector { width: 24px; margin: 0 4px; }
     .wizard-indicator { padding: 0 8px; }
+    .wizard-step { position: relative; }
+    .wizard-step::after { content: ''; position: absolute; inset: -8px; min-width: 44px; min-height: 44px; }
 
     /* Toast */
     .toast {
@@ -1347,7 +1370,7 @@
   }
 
   @media (max-width: 400px) {
-    .wizard-step-circle { width: 24px; height: 24px; font-size: var(--text-xs); }
+    .wizard-step-circle { width: 32px; height: 32px; font-size: var(--text-xs); }
     .wizard-step-connector { width: 16px; margin: 0 2px; }
   }
 
@@ -1365,7 +1388,7 @@
   .loading-text { font-size: var(--text-base); color: var(--text-muted); font-family: var(--font-mono); }
 
   /* Step-based progress indicator (Pyodide loading) */
-  .progress-steps { display: flex; align-items: center; gap: 0; margin-top: 8px; }
+  .progress-steps { display: flex; align-items: center; gap: 0; margin-top: 8px; flex-wrap: wrap; }
   .progress-step {
     display: flex; align-items: center; gap: 8px; padding: 6px 14px;
     font-size: var(--text-sm); font-family: var(--font-mono);
@@ -1403,7 +1426,7 @@
   .toast.show { transform: translateY(0); opacity: 1; }
   .toast.error { border-color: var(--error); color: var(--error); }
   .toast.warning { border-color: var(--warning); color: var(--warning); }
-  .toast-msg { flex: 1; }
+  .toast-msg { flex: 1; word-break: break-word; }
   .toast-dismiss {
     background: none; border: none; color: inherit; cursor: pointer;
     font-size: var(--text-lg-xl); line-height: 1; padding: 0 2px; opacity: 0.6;
@@ -1912,11 +1935,12 @@
   }
   .ctx-menu-sub {
     display: none; position: absolute;
-    left: 100%; top: -4px;
+    left: 100%; right: auto; top: -4px;
     min-width: 160px; background: var(--surface);
     border: 1px solid var(--border); border-radius: var(--radius-md);
     padding: 4px 0; box-shadow: var(--shadow-lg);
   }
+  .ctx-menu-sub.flip-left { left: auto; right: 100%; }
   .ctx-menu-item.has-sub:hover > .ctx-menu-sub { display: block; }
 
   /* ===== 34. TEMPLATE BUILDER ===== */
@@ -2326,6 +2350,8 @@
     .app-sidebar .sidebar-status-badge .status-chevron { display: none; }
     .app-sidebar .sidebar-status-badge { justify-content: center; padding: var(--space-sm); }
     .sidebar-toggle { display: none; }
+    .help-sidebar.open { width: 260px; }
+    .help-sidebar-inner { width: 260px; min-width: 260px; }
   }
   @media (max-width: 768px) {
     .app-shell { flex-direction: column; }
@@ -2338,7 +2364,7 @@
     }
     .mobile-bottom-nav .dev-nav-tab {
       flex: 1; flex-direction: column; gap: var(--space-2xs);
-      padding: var(--space-sm) var(--space-xs); border-left: none;
+      padding: 8px; min-height: 44px; border-left: none;
       border-bottom: var(--border-width-accent) solid transparent;
       text-align: center; justify-content: center;
       font-size: var(--text-2xs);
@@ -2349,7 +2375,10 @@
     }
     .mobile-bottom-nav .dev-nav-tab svg { width: var(--icon-sm); height: var(--icon-sm); }
     .dev-split { flex-direction: column; }
+    .dev-split > .dev-pane:first-child { flex: 2; }
+    .dev-split > .dev-pane:last-child { flex: 1; min-height: 200px; }
     .dev-pane-resizer { display: none; }
+    .dev-docx-preview { padding: 20px 16px; }
     .help-sidebar.open {
       position: absolute; right: 0; top: 0; bottom: 0;
       z-index: 50; width: 100%;
@@ -2366,6 +2395,7 @@
     .gh-connect-modal,
     .paste-data-modal,
     .bundle-import-modal { backdrop-filter: none; }
+    .console-panel { opacity: 0.85; }
   }
 </style>
 </head>
@@ -11335,6 +11365,14 @@ function showContextMenu(x, y, items, boundingEl) {
         childEl.addEventListener('click', () => { hideContextMenu(); child.action(); });
         sub.appendChild(childEl);
       });
+      parent.addEventListener('mouseenter', () => {
+        const subRect = sub.getBoundingClientRect();
+        if (subRect.right > window.innerWidth) {
+          sub.classList.add('flip-left');
+        } else {
+          sub.classList.remove('flip-left');
+        }
+      });
       parent.appendChild(sub);
       menu.appendChild(parent);
       return;
@@ -11425,6 +11463,12 @@ function ctxMenuHandleKeydown(e) {
         const sub = focused.querySelector('[role="menu"]');
         if (sub) {
           sub.style.display = 'block';
+          const subRect = sub.getBoundingClientRect();
+          if (subRect.right > window.innerWidth) {
+            sub.classList.add('flip-left');
+          } else {
+            sub.classList.remove('flip-left');
+          }
           const firstChild = sub.querySelector('[role="menuitem"]');
           if (firstChild) firstChild.focus();
         }
@@ -11459,6 +11503,12 @@ function ctxMenuHandleKeydown(e) {
         const sub = focused.querySelector('[role="menu"]');
         if (sub) {
           sub.style.display = 'block';
+          const subRect = sub.getBoundingClientRect();
+          if (subRect.right > window.innerWidth) {
+            sub.classList.add('flip-left');
+          } else {
+            sub.classList.remove('flip-left');
+          }
           const firstChild = sub.querySelector('[role="menuitem"]');
           if (firstChild) firstChild.focus();
         }

--- a/tests/test_dev_mode.py
+++ b/tests/test_dev_mode.py
@@ -1091,6 +1091,43 @@ def test_mobile_bottom_nav_exists(index_html: str) -> None:
 
 
 # ============================================================
+#  ISSUE #236 — Mobile responsiveness fixes
+# ============================================================
+
+
+def test_body_uses_dvh_fallback(index_html: str) -> None:
+    """Body height uses 100dvh with 100vh fallback (#236 P0-3)."""
+    assert "100dvh" in index_html
+
+
+def test_ios_input_zoom_prevention(index_html: str) -> None:
+    """Mobile inputs use 16px font to prevent iOS auto-zoom (#236 P0-1)."""
+    # The 600px media query should force 16px on form inputs
+    assert "font-size: 16px !important" in index_html
+
+
+def test_mobile_nav_min_height(index_html: str) -> None:
+    """Mobile bottom nav tabs have 44px minimum touch target (#236 P0-2)."""
+    assert "min-height: 44px" in index_html
+
+
+def test_overflow_wrap_on_body(index_html: str) -> None:
+    """Body has overflow-wrap: break-word for long text (#236 P1-1)."""
+    assert "overflow-wrap: break-word" in index_html
+
+
+def test_ctx_menu_sub_flip(index_html: str) -> None:
+    """Context menu submenus can flip left to stay on-screen (#236 P1-4)."""
+    assert "flip-left" in index_html
+
+
+def test_toast_word_break(index_html: str) -> None:
+    """Toast messages wrap long content (#236 P3-1)."""
+    # Find word-break in toast-related CSS
+    assert "word-break: break-word" in index_html
+
+
+# ============================================================
 #  ISSUE #122 — Regression: user mode unchanged
 # ============================================================
 


### PR DESCRIPTION
## Summary

Resolves 15 of 17 findings from the comprehensive responsiveness audit (#236). Two P3 items deferred (modal bottom-sheet consistency, fluid type tokens).

**P0 — Critical (3):** iOS auto-zoom prevention (16px input font on mobile), 44px mobile nav touch targets, `100dvh` fallback for Safari address bar.

**P1 — High (5):** Global `overflow-wrap: break-word`, touch expansion for 5 close/dismiss buttons, `.form-title` scales to 22px on mobile, context menu submenu `flip-left` on viewport edge (CSS + JS), force-visible hover-only elements on touch (preset buttons, drag handles, add-section dividers).

**P2 — Moderate (4):** DOCX preview padding reduced on mobile, help sidebar narrowed at 1024px, 2:1 editor/preview split on mobile, wizard circles kept at 32px minimum with touch expansion.

**P3 — Polish (3):** Toast `word-break`, progress steps `flex-wrap`, console panel opacity on touch devices.

Closes #236

## Test plan

- [x] 685 tests pass (6 new structural tests for key fixes)
- [x] Lint clean
- [ ] Manual: verify no iOS auto-zoom on input focus
- [ ] Manual: verify context menu submenus stay on-screen
- [ ] Manual: verify mobile nav tabs are tappable
- [ ] Manual: verify no horizontal overflow on 320px viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)